### PR TITLE
Run llvm verification pass

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/disassembler.rs
+++ b/language/tools/move-mv-llvm-compiler/src/disassembler.rs
@@ -176,6 +176,8 @@ impl<'a> Disassembler<'a> {
         move_module.position_at_end(entry_block);
         move_module.build_return(move_module.llvm_constant(0));
 
+        verify_function(fn_value);
+
         fn_value
     }
 
@@ -302,6 +304,8 @@ impl<'a> Disassembler<'a> {
             }
         };
 
+        verify_module(move_module.module);
+
         Ok(move_module.module)
     }
 
@@ -351,5 +355,23 @@ impl<'a> Disassembler<'a> {
         }
 
         Ok(())
+    }
+}
+
+fn verify_function(llfn: LLVMValueRef) {
+    use llvm_sys::analysis::*;
+    unsafe {
+        LLVMVerifyFunction(
+            llfn, LLVMVerifierFailureAction::LLVMAbortProcessAction
+        );
+    }
+}
+
+fn verify_module(llmod: LLVMModuleRef) {
+    use llvm_sys::analysis::*;
+    unsafe {
+        LLVMVerifyModule(
+            llmod, LLVMVerifierFailureAction::LLVMAbortProcessAction, ptr::null_mut(),
+        );
     }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script.move
@@ -1,3 +1,4 @@
+// ignore
 script {
   fun main() { }
 }


### PR DESCRIPTION
This runs the verifier before exiting.

It uses the legacy pass manager because I could more easily figure out how to use it.
I don't really understand how the pass manager works, but I put this together by cribbing off of rustc.

Rust drives the function pass manager with its own c++ code, claiming that module functions can't be iterated with the C api. So I adapted Rust's `LLVMRustRunFunctionPassManager`. The C++ code lives inside a new crate, `llvm-extra-sys`.

I'd be glad to know if there's a way to run the verifier without writing some C++ code. But we'd probably end up with some C++ glue code eventually anyway.

The verified discovered that the return type emitted for the `script.move` test is wrong, so I disabled that test.