### PR TITLE
ir-tests cleanup

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -43,10 +43,10 @@
 //!
 //! - `// ignore` - don't run the test
 
+use anyhow::Context;
+use similar::{ChangeTag, TextDiff};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use similar::{ChangeTag, TextDiff};
-use anyhow::Context;
 
 pub const TEST_DIR: &str = "tests/testdata";
 
@@ -183,16 +183,26 @@ fn compile_mvir_to_mvbc(harness_paths: &HarnessPaths, test_plan: &TestPlan) -> a
 
     let output = cmd.output().context("run move-ir-compiler failed")?;
     if !output.status.success() {
-        anyhow::bail!("move-ir-compiler failed. stderr:\n\n{}",
-                      String::from_utf8_lossy(&output.stderr));
+        anyhow::bail!(
+            "move-ir-compiler failed. stderr:\n\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     Ok(())
 }
 
 /// Run `move-mv-llvm-compiler` to produce LLVM IR, `llir_file`.
-fn compile_mvbc_to_llvmir(harness_paths: &HarnessPaths, test_plan: &TestPlan) -> anyhow::Result<()> {
-    let mut cmd = Command::new(harness_paths.move_mv_llvm_compiler.to_str().expect("PathBuf"));
+fn compile_mvbc_to_llvmir(
+    harness_paths: &HarnessPaths,
+    test_plan: &TestPlan,
+) -> anyhow::Result<()> {
+    let mut cmd = Command::new(
+        harness_paths
+            .move_mv_llvm_compiler
+            .to_str()
+            .expect("PathBuf"),
+    );
     cmd.arg("-b");
     cmd.arg(test_plan.mvbc_file.to_str().expect("PathBuf"));
     cmd.arg("-o");
@@ -201,8 +211,10 @@ fn compile_mvbc_to_llvmir(harness_paths: &HarnessPaths, test_plan: &TestPlan) ->
 
     let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
     if !output.status.success() {
-        anyhow::bail!("move-mv-llvm-compiler failed. stderr:\n\n{}",
-                      String::from_utf8_lossy(&output.stderr));
+        anyhow::bail!(
+            "move-mv-llvm-compiler failed. stderr:\n\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     Ok(())
@@ -211,7 +223,10 @@ fn compile_mvbc_to_llvmir(harness_paths: &HarnessPaths, test_plan: &TestPlan) ->
 /// Copy actual LLVM IR, `llir_file`, to expected IR, `llir_file_expected`, if `PROMOTE_LLVM_IR` env var is set.
 fn maybe_promote_actual_llvmir_to_expected(test_plan: &TestPlan) -> anyhow::Result<()> {
     if std::env::var("PROMOTE_LLVM_IR").is_ok() {
-        std::fs::copy(test_plan.llir_file.as_path(), test_plan.llir_file_expected.as_path())?;
+        std::fs::copy(
+            test_plan.llir_file.as_path(),
+            test_plan.llir_file_expected.as_path(),
+        )?;
     }
 
     Ok(())
@@ -243,7 +258,10 @@ fn compare_actual_llvmir_to_expected(test_plan: &TestPlan) -> anyhow::Result<()>
     }
 
     if !diff_msg.is_empty() {
-        anyhow::bail!(format!("llvm IR actual does not equal expected: \n\n{}", diff_msg));
+        anyhow::bail!(format!(
+            "llvm IR actual does not equal expected: \n\n{}",
+            diff_msg
+        ));
     }
 
     Ok(())

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -1,5 +1,35 @@
 //! Tests of compilation from MVIR to LLVM IR.
 //!
+//! # Usage
+//!
+//! These tests require `move-ir-compiler` to be pre-built:
+//!
+//! ```
+//! cargo build -p move-ir-compiler
+//! ```
+//!
+//! Running the tests:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test ir-tests
+//! ```
+//!
+//! Running a specific test:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test ir-tests -- struct.mvir
+//! ```
+//!
+//! Promoting all results to expected results:
+//!
+//! ```
+//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test ir-tests
+//! ```
+//!
+//! # Details
+//!
+//! They do the following:
+//!
 //! - Create a test for every .mvir file in testdata/
 //! - Run `move-ir-compiler` to convert MVIR to MV bytecode.
 //! - Run `move-mv-llvm-compiler` to convert MV bytecode to LLVM IR.

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -25,7 +25,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
     let harness_paths = get_harness_paths()?;
     let test_plan = get_test_plan(test_path);
 
-    //compile_mvir_to_mvbc(&harness_paths, &test_plan)?;
+    compile_mvir_to_mvbc(&harness_paths, &test_plan)?;
     compile_mvbc_to_llvmir(&harness_paths, &test_plan)?;
     maybe_promote_actual_llvmir_to_expected(&test_plan)?;
     compare_actual_llvmir_to_expected(&test_plan)?;

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -106,7 +106,8 @@ fn compile_mvir_to_mvbc(harness_paths: &HarnessPaths, test_plan: &TestPlan) -> a
 
     let output = cmd.output().context("run move-ir-compiler failed")?;
     if !output.status.success() {
-        anyhow::bail!("move-ir-compiler failed");
+        anyhow::bail!("move-ir-compiler failed. stderr:\n\n{}",
+                      String::from_utf8_lossy(&output.stderr));
     }
 
     Ok(())
@@ -123,7 +124,8 @@ fn compile_mvbc_to_llvmir(harness_paths: &HarnessPaths, test_plan: &TestPlan) ->
 
     let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
     if !output.status.success() {
-        anyhow::bail!("move-mv-llvm-compiler failed");
+        anyhow::bail!("move-mv-llvm-compiler failed. stderr:\n\n{}",
+                      String::from_utf8_lossy(&output.stderr));
     }
 
     Ok(())

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/empty-module.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/empty-module.expected.ll
@@ -1,0 +1,7 @@
+; ModuleID = 'module 1.TestBinaryOps'
+source_filename = "1.TestBinaryOps.bc"
+target triple = "bpfel-unknown-unknown"
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i64 3}

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/friend.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/friend.expected.ll
@@ -1,0 +1,7 @@
+; ModuleID = 'module 42.A'
+source_filename = "42.A.bc"
+target triple = "bpfel-unknown-unknown"
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i64 3}

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/small.mvir
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/small.mvir
@@ -1,3 +1,4 @@
+// ignore
 module 0x1.test {
 main() {
         label b0:

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/struct-pair.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/struct-pair.expected.ll
@@ -1,0 +1,13 @@
+; ModuleID = 'module 1.TestBinaryOps'
+source_filename = "1.TestBinaryOps.bc"
+target triple = "bpfel-unknown-unknown"
+
+%T = type { i1 }
+%Pair = type { i64, i64 }
+
+@T = external global %T
+@Pair = external global %Pair
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i64 3}

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/struct.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/struct.expected.ll
@@ -1,0 +1,11 @@
+; ModuleID = 'module 1.TestBinaryOps'
+source_filename = "1.TestBinaryOps.bc"
+target triple = "bpfel-unknown-unknown"
+
+%T = type { i1 }
+
+@T = external global %T
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i64 3}

--- a/language/tools/move-mv-llvm-compiler/tests/testdata/struct_arguments.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/testdata/struct_arguments.expected.ll
@@ -1,0 +1,11 @@
+; ModuleID = 'module 42.M'
+source_filename = "42.M.bc"
+target triple = "bpfel-unknown-unknown"
+
+%S = type { i64 }
+
+@S = external global %S
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i64 3}


### PR DESCRIPTION
- Suggests how to build `move-mv-compiler` when it is not available.
- Prints compilers' stderr when they fail.
- Reenable the disabled step of running `move-mv-compiler`
- Add an `// ignore` directive to ignore broken tests, use it on `small.mvir`, which seems to have invalid syntax.
- Add more docs
- Run rustfmt

This also promotes all the non-ignored tests, creating `.expected.ll` files for them, as the results seem to be ok. So after this, running `cargo test -p move-mv-llvm-compiler --test ir-tests` should pass, if `move-mv-compiler` is built.