### PR TITLE
Support multiple modules, add function calls, unfork rbpf, etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "solana_rbpf"
 version = "0.2.38"
-source = "git+https://github.com/brson/rbpf.git?rev=124c732056bd05d773ad48107ff1c33fb06dc989#124c732056bd05d773ad48107ff1c33fb06dc989"
+source = "git+https://github.com/solana-labs/rbpf.git?rev=c03dbfef82487396fc6f96d2cfeca409d6181192#c03dbfef82487396fc6f96d2cfeca409d6181192"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -37,9 +37,8 @@ datatest-stable = "0.1.1"
 similar = "2.1.0"
 
 [dev-dependencies.solana_rbpf]
-# nb: this fork is carrying a minor workaround for an undiagnosed issue with how how are linking bpf
-git = "https://github.com/brson/rbpf.git"
-rev = "124c732056bd05d773ad48107ff1c33fb06dc989"
+git = "https://github.com/solana-labs/rbpf.git"
+rev = "c03dbfef82487396fc6f96d2cfeca409d6181192"
 
 [features]
 default = []

--- a/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
+++ b/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
@@ -104,7 +104,7 @@ pub enum AttributeKind {
 
 // These only exist in the Solana LLVM fork,
 // and are not provided by the llvm-sys crate.
-extern {
+extern "C" {
     pub fn LLVMInitializeSBFTargetInfo();
     pub fn LLVMInitializeSBFTarget();
     pub fn LLVMInitializeSBFTargetMC();

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -90,8 +90,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut dep_bytecode_bytes = vec![];
     for dep in &args.bytecode_dependency_paths {
-        let bytes = fs::read(dep)
-            .context("Unable to read dependency bytecode file {dep}")?;
+        let bytes = fs::read(dep).context("Unable to read dependency bytecode file {dep}")?;
         dep_bytecode_bytes.push(bytes);
     }
 
@@ -145,9 +144,10 @@ fn main() -> anyhow::Result<()> {
             dep_move_modules.push(dep_module);
         }
 
-        let modules = dep_move_modules.into_iter().chain(
-            Some(main_move_module)
-        ).collect::<Vec<_>>();
+        let modules = dep_move_modules
+            .into_iter()
+            .chain(Some(main_move_module))
+            .collect::<Vec<_>>();
 
         move_model::run_bytecode_model_builder(&modules)?
     };

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -11,7 +11,7 @@ pub impl<'a> ModuleEnvExt for mm::ModuleEnv<'a> {
 }
 
 #[extension_trait]
-pub impl<'a> FunctionEnxExt for mm::FunctionEnv<'a> {
+pub impl<'a> FunctionEnvExt for mm::FunctionEnv<'a> {
     fn llvm_symbol_name(&self) -> String {
         let name = self.get_full_name_str();
         if name == "<SELF>::<SELF>" {
@@ -21,6 +21,16 @@ pub impl<'a> FunctionEnxExt for mm::FunctionEnv<'a> {
         } else {
             let name = name.replace(':', "_");
             name
+        }
+    }
+}
+
+#[extension_trait]
+pub impl FunIdExt for mm::FunId {
+    fn qualified(&self, m: mm::ModuleId) -> mm::QualifiedId<mm::FunId> {
+        mm::QualifiedId {
+            module_id: m,
+            id: *self,
         }
     }
 }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -13,13 +13,13 @@ pub impl<'a> ModuleEnvExt for mm::ModuleEnv<'a> {
 #[extension_trait]
 pub impl<'a> FunctionEnxExt for mm::FunctionEnv<'a> {
     fn llvm_symbol_name(&self) -> String {
-        // fixme use get_full_name_str
-        let name = self.get_name_str();
-        if name == "<SELF>" {
+        let name = self.get_full_name_str();
+        if name == "<SELF>::<SELF>" {
             // fixme move-model names script fns "<SELF>".
             // we might want to preserve the actual names
             "main".to_string()
         } else {
+            let name = name.replace(':', "_");
             name
         }
     }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -268,10 +268,10 @@ impl Builder {
                 "retval".cstr(),
             );
 
-            LLVMBuildStore(self.0, ret, dst.1.0);
+            LLVMBuildStore(self.0, ret, dst.1 .0);
         }
     }
-    
+
     pub fn build_unreachable(&self) {
         unsafe {
             LLVMBuildUnreachable(self.0);

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -224,7 +224,9 @@ impl Builder {
         }
     }
 
-    pub fn load_call(&self, fnty: FunctionType, fnval: Function, args: &[(Type, Alloca)]) {
+    pub fn load_call(&self, fnval: Function, args: &[(Type, Alloca)]) {
+        let fnty = fnval.llvm_type();
+
         unsafe {
             let mut args = args
                 .iter()
@@ -245,6 +247,31 @@ impl Builder {
         }
     }
 
+    pub fn load_call_store(&self, fnval: Function, args: &[(Type, Alloca)], dst: (Type, Alloca)) {
+        let fnty = fnval.llvm_type();
+
+        unsafe {
+            let mut args = args
+                .iter()
+                .enumerate()
+                .map(|(i, (ty, val))| {
+                    let name = format!("call_arg_{i}");
+                    LLVMBuildLoad2(self.0, ty.0, val.0, name.cstr())
+                })
+                .collect::<Vec<_>>();
+            let ret = LLVMBuildCall2(
+                self.0,
+                fnty.0,
+                fnval.0,
+                args.as_mut_ptr(),
+                args.len() as libc::c_uint,
+                "retval".cstr(),
+            );
+
+            LLVMBuildStore(self.0, ret, dst.1.0);
+        }
+    }
+    
     pub fn build_unreachable(&self) {
         unsafe {
             LLVMBuildUnreachable(self.0);
@@ -299,6 +326,7 @@ impl FunctionType {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Function(LLVMValueRef);
 
 impl Function {
@@ -330,7 +358,7 @@ impl Function {
     }
 
     pub fn llvm_type(&self) -> FunctionType {
-        unsafe { FunctionType(LLVMTypeOf(self.0)) }
+        unsafe { FunctionType(LLVMGlobalGetValueType(self.0)) }
     }
 
     pub fn verify(&self) {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -162,8 +162,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     }
                 };
 
-                let ll_parm_tys =
-                    fn_env
+                let ll_parm_tys = fn_env
                     .get_parameter_types()
                     .iter()
                     .map(|mty| self.llvm_type(mty))
@@ -458,12 +457,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
     ) {
         dbg!((mod_id, fun_id, types, dst, src));
 
-        let dst_locals = dst.iter().map(|i| {
-            &self.locals[*i]
-        }).collect::<Vec<_>>();
-        let src_locals = src.iter().map(|i| {
-            &self.locals[*i]
-        }).collect::<Vec<_>>();
+        let dst_locals = dst.iter().map(|i| &self.locals[*i]).collect::<Vec<_>>();
+        let src_locals = src.iter().map(|i| &self.locals[*i]).collect::<Vec<_>>();
 
         let ll_fn = self.fn_decls[&fun_id.qualified(mod_id)];
 
@@ -475,19 +470,19 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
 
         match dst {
             None => {
-                let src = src_locals.iter().map(|l| {
-                    (l.llty, l.llval)
-                }).collect::<Vec<_>>();
-                self.llvm_builder
-                    .load_call(ll_fn, &src);
+                let src = src_locals
+                    .iter()
+                    .map(|l| (l.llty, l.llval))
+                    .collect::<Vec<_>>();
+                self.llvm_builder.load_call(ll_fn, &src);
             }
             Some(dst) => {
                 let dst = (dst.llty, dst.llval);
-                let src = src_locals.iter().map(|l| {
-                    (l.llty, l.llval)
-                }).collect::<Vec<_>>();
-                self.llvm_builder
-                    .load_call_store(ll_fn, &src, dst);
+                let src = src_locals
+                    .iter()
+                    .map(|l| (l.llty, l.llval))
+                    .collect::<Vec<_>>();
+                self.llvm_builder.load_call_store(ll_fn, &src, dst);
             }
         }
     }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define void @test() {
+define void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define void @test() {
+define void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define i1 @test(i8 %0, i8 %1) {
+define i1 @Test__test(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define i8 @test(i1 %0) {
+define i8 @Test__test(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define i8 @test(i8 %0, i8 %1) {
+define i8 @Test__test(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -1,0 +1,23 @@
+; ModuleID = '0x101__Test2'
+source_filename = "<unknown>"
+
+define i8 @Test2__test2(i8 %0, i8 %1) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i8, align 1
+  store i8 %0, ptr %local_0, align 1
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %add_src_0 = load i8, ptr %local_2, align 1
+  %add_src_1 = load i8, ptr %local_3, align 1
+  %add_dst = add i8 %add_src_0, %add_src_1
+  store i8 %add_dst, ptr %local_4, align 1
+  %retval = load i8, ptr %local_4, align 1
+  ret i8 %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
@@ -1,0 +1,25 @@
+; ModuleID = '0x100__Test1'
+source_filename = "<unknown>"
+
+define i8 @Test1__test1(i8 %0, i8 %1) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i8, align 1
+  store i8 %0, ptr %local_0, align 1
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load i8, ptr %local_3, align 1
+  %retval = call i8 @Test2__test2(i8 %call_arg_0, i8 %call_arg_1)
+  store i8 %retval, ptr %local_4, align 1
+  %retval2 = load i8, ptr %local_4, align 1
+  ret i8 %retval2
+}
+
+declare i8 @Test2__test2(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -1,0 +1,18 @@
+; ModuleID = '<SELF>'
+source_filename = "<unknown>"
+
+define void @main() {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  store i8 1, ptr %local_0, align 1
+  store i8 2, ptr %local_1, align 1
+  %call_arg_0 = load i8, ptr %local_0, align 1
+  %call_arg_1 = load i8, ptr %local_1, align 1
+  %retval = call i8 @Test1__test1(i8 %call_arg_0, i8 %call_arg_1)
+  store i8 %retval, ptr %local_2, align 1
+  ret void
+}
+
+declare i8 @Test1__test1(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module.move
@@ -1,0 +1,23 @@
+module 0x100::Test1 {
+  use 0x101::Test2;
+
+  public fun test1(a: u8, b: u8): u8 {
+    Test2::test2(a, b)
+  }
+}
+
+module 0x101::Test2 {
+  public fun test2(a: u8, b: u8): u8 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u8 = 1;
+    let b: u8 = 2;
+    let _c = 0x100::Test1::test1(a, b);
+    // assert!(c == 3);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
@@ -1,7 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
-define i8 @test() {
+define i8 @Test__test() {
 entry:
   %local_0 = alloca i8, align 1
   store i8 100, ptr %local_0, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -137,6 +137,7 @@ fn run_rbpf(exe: &Path) -> anyhow::Result<()> {
         enable_elf_vaddr: false,
         reject_rodata_stack_overlap: false,
         static_syscalls: false,
+        enable_instruction_meter: false,
         ..Config::default()
     };
     let loader = Arc::new(BuiltInProgram::new_loader(config));

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -96,14 +96,13 @@ fn link_object_files(
     sbf_tools: &SbfTools,
     compilation_units: &[tc::CompilationUnit],
 ) -> anyhow::Result<PathBuf> {
-
     let link_script = {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("cargo manifest dir");
         let manifest_dir = PathBuf::from(manifest_dir);
         let link_script = manifest_dir.join("tests/sbf-link-script.ld");
         link_script.to_string_lossy().to_string()
     };
-    
+
     let output_dylib = test_plan.build_dir.join("output.so");
 
     let mut cmd = Command::new(&sbf_tools.lld);

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/multi-module.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/multi-module.move
@@ -1,0 +1,23 @@
+module 0x100::Test1 {
+  use 0x101::Test2;
+
+  public fun test1(a: u8, b: u8): u8 {
+    Test2::test2(a, b)
+  }
+}
+
+module 0x101::Test2 {
+  public fun test2(a: u8, b: u8): u8 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u8 = 3;
+    let b: u8 = 2;
+    let _c = 0x100::Test1::test1(a, b);
+    // assert!(c == 5);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/sbf-link-script.ld
+++ b/language/tools/move-mv-llvm-compiler/tests/sbf-link-script.ld
@@ -1,0 +1,24 @@
+PHDRS
+{
+  text PT_LOAD ;
+  rodata PT_LOAD ;
+  data PT_LOAD ;
+  dynamic PT_DYNAMIC ;
+}
+
+SECTIONS
+{
+  . = SIZEOF_HEADERS;
+  .text : { *(.text*) } :text
+  .rodata : { *(.rodata*) } :rodata
+  .data.rel.ro : { *(.data.rel.ro*) } :rodata
+  .dynamic : { *(.dynamic) } :dynamic
+  .dynsym : { *(.dynsym) } :data
+  .dynstr : { *(.dynstr) } :data
+  .rel.dyn : { *(.rel.dyn) } :data
+  /DISCARD/ : {
+      *(.eh_frame*)
+      *(.gnu.hash*)
+      *(.hash*)
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -201,14 +201,17 @@ pub fn compile_all_bytecode(
     outtype_flag: &str,
     outfile: &dyn Fn(&CompilationUnit) -> PathBuf,
 ) -> anyhow::Result<()> {
-
     // compilation_units is sorted by dependencies
-    let compilation_units_with_deps: Vec<(&CompilationUnit, Vec<&CompilationUnit>)>
-        = compilation_units.iter().enumerate().map(|(i, cu)| {
-            let deps: Vec<_> = compilation_units.iter().take(i).collect();
-            (cu, deps)
-        }).collect();
-    
+    let compilation_units_with_deps: Vec<(&CompilationUnit, Vec<&CompilationUnit>)> =
+        compilation_units
+            .iter()
+            .enumerate()
+            .map(|(i, cu)| {
+                let deps: Vec<_> = compilation_units.iter().take(i).collect();
+                (cu, deps)
+            })
+            .collect();
+
     for (cu, deps) in compilation_units_with_deps {
         let mut cmd = Command::new(&harness_paths.move_mv_llvm_compiler);
         cmd.arg("-b");

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -129,6 +129,10 @@ pub enum CompilationUnitType {
     Module,
 }
 
+/// Return all paths to all bytecode modules.
+///
+/// They are ordered topologically by dependency graph,
+/// as required by the move model.
 pub fn find_compilation_units(test_plan: &TestPlan) -> anyhow::Result<Vec<CompilationUnit>> {
     let modules_dir = test_plan.build_dir.join("modules");
     let scripts_dir = test_plan.build_dir.join("scripts");
@@ -145,6 +149,8 @@ pub fn find_compilation_units(test_plan: &TestPlan) -> anyhow::Result<Vec<Compil
             continue;
         }
 
+        let mut paths = vec![];
+
         for dirent in fs::read_dir(&dir)? {
             let dirent = dirent?;
             let path = dirent.path();
@@ -152,8 +158,15 @@ pub fn find_compilation_units(test_plan: &TestPlan) -> anyhow::Result<Vec<Compil
                 continue;
             }
 
-            let bytecode = path;
+            paths.push(path);
+        }
 
+        // The move compiler conveniently outputs modules with topo-sorted names!
+        // So we just have to sort the filenames and we've got them in the correct order.
+        paths.sort();
+
+        for path in paths {
+            let bytecode = path;
             units.push(CompilationUnit { type_, bytecode });
         }
     }
@@ -188,7 +201,15 @@ pub fn compile_all_bytecode(
     outtype_flag: &str,
     outfile: &dyn Fn(&CompilationUnit) -> PathBuf,
 ) -> anyhow::Result<()> {
-    for cu in compilation_units {
+
+    // compilation_units is sorted by dependencies
+    let compilation_units_with_deps: Vec<(&CompilationUnit, Vec<&CompilationUnit>)>
+        = compilation_units.iter().enumerate().map(|(i, cu)| {
+            let deps: Vec<_> = compilation_units.iter().take(i).collect();
+            (cu, deps)
+        }).collect();
+    
+    for (cu, deps) in compilation_units_with_deps {
         let mut cmd = Command::new(&harness_paths.move_mv_llvm_compiler);
         cmd.arg("-b");
         cmd.arg(&cu.bytecode);
@@ -198,6 +219,11 @@ pub fn compile_all_bytecode(
 
         if cu.type_ == CompilationUnitType::Script {
             cmd.arg("-s");
+        }
+
+        for dep in deps {
+            cmd.arg("-d");
+            cmd.arg(&dep.bytecode);
         }
 
         let output = cmd.output().context("run move-mv-llvm-compiler failed")?;


### PR DESCRIPTION
This does a number of things with the goal of linking multiple modules, which is required to test function calls (among other things), as rbpf-tests runs move _scripts_, which contain only one function. To call another function the tests need to additionally include modules.

- Pass paths of bytecode dependencies to move-mv-llvm-compiler. move-build fortunately gives every compiled module a name like `1_ModuleA.mv`, where the number orders the modules topologically, so the dependencies of any module are the ones that sort before it.
- When translating a module, first declare all local functions, and all external functions called by the module. The move model conveniently tells us every called function.
- Change the function symbol names to include the module name to avoid obvious name collisions. The naming will need to change more in the future probably.
- Add llvm lowering of function calls.
- Add rustc's linkerscript for the sbf target. This produces binaries that rbpf validates. I don't understand what transformation exactly this does that causes the bins to validate. Switch from my rbpf fork back to solana's.

I introduced a clone of the ModuleEnv to get around an awkward borrowing problem, and left a fixme. I also found that the `'mm` lifetime is wrong, but harmless for now. I'll think about how to better structure this to make the borrowing simpler.