### PR TITLE
Fix rbpf-tests selection

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -9,7 +9,7 @@ use test_common as tc;
 
 pub const TEST_DIR: &str = "tests/rbpf-tests";
 
-datatest_stable::harness!(run_test, TEST_DIR, r".*\.move");
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
 
 fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     Ok(run_test_inner(test_path)?)


### PR DESCRIPTION
Need to specify that `.move` is the end of the file name. Otherwise it picks up emacs temp files. The other test harnesses do this correctly.