### PR TITLE
Implement dynamic arithmetic precondition checks.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -337,9 +337,7 @@ impl Builder {
             let mut args = args
                 .iter()
                 .enumerate()
-                .map(|(_i, val)| {
-                    val.0
-                })
+                .map(|(_i, val)| val.0)
                 .collect::<Vec<_>>();
             LLVMBuildCall2(
                 self.0,

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -179,6 +179,12 @@ impl Drop for Builder {
 }
 
 impl Builder {
+    pub fn get_insert_block(&self) -> BasicBlock {
+        unsafe {
+            BasicBlock(LLVMGetInsertBlock(self.0))
+        }
+    }
+
     pub fn position_at_end(&self, bb: BasicBlock) {
         unsafe {
             LLVMPositionBuilderAtEnd(self.0, bb.0);
@@ -264,6 +270,12 @@ impl Builder {
         }
     }
 
+    pub fn build_cond_br(&self, cnd_reg: LLVMValueRef, bb0: BasicBlock, bb1: BasicBlock) {
+        unsafe {
+            LLVMBuildCondBr(self.0, cnd_reg, bb0.0, bb1.0);
+        }
+    }
+
     pub fn load_cond_br(&self, ty: Type, val: Alloca, bb0: BasicBlock, bb1: BasicBlock) {
         unsafe {
             let cnd_reg = LLVMBuildLoad2(self.0, ty.0, val.0, "cnd".cstr());
@@ -316,6 +328,27 @@ impl Builder {
             );
 
             LLVMBuildStore(self.0, ret, dst.1 .0);
+        }
+    }
+
+    pub fn build_call_imm(&self, fnval: Function, args: &[Constant]) {
+        let fnty = fnval.llvm_type();
+        unsafe {
+            let mut args = args
+                .iter()
+                .enumerate()
+                .map(|(_i, val)| {
+                    val.0
+                })
+                .collect::<Vec<_>>();
+            LLVMBuildCall2(
+                self.0,
+                fnty.0,
+                fnval.0,
+                args.as_mut_ptr(),
+                args.len() as libc::c_uint,
+                "".cstr(),
+            );
         }
     }
 
@@ -387,6 +420,9 @@ impl Type {
     pub fn ptr_type(&self) -> Type {
         unsafe { Type(LLVMPointerType(self.0, 0)) }
     }
+    pub fn get_int_type_width(&self) -> u32 {
+        unsafe { LLVMGetIntTypeWidth(self.0) }
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -452,7 +488,11 @@ impl Function {
 #[derive(Copy, Clone)]
 pub struct BasicBlock(LLVMBasicBlockRef);
 
-impl BasicBlock {}
+impl BasicBlock {
+    pub fn get_basic_block_parent(&self) -> Function {
+        unsafe { Function(LLVMGetBasicBlockParent(self.0)) }
+    }
+}
 
 #[derive(Copy, Clone)]
 pub struct Alloca(LLVMValueRef);
@@ -471,12 +511,20 @@ impl Constant {
     }
     pub fn int128(ty: Type, v: u128) -> Constant {
         unsafe {
-            // TODO: Make sure the endianness is correct.
-            // TODO: Add a testcase with both endianness to make sure this even works.
-            let words: [u64; 2] = [(v >> 64) as u64, v as u64];
-            Constant(LLVMConstIntOfArbitraryPrecision(ty.0, 2, words.as_ptr()))
+            let val_as_str = format!("{v}");
+            Constant(LLVMConstIntOfString(ty.0, val_as_str.cstr(), 10))
         }
     }
+    pub fn generic_int(ty: Type, v: u128) -> Constant {
+        unsafe {
+            match LLVMGetIntTypeWidth(ty.0) {
+                8 | 32 | 64 => Self::int(ty, v as u64),
+                128 => Self::int128(ty, v),
+                _ => todo!(),
+            }
+        }
+    }
+    pub fn get0(&self) -> LLVMValueRef { self.0 }
 }
 
 pub struct Target(LLVMTargetRef);

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -455,6 +455,48 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         self.llvm_builder.build_store(dst_reg, dst_llval);
     }
 
+    fn emit_precond_for_shift(
+        &self,
+        src1_idx: mast::TempIndex,
+        src1_reg: LLVMValueRef,
+    ) {
+        use move_core_types::vm_status::StatusCode;
+        // Generate the following LLVM IR to check that the shift count is in range.
+        //   ...
+        //   %rangecond = icmp uge {i8/32/64/128} %n_bits, {8/32/64/128}
+        //   br i1 %rangecond, %rangechk_abort, %rangechk_join
+        // then_bb:
+        //   call void @move_rt_abort(i64 AIRTHMETIC_ERROR)
+        //   unreachable
+        // join_bb:
+        //  ...
+        //
+
+        // Generate the range check compare.
+        let builder = &self.llvm_builder;
+        let src1_llty = &self.locals[src1_idx].llty;
+        let src1_width = src1_llty.get_int_type_width();
+        let const_llval = llvm::Constant::generic_int(*src1_llty, src1_width as u128).get0();
+        let rangechk_cond_reg = self.llvm_builder.build_compare(
+            llvm::LLVMIntPredicate::LLVMIntUGE,
+            src1_reg,
+            const_llval,
+            "rangecond",
+        );
+
+        // Generate and insert the two new basic blocks.
+        let curr_bb = builder.get_insert_block();
+        let parent_func = curr_bb.get_basic_block_parent();
+        let then_bb = parent_func.insert_basic_block_after(curr_bb, "then_bb");
+        let join_bb = parent_func.insert_basic_block_after(then_bb, "join_bb");
+
+        // Generate the conditional branch and call to abort.
+        builder.build_cond_br(rangechk_cond_reg, then_bb, join_bb);
+        builder.position_at_end(then_bb);
+        self.emit_rtcall_abort_raw(StatusCode::ARITHMETIC_ERROR as u64);
+        builder.position_at_end(join_bb);
+    }
+
     fn translate_arithm_impl(
         &self,
         dst: &[mast::TempIndex],
@@ -466,6 +508,11 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         assert_eq!(src.len(), 2);
         let src0_reg = self.load_reg(src[0], &format!("{name}_src_0"));
         let src1_reg = self.load_reg(src[1], &format!("{name}_src_1"));
+
+        if op == llvm_sys::LLVMOpcode::LLVMLShr || op == llvm_sys::LLVMOpcode::LLVMShl {
+            self.emit_precond_for_shift(src[1], src1_reg);
+        }
+
         let dst_reg = self
             .llvm_builder
             .build_binop(op, src0_reg, src1_reg, &format!("{name}_dst"));
@@ -819,6 +866,33 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 .add_function_with_attrs(&name, llty, &attrs);
             llfn
         }
+    }
+
+    fn emit_rtcall_abort_raw(&self, val: u64) {
+        // TODO: Refactor get_runtime_function to avoid the below partial duplication.
+        let name = "move_rt_abort";
+        let llfn = self.llvm_module.get_named_function(&name);
+        let thefn = if let Some(llfn) = llfn {
+            llfn
+        } else {
+            let (llty, attrs) = {
+                let ret_ty = self.llvm_cx.void_type();
+                let param_tys = &[self.llvm_cx.int64_type()];
+                let llty = llvm::FunctionType::new(ret_ty, param_tys);
+                let attrs = vec![llvm::AttributeKind::NoReturn];
+                (llty, attrs)
+            };
+
+            let llfn = self
+                .llvm_module
+                .add_function_with_attrs(&name, llty, &attrs);
+            llfn
+        };
+        //
+        let param_ty = self.llvm_cx.int64_type();
+        let const_llval = llvm::Constant::generic_int(param_ty, val as u128);
+        self.llvm_builder.build_call_imm(thefn, &[const_llval]);
+        self.llvm_builder.build_unreachable();
     }
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -58,6 +58,14 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shl_src_0 = load i8, ptr %local_2, align 1
   %shl_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %shl_dst = shl i8 %shl_src_0, %shl_src_1
   store i8 %shl_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
@@ -79,6 +87,14 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shr_src_0 = load i8, ptr %local_2, align 1
   %shr_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shr_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %shr_dst = lshr i8 %shr_src_0, %shr_src_1
   store i8 %shr_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
@@ -105,3 +121,8 @@ entry:
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
@@ -1,0 +1,43 @@
+; ModuleID = '0x100__Test'
+source_filename = "<unknown>"
+
+define i128 @Test__takes_u128(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %retval = load i128, ptr %local_1, align 4
+  ret i128 %retval
+}
+
+define i128 @Test__test_const_u128() {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i128, align 8
+  %local_3 = alloca i128, align 8
+  %local_4 = alloca i128, align 8
+  %local_5 = alloca i128, align 8
+  %local_6 = alloca i128, align 8
+  %local_7 = alloca i128, align 8
+  store i128 7, ptr %local_0, align 4
+  %call_arg_0 = load i128, ptr %local_0, align 4
+  %retval = call i128 @Test__takes_u128(i128 %call_arg_0)
+  store i128 %retval, ptr %local_1, align 4
+  store i128 4294967296, ptr %local_2, align 4
+  %call_arg_01 = load i128, ptr %local_2, align 4
+  %retval2 = call i128 @Test__takes_u128(i128 %call_arg_01)
+  store i128 %retval2, ptr %local_3, align 4
+  store i128 18446744073709551616, ptr %local_4, align 4
+  %call_arg_03 = load i128, ptr %local_4, align 4
+  %retval4 = call i128 @Test__takes_u128(i128 %call_arg_03)
+  store i128 %retval4, ptr %local_5, align 4
+  store i128 -170141183460469231731687303715884105728, ptr %local_6, align 4
+  %call_arg_05 = load i128, ptr %local_6, align 4
+  %retval6 = call i128 @Test__takes_u128(i128 %call_arg_05)
+  store i128 %retval6, ptr %local_7, align 4
+  %retval7 = load i128, ptr %local_7, align 4
+  ret i128 %retval7
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128.move
@@ -1,0 +1,17 @@
+// Check that large constants are created correctly.
+
+module 0x100::Test {
+  fun takes_u128(a: u128): u128 {
+    a
+  }
+  fun test_const_u128(): u128 {
+    let u1: u128 = 7;
+    takes_u128(u1);
+    let u2: u128 = 1 << 32;
+    takes_u128(u2);
+    let u3: u128 = 1 << 64;
+    takes_u128(u3);
+    let u4: u128 = 1 << 127;
+    takes_u128(u4)
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise-rangechk-abort.move
@@ -1,0 +1,22 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_shl(a: u8, b: u8): u8 {
+    let c = a << b;
+    c
+  }
+  public fun test_shr(a: u8, b: u8): u8 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u8 = 1;
+    let b: u8 = 4;
+    assert!(0x101::Test1::test_shl(a, b) == 16, 10);  // Ok: count in range.
+
+    0x101::Test1::test_shr(a, 9);  // Abort: count out of range.
+  }
+}


### PR DESCRIPTION
This implements precondition checking infrastructure, targeting shift operations first. Move requires that certain value preconditions hold dynamically for various arithmetic and bitwise operators. For example, the shift amount on shift operations must be less than the operand bit width. If a precondition fails, the code aborts at runtime.

Currently, we use move_core_types::vm_status::StatusCode::ARITHMETIC_ERROR, which is the same value the Move VM would return for these errors.

This also fixes an unrelated defect in Constant::int128 which was incorrectly constructing APInts from the wrong word order. Instead, we now use LLVMConstIntOfString to avoid byte order issues.

Remastered test results for move-ir-tests/bitwise.move to account for the dynamic checks.

Added a new runtime rbpf test to ensure that the range check indeed fires when the shift count is out of range (and doesn't fire if the value is in range).

Implementing preconditions for the remaining arithmetic operations will come in a follow-up patch.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
