### PR TITLE
Switch to the sbf-solana-solana target

### DIFF
--- a/language/tools/move-mv-llvm-compiler/README.md
+++ b/language/tools/move-mv-llvm-compiler/README.md
@@ -18,21 +18,21 @@ Read more about bytecode translations from [here](https://github.com/move-langua
 
 Building requires a local build of [`llvm-project`](https://github.com/solana-labs/llvm-project)
 from Solana's fork that supports the Solana variant of eBPF,
-and testing requires an installation of the Solana [`bpf-tools`](https://github.com/solana-labs/bpf-tools).
+and testing requires an installation of the Solana [`sbf-tools`](https://github.com/solana-labs/sbf-tools).
 
 Known working revisions of both:
 
 - llvm-project: commit `a0bf4d22b6af79f5f4d9a0b42ac3ef855e79b602`,
   tag `15.0-2022-08-09`,
   from the `solana-labs` repo
-- bpf-tools: version `1.32`
+- sbf-tools: version `1.32`
 
-`bpf-tools` can be extracted from the binary release.
+`sbf-tools` can be extracted from the binary release.
 
 Export two environment variables:
 
 - `LLVM_SYS_150_PREFIX` - the path to the LLVM build directory
-- `BPF_TOOLS_ROOT` - the path at which `bpf-tools` was extracted
+- `SBF_TOOLS_ROOT` - the path at which `sbf-tools` was extracted
 
 ## Testing
 
@@ -40,7 +40,7 @@ This project contains three test suites:
 
 - `ir-tests` - converts Move IR (`.mvir`) to LLVM IR,
 - `move-ir-tests` - converts Move source (`.move`) to LLVM IR,
-- `rbpf-tests` - runs move as BPF in the `rbpf` VM.
+- `rbpf-tests` - runs move as SBF in the `rbpf` VM.
 
 These test require the `move-ir-compiler` and `move-build` tools,
 which can be built with

--- a/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
+++ b/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
@@ -101,3 +101,14 @@ pub enum AttributeKind {
     NoUndef = 33,
     SanitizeMemTag = 34,
 }
+
+// These only exist in the Solana LLVM fork,
+// and are not provided by the llvm-sys crate.
+extern {
+    pub fn LLVMInitializeSBFTargetInfo();
+    pub fn LLVMInitializeSBFTarget();
+    pub fn LLVMInitializeSBFTargetMC();
+    pub fn LLVMInitializeSBFAsmPrinter();
+    pub fn LLVMInitializeSBFAsmParser();
+    pub fn LLVMInitializeSBFDisassembler();
+}

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -23,12 +23,13 @@ use std::ptr;
 pub use llvm_extra_sys::AttributeKind;
 pub use llvm_sys::LLVMIntPredicate;
 
-pub fn initialize_bpf() {
+pub fn initialize_sbf() {
     unsafe {
-        LLVMInitializeBPFTargetInfo();
-        LLVMInitializeBPFTarget();
-        LLVMInitializeBPFTargetMC();
-        LLVMInitializeBPFAsmPrinter();
+        LLVMInitializeSBFTargetInfo();
+        LLVMInitializeSBFTarget();
+        LLVMInitializeSBFTargetMC();
+        LLVMInitializeSBFAsmPrinter();
+        LLVMInitializeSBFAsmParser();
     }
 }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -42,7 +42,7 @@ pub enum Target {
 impl Target {
     fn triple(&self) -> &'static str {
         match self {
-            Target::Solana => "bpfel-unknown-unknown",
+            Target::Solana => "sbf-solana-solana",
         }
     }
 
@@ -61,7 +61,7 @@ impl Target {
     fn initialize_llvm(&self) {
         match self {
             Target::Solana => {
-                llvm::initialize_bpf();
+                llvm::initialize_sbf();
             }
         }
     }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -16,7 +16,7 @@ fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
-    let bpf_tools = get_bpf_tools()?;
+    let sbf_tools = get_sbf_tools()?;
 
     let harness_paths = tc::get_harness_paths()?;
     let test_plan = tc::get_test_plan(test_path)?;
@@ -32,7 +32,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
 
     compile_all_bytecode_to_object_files(&harness_paths, &compilation_units)?;
 
-    let exe = link_object_files(&test_plan, &bpf_tools, &compilation_units)?;
+    let exe = link_object_files(&test_plan, &sbf_tools, &compilation_units)?;
 
     run_rbpf(&exe)?;
 
@@ -55,50 +55,50 @@ fn compile_all_bytecode_to_object_files(
     })
 }
 
-struct BpfTools {
+struct SbfTools {
     _root: PathBuf,
     clang: PathBuf,
     rustc: PathBuf,
     lld: PathBuf,
 }
 
-fn get_bpf_tools() -> anyhow::Result<BpfTools> {
-    let bpf_tools_root =
-        std::env::var("BPF_TOOLS_ROOT").context("env var BPF_TOOLS_ROOT not set")?;
-    let bpf_tools_root = PathBuf::from(bpf_tools_root);
+fn get_sbf_tools() -> anyhow::Result<SbfTools> {
+    let sbf_tools_root =
+        std::env::var("SBF_TOOLS_ROOT").context("env var SBF_TOOLS_ROOT not set")?;
+    let sbf_tools_root = PathBuf::from(sbf_tools_root);
 
-    let bpf_tools = BpfTools {
-        _root: bpf_tools_root.clone(),
-        clang: bpf_tools_root
+    let sbf_tools = SbfTools {
+        _root: sbf_tools_root.clone(),
+        clang: sbf_tools_root
             .join("llvm/bin/clang")
             .with_extension(std::env::consts::EXE_EXTENSION),
-        rustc: bpf_tools_root
+        rustc: sbf_tools_root
             .join("rust/bin/rustc")
             .with_extension(std::env::consts::EXE_EXTENSION),
-        lld: bpf_tools_root.join("llvm/bin/ld.lld"),
+        lld: sbf_tools_root.join("llvm/bin/ld.lld"),
     };
 
-    if !bpf_tools.clang.exists() {
-        anyhow::bail!("no clang bin at {}", bpf_tools.clang.display());
+    if !sbf_tools.clang.exists() {
+        anyhow::bail!("no clang bin at {}", sbf_tools.clang.display());
     }
-    if !bpf_tools.rustc.exists() {
-        anyhow::bail!("no rustc bin at {}", bpf_tools.rustc.display());
+    if !sbf_tools.rustc.exists() {
+        anyhow::bail!("no rustc bin at {}", sbf_tools.rustc.display());
     }
-    if !bpf_tools.lld.exists() {
-        anyhow::bail!("no lld bin at {}", bpf_tools.lld.display());
+    if !sbf_tools.lld.exists() {
+        anyhow::bail!("no lld bin at {}", sbf_tools.lld.display());
     }
 
-    Ok(bpf_tools)
+    Ok(sbf_tools)
 }
 
 fn link_object_files(
     test_plan: &tc::TestPlan,
-    bpf_tools: &BpfTools,
+    sbf_tools: &SbfTools,
     compilation_units: &[tc::CompilationUnit],
 ) -> anyhow::Result<PathBuf> {
     let output_dylib = test_plan.build_dir.join("output.so");
 
-    let mut cmd = Command::new(&bpf_tools.lld);
+    let mut cmd = Command::new(&sbf_tools.lld);
     cmd.args(["-z", "notext"]);
     cmd.arg("-shared");
     cmd.arg("--Bdynamic");


### PR DESCRIPTION
Fixes https://github.com/solana-labs/move/issues/33

Running the tests now requires the _sbf-tools_ and setting `SBF_TOOLS_ROOT`, not `BPF_TOOLS_ROOT`. Instructions are updated.