### PR TITLE
Mark abort_code allow(unused)

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -61,6 +61,7 @@ impl TestPlan {
         self.directives.contains(&TestDirective::Ignore)
     }
 
+    #[allow(unused)] // not used by all test harnesses
     pub fn abort_code(&self) -> Option<u64> {
         self.directives.iter().find_map(|d| match d {
             TestDirective::Abort(code) => Some(*code),


### PR DESCRIPTION
This file is shared between two different test harnesses, and abort_code is not used by move-ir-tests, so it is emitting a warning.