### PR TITLE
Don't emit duplicate function declarations.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/call-foreign-2.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/call-foreign-2.move
@@ -1,0 +1,28 @@
+// regression-test for incorrectly double-declaring function `a` here.
+
+module 0x101::foo {
+  public fun a(): u8 {
+    1
+  }
+}
+
+module 0x102::bar {
+  use 0x101::foo;
+
+  public fun b(): u8 {
+    foo::a()
+  }
+
+  public fun c(): u8 {
+    foo::a()
+  }
+}
+
+script {
+  use 0x102::bar;
+
+  fun main() {
+    let v = bar::c();
+    assert!(v == 1, 11);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/call-local.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/call-local.move
@@ -1,0 +1,20 @@
+// regression-test for incorrectly double-declaring function `a` here.
+
+module 0x101::foo {
+  public fun a(): u8 {
+    1
+  }
+
+  public fun b(): u8 {
+    a()
+  }
+}
+
+script {
+  use 0x101::foo;
+
+  fun main() {
+    let v = foo::a();
+    assert!(v == 1, 11);
+  }
+}


### PR DESCRIPTION
Only declare functions once.

Previous code was declaring functions every time they were called, resulting in LLVM silently creating functions named e.g. `a.1`.
