### PR TITLE
Eliminate warnings

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
+++ b/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
@@ -12,7 +12,6 @@ use std::marker::PhantomData;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::{fs::File, mem::MaybeUninit};
 
 use move_binary_format::{
     file_format::{

--- a/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
@@ -1,5 +1,7 @@
 //! This module contains some supplemental functions for dealing with errors.
 
+#![allow(unused)]
+
 use libc::c_void;
 use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
 use llvm_sys::error_handling::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};

--- a/language/tools/move-mv-llvm-compiler/src/support/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 #[deny(missing_docs)]
 pub mod error_handling;
 


### PR DESCRIPTION
The build is pretty noisy at the moment. I've added `#![allow(unused)]` to a few modules for now, and fixed some code patterns that were getting other warnings.