### PR TITLE
Run `cargo x fmt`

### DIFF
--- a/language/tools/move-mv-llvm-compiler/llvm-extra-sys/build.rs
+++ b/language/tools/move-mv-llvm-compiler/llvm-extra-sys/build.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context};
-use std::path::PathBuf;
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 fn main() -> anyhow::Result<()> {
     // Get the path to llvm-config from the llvm-sys crate

--- a/language/tools/move-mv-llvm-compiler/src/cstr.rs
+++ b/language/tools/move-mv-llvm-compiler/src/cstr.rs
@@ -6,10 +6,7 @@
 //! forever. The wasted memory will likely never matter for this compiler, and
 //! is easy to refactor into something more robust if it ever does matter.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::thread_local;
+use std::{cell::RefCell, collections::HashMap, ffi::CString, thread_local};
 
 pub trait SafeCStr {
     fn cstr(&self) -> *const libc::c_char;

--- a/language/tools/move-mv-llvm-compiler/src/disassembler.rs
+++ b/language/tools/move-mv-llvm-compiler/src/disassembler.rs
@@ -17,19 +17,18 @@ use move_bytecode_source_map::{mapping::SourceMapping, source_map::FunctionSourc
 
 use move_core_types::identifier::IdentStr;
 
-use llvm_sys::prelude::{LLVMContextRef as LLVMContext, LLVMModuleRef, LLVMTypeRef, LLVMValueRef};
 use llvm_sys::{
     core::{
         LLVMAddFunction, LLVMAddGlobal, LLVMDisposeMessage, LLVMDumpModule, LLVMFunctionType,
         LLVMGetStructName, LLVMModuleCreateWithNameInContext,
     },
+    prelude::{LLVMContextRef as LLVMContext, LLVMModuleRef, LLVMTypeRef, LLVMValueRef},
     target_machine::LLVMCodeGenOptLevel,
 };
 
 use move_ir_types::location::Loc;
 
-use std::ffi::CStr;
-use std::{fs::File, ptr};
+use std::{ffi::CStr, fs::File, ptr};
 
 use crate::{move_bpf_module::MoveBPFModule, support::to_c_str};
 
@@ -335,8 +334,10 @@ impl<'a> Disassembler<'a> {
         llvm_ir: bool,
         output_file_name: &String,
     ) -> Result<()> {
-        use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
-        use llvm_sys::core::{LLVMPrintModuleToFile, LLVMPrintModuleToString};
+        use llvm_sys::{
+            bit_writer::LLVMWriteBitcodeToFD,
+            core::{LLVMPrintModuleToFile, LLVMPrintModuleToString},
+        };
         use std::os::unix::io::AsRawFd;
 
         unsafe {

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -8,8 +8,7 @@
 
 use anyhow::Context;
 use clap::Parser;
-use llvm_sys::core::LLVMContextCreate;
-use llvm_sys::prelude::LLVMModuleRef;
+use llvm_sys::{core::LLVMContextCreate, prelude::LLVMModuleRef};
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{CompiledModule, CompiledScript},
@@ -195,13 +194,12 @@ pub fn llvm_write_to_file(
     llvm_ir: bool,
     output_file_name: &String,
 ) -> anyhow::Result<()> {
-    use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
-    use llvm_sys::core::{LLVMDisposeMessage, LLVMPrintModuleToFile, LLVMPrintModuleToString};
+    use llvm_sys::{
+        bit_writer::LLVMWriteBitcodeToFD,
+        core::{LLVMDisposeMessage, LLVMPrintModuleToFile, LLVMPrintModuleToString},
+    };
     use move_mv_llvm_compiler::support::to_c_str;
-    use std::ffi::CStr;
-    use std::fs::File;
-    use std::os::unix::io::AsRawFd;
-    use std::ptr;
+    use std::{ffi::CStr, fs::File, os::unix::io::AsRawFd, ptr};
 
     unsafe {
         if llvm_ir {

--- a/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
+++ b/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
@@ -7,24 +7,28 @@ use llvm_sys::core::{
     LLVMStructCreateNamed, LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeOf, LLVMVoidType,
 };
 
-use llvm_sys::debuginfo::{LLVMCreateDIBuilder, LLVMDIBuilderCreateFile};
-use llvm_sys::prelude::{
-    LLVMBasicBlockRef, LLVMBuilderRef, LLVMContextRef, LLVMDIBuilderRef, LLVMMetadataRef,
-    LLVMModuleRef, LLVMTypeRef, LLVMValueRef,
+use llvm_sys::{
+    debuginfo::{LLVMCreateDIBuilder, LLVMDIBuilderCreateFile},
+    prelude::{
+        LLVMBasicBlockRef, LLVMBuilderRef, LLVMContextRef, LLVMDIBuilderRef, LLVMMetadataRef,
+        LLVMModuleRef, LLVMTypeRef, LLVMValueRef,
+    },
+    target_machine::{
+        LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine, LLVMGetTargetFromName,
+        LLVMRelocMode, LLVMTargetMachineRef, LLVMTargetRef,
+    },
+    LLVMModuleFlagBehavior, LLVMTypeKind,
 };
-use llvm_sys::target_machine::{
-    LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine, LLVMGetTargetFromName,
-    LLVMRelocMode, LLVMTargetMachineRef, LLVMTargetRef,
-};
-use llvm_sys::{LLVMModuleFlagBehavior, LLVMTypeKind};
 
 use crate::support::{to_c_str, LLVMString};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use std::collections::HashMap;
-use std::ffi::CStr;
-use std::fmt::{self, Debug};
-use std::marker::PhantomData;
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    fmt::{self, Debug},
+    marker::PhantomData,
+};
 
 use move_binary_format::file_format::{SignatureToken, StructHandleIndex, TypeParameterIndex};
 use move_bytecode_source_map::mapping::SourceMapping;

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -10,16 +10,14 @@
 //! - Provides high-level instruction builders compatible with the stackless bytecode model.
 
 use llvm_extra_sys::*;
-use llvm_sys::core::*;
-use llvm_sys::prelude::*;
-use llvm_sys::target::*;
-use llvm_sys::target_machine::*;
-use llvm_sys::LLVMOpcode;
+use llvm_sys::{core::*, prelude::*, target::*, target_machine::*, LLVMOpcode};
 
 use crate::cstr::SafeCStr;
 
-use std::ffi::{CStr, CString};
-use std::ptr;
+use std::{
+    ffi::{CStr, CString},
+    ptr,
+};
 
 pub use llvm_extra_sys::AttributeKind;
 pub use llvm_sys::LLVMIntPredicate;

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -26,14 +26,12 @@
 //! In general though this compiler does not need to be efficient at compile time -
 //! we can clone things when it makes managing lifetimes easier.
 
-use crate::stackless::extensions::*;
-use crate::stackless::llvm;
+use crate::stackless::{extensions::*, llvm};
 use llvm_sys::prelude::LLVMValueRef;
-use move_model::ast as mast;
-use move_model::model as mm;
-use move_model::ty as mty;
-use move_stackless_bytecode::stackless_bytecode as sbc;
-use move_stackless_bytecode::stackless_bytecode_generator::StacklessBytecodeGenerator;
+use move_model::{ast as mast, model as mm, ty as mty};
+use move_stackless_bytecode::{
+    stackless_bytecode as sbc, stackless_bytecode_generator::StacklessBytecodeGenerator,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Copy, Clone)]

--- a/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
@@ -3,10 +3,12 @@
 #![allow(unused)]
 
 use libc::c_void;
-use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
-use llvm_sys::error_handling::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};
-use llvm_sys::prelude::LLVMDiagnosticInfoRef;
-use llvm_sys::LLVMDiagnosticSeverity;
+use llvm_sys::{
+    core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity},
+    error_handling::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler},
+    prelude::LLVMDiagnosticInfoRef,
+    LLVMDiagnosticSeverity,
+};
 
 #[cfg(feature = "internal-getters")]
 use crate::LLVMReference;

--- a/language/tools/move-mv-llvm-compiler/src/support/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/mod.rs
@@ -3,15 +3,19 @@
 pub mod error_handling;
 
 use libc::c_char;
-use llvm_sys::core::{LLVMCreateMessage, LLVMDisposeMessage};
-use llvm_sys::error_handling::LLVMEnablePrettyStackTrace;
-use llvm_sys::support::LLVMLoadLibraryPermanently;
+use llvm_sys::{
+    core::{LLVMCreateMessage, LLVMDisposeMessage},
+    error_handling::LLVMEnablePrettyStackTrace,
+    support::LLVMLoadLibraryPermanently,
+};
 
-use std::borrow::Cow;
-use std::error::Error;
-use std::ffi::{CStr, CString};
-use std::fmt::{self, Debug, Display, Formatter};
-use std::ops::Deref;
+use std::{
+    borrow::Cow,
+    error::Error,
+    ffi::{CStr, CString},
+    fmt::{self, Debug, Display, Formatter},
+    ops::Deref,
+};
 
 /// An owned LLVM String. Also known as a LLVM Message
 #[derive(Eq)]

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -45,8 +45,10 @@
 
 use anyhow::Context;
 use similar::{ChangeTag, TextDiff};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 pub const TEST_DIR: &str = "tests/ir-tests";
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
@@ -46,8 +46,10 @@
 
 use extension_trait::extension_trait;
 use similar::{ChangeTag, TextDiff};
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 mod test_common;
 use test_common as tc;

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -1,8 +1,10 @@
 use anyhow::Context;
 use extension_trait::extension_trait;
 use solana_rbpf as rbpf;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 mod test_common;
 use test_common as tc;
@@ -223,12 +225,10 @@ fn link_object_files(
 }
 
 fn run_rbpf(test_plan: &tc::TestPlan, exe: &Path) -> anyhow::Result<()> {
-    use rbpf::ebpf;
-    use rbpf::elf::Executable;
-    use rbpf::error::EbpfError;
-    use rbpf::memory_region::MemoryRegion;
-    use rbpf::verifier::RequisiteVerifier;
-    use rbpf::vm::*;
+    use rbpf::{
+        ebpf, elf::Executable, error::EbpfError, memory_region::MemoryRegion,
+        verifier::RequisiteVerifier, vm::*,
+    };
 
     let loader = rbpf_setup::build_loader()?;
 
@@ -292,9 +292,7 @@ fn run_rbpf(test_plan: &tc::TestPlan, exe: &Path) -> anyhow::Result<()> {
 mod rbpf_setup {
     use super::rbpf;
     use anyhow::anyhow;
-    use rbpf::error::EbpfError;
-    use rbpf::memory_region::MemoryMapping;
-    use rbpf::vm::*;
+    use rbpf::{error::EbpfError, memory_region::MemoryMapping, vm::*};
     use std::sync::Arc;
 
     #[derive(Default, Debug)]

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -1,8 +1,10 @@
 use anyhow::Context;
-use std::ffi::OsStr;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[derive(Debug)]
 pub struct HarnessPaths {


### PR DESCRIPTION
Another discovery while trying to get some CI setup. Upstream customizes `cargo fmt` with their own `cargo x fmt` tool. When run, it makes changes to all our imports.

Like in https://github.com/solana-labs/move/pull/77 we need to be running `cargo x lint`, `cargo x clippy`, and `cargo x fmt` on every commit.
