### PR TITLE
Upgrade to platform-tools 1.36 and corresponding LLVM.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/README.md
+++ b/language/tools/move-mv-llvm-compiler/README.md
@@ -18,21 +18,21 @@ Read more about bytecode translations from [here](https://github.com/move-langua
 
 Building requires a local build of [`llvm-project`](https://github.com/solana-labs/llvm-project)
 from Solana's fork that supports the Solana variant of eBPF,
-and testing requires an installation of the Solana [`sbf-tools`](https://github.com/solana-labs/sbf-tools).
+and testing requires an installation of the Solana [`platform-tools`](https://github.com/solana-labs/platform-tools).
 
 Known working revisions of both:
 
-- llvm-project: commit `a0bf4d22b6af79f5f4d9a0b42ac3ef855e79b602`,
-  tag `15.0-2022-08-09`,
+- llvm-project: commit `33c3629caa59b59d8f585736a4a5194aa9e9377d`,
+  tag `solana-tools-v1.36`,
   from the `solana-labs` repo
-- sbf-tools: version `1.32`
+- platform-tools: version `1.36`
 
-`sbf-tools` can be extracted from the binary release.
+`platform-tools` can be extracted from the binary release.
 
 Export two environment variables:
 
 - `LLVM_SYS_150_PREFIX` - the path to the LLVM build directory
-- `SBF_TOOLS_ROOT` - the path at which `sbf-tools` was extracted
+- `PLATFORM_TOOLS_ROOT` - the path at which `platform-tools` was extracted
 
 ### Instructions to build solana-labs/llvm-project
 
@@ -44,17 +44,17 @@ $ ninja clang
 $ export LLVM_SYS_150_PREFIX=/path/to/llvm-project/build
 ```
 
-### Instructions to get solana-labs/sbf-tools
+### Instructions to get solana-labs/platform-tools
 
 ```
-$ cd /path/to/sbf-tools/releases/
+$ cd /path/to/platform-tools/releases/
 # For OSX download solana-bpf-tools-osx.tar.bz2
-$ wget https://github.com/solana-labs/sbf-tools/releases/download/v1.32/solana-bpf-tools-linux.tar.bz2
-$ mkdir v1.32 && cd v1.32
-$ tar -xf ../solana-bpf-tools-linux.tar.bz2
-$ ls /path/to/sbf-tools/releases/v1.32
+$ wget https://github.com/solana-labs/platform-tools/releases/download/v1.36/solana-platform-tools-linux.tar.bz2
+$ mkdir v1.36 && cd v1.36
+$ tar -xf ../solana-platform-tools-linux.tar.bz2
+$ ls /path/to/platform-tools/releases/v1.36
 llvm  rust  version.md
-$ export SBF_TOOLS_ROOT=/path/to/sbf-tools/releases/v1.32
+$ export PLATFORM_TOOLS_ROOT=/path/to/platform-tools/releases/v1.36
 ```
 
 ## Testing

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -56,7 +56,7 @@ fn compile_all_bytecode_to_object_files(
     })
 }
 
-struct SbfTools {
+struct PlatformTools {
     _root: PathBuf,
     clang: PathBuf,
     rustc: PathBuf,
@@ -64,12 +64,12 @@ struct SbfTools {
     lld: PathBuf,
 }
 
-fn get_sbf_tools() -> anyhow::Result<SbfTools> {
+fn get_sbf_tools() -> anyhow::Result<PlatformTools> {
     let sbf_tools_root =
-        std::env::var("SBF_TOOLS_ROOT").context("env var SBF_TOOLS_ROOT not set")?;
+        std::env::var("PLATFORM_TOOLS_ROOT").context("env var PLATFORM_TOOLS_ROOT not set")?;
     let sbf_tools_root = PathBuf::from(sbf_tools_root);
 
-    let sbf_tools = SbfTools {
+    let sbf_tools = PlatformTools {
         _root: sbf_tools_root.clone(),
         clang: sbf_tools_root
             .join("llvm/bin/clang")
@@ -104,7 +104,7 @@ struct Runtime {
     archive_file: PathBuf,
 }
 
-fn get_runtime(sbf_tools: &SbfTools) -> anyhow::Result<Runtime> {
+fn get_runtime(sbf_tools: &PlatformTools) -> anyhow::Result<Runtime> {
     static BUILD: std::sync::Once = std::sync::Once::new();
 
     BUILD.call_once(|| {
@@ -150,7 +150,7 @@ fn get_runtime(sbf_tools: &SbfTools) -> anyhow::Result<Runtime> {
     Ok(Runtime { archive_file })
 }
 
-impl SbfTools {
+impl PlatformTools {
     fn run_cargo(&self, args: &[&str]) -> anyhow::Result<()> {
         let target_dir = {
             let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("cargo manifest dir");
@@ -180,7 +180,7 @@ impl SbfTools {
 
 fn link_object_files(
     test_plan: &tc::TestPlan,
-    sbf_tools: &SbfTools,
+    sbf_tools: &PlatformTools,
     compilation_units: &[tc::CompilationUnit],
     runtime: &Runtime,
 ) -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
sbf-tools is now called platform-tools. This PR makes a few changes to accomodate:

- changes the `SBF_TOOLS_ROOT` environment variable to `PLATFORM_TOOLS_ROOT`
- changes the docs to recommend platform-tools 1.36 and the corresponding LLVM commit 33c3629caa59b59d8f585736a4a5194aa9e9377d

Note that it seems that the platform tools and the specific LLVM commit must be paired. I was seeing linker errors using the previous LLVM commit with the new platform tools.

After this is merged everybody will want to upgrade platform-tools and LLVM and change their SBF_TOOLS_ROOT env var to PLATFORM_TOOLS_ROOT.

