### PR TITLE
Generate logical shift right for Operation::Shr.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -566,8 +566,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 self.translate_arithm_impl(dst, src, "shl", llvm_sys::LLVMOpcode::LLVMShl);
             }
             Operation::Shr => {
-                // fixme is this an arithmetic or logical shift?
-                self.translate_arithm_impl(dst, src, "shr", llvm_sys::LLVMOpcode::LLVMAShr);
+                self.translate_arithm_impl(dst, src, "shr", llvm_sys::LLVMOpcode::LLVMLShr);
             }
             Operation::Lt => {
                 assert_eq!(dst.len(), 1);

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -79,7 +79,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shr_src_0 = load i8, ptr %local_2, align 1
   %shr_src_1 = load i8, ptr %local_3, align 1
-  %shr_dst = ashr i8 %shr_src_0, %shr_src_1
+  %shr_dst = lshr i8 %shr_src_0, %shr_src_1
   store i8 %shr_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval


### PR DESCRIPTION
The Move shr operation appears to be logical, so generate LLVM lshr instead of LLVM ashr.

The Move interpreter invokes values_impl.rs:shr_checked for these, where shr_checked uses the ordinary Rust >> operator on Move's unsigned types.

According to the Rust reference for operator >>, "Arithmetic right shift on signed integer types, logical right shift on unsigned integer types".

Fixes https://github.com/solana-labs/move/issues/69.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
