### PR TITLE
Generate/view GraphViz dot files for each control flow graph.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -64,10 +64,14 @@ struct Args {
     #[clap(short = 'O')]
     pub obj: bool,
 
-    /// Output GraphViz dot graph files for each CFG
-    /// (1: gen dot files, 2: invoke xdot viewer on files)"
-    #[clap(long = "gen-dot-cfg", default_value = "0")]
-    pub gen_dot_cfg: u8,
+    /// Write or view GraphViz dot graph files for each CFG.
+    /// ("write": gen dot files, "view": gen dot files and invoke xdot viewer)"
+    #[clap(long = "gen-dot-cfg", default_value = "")]
+    pub gen_dot_cfg: String,
+
+    /// Path to GraphViz output files (defaults to current working directory).
+    #[clap(long = "dot-out-dir", default_value = "")]
+    pub dot_file_path: String,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -168,6 +172,16 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("can't output both LLVM IR (-S) and object file (-O)");
     }
 
+    let dot_info = match (&*args.gen_dot_cfg) {
+        "write" => "w:".to_owned() + &args.dot_file_path,
+        "view" => "v:".to_owned() + &args.dot_file_path,
+        "" => "".to_owned(),
+        _ => {
+            eprintln!("unexpected gen-dot-cfg option '{}', ignored.", &args.gen_dot_cfg);
+            "".to_owned()
+        },
+    };
+
     {
         use move_mv_llvm_compiler::stackless::*;
 
@@ -177,7 +191,7 @@ fn main() -> anyhow::Result<()> {
             .map(|m| m.get_id())
             .expect(".");
         let global_cx = GlobalContext::new(&model_env, Target::Solana);
-        let mod_cx = global_cx.create_module_context(mod_id, args.gen_dot_cfg);
+        let mod_cx = global_cx.create_module_context(mod_id, &dot_info);
         let mut llmod = mod_cx.translate();
         if !args.obj {
             llvm_write_to_file(llmod.as_mut(), args.llvm_ir, &args.output_file_path)?;

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -63,6 +63,11 @@ struct Args {
     /// Output an object file
     #[clap(short = 'O')]
     pub obj: bool,
+
+    /// Output GraphViz dot graph files for each CFG
+    /// (1: gen dot files, 2: invoke xdot viewer on files)"
+    #[clap(long = "gen-dot-cfg", default_value = "0")]
+    pub gen_dot_cfg: u8,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -172,7 +177,7 @@ fn main() -> anyhow::Result<()> {
             .map(|m| m.get_id())
             .expect(".");
         let global_cx = GlobalContext::new(&model_env, Target::Solana);
-        let mod_cx = global_cx.create_module_context(mod_id);
+        let mod_cx = global_cx.create_module_context(mod_id, args.gen_dot_cfg);
         let mut llmod = mod_cx.translate();
         if !args.obj {
             llvm_write_to_file(llmod.as_mut(), args.llvm_ir, &args.output_file_path)?;

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -35,6 +35,7 @@ use llvm_sys::prelude::LLVMValueRef;
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_stackless_bytecode::{
     stackless_bytecode as sbc, stackless_bytecode_generator::StacklessBytecodeGenerator,
+    stackless_control_flow_graph::generate_cfg_in_dot_format,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -91,6 +92,7 @@ impl<'up> GlobalContext<'up> {
     pub fn create_module_context<'this>(
         &'this self,
         id: mm::ModuleId,
+        gen_dot_cfg: u8,
     ) -> ModuleContext<'up, 'this> {
         let env = self.env.get_module(id);
         let name = env.llvm_module_name();
@@ -101,6 +103,7 @@ impl<'up> GlobalContext<'up> {
             llvm_builder: self.llvm_cx.create_builder(),
             fn_decls: BTreeMap::new(),
             _target: self.target,
+            gen_dot_cfg,
         }
     }
 }
@@ -116,6 +119,7 @@ pub struct ModuleContext<'mm, 'up> {
     /// This includes local functions and dependencies.
     fn_decls: BTreeMap<mm::QualifiedId<mm::FunId>, llvm::Function>,
     _target: Target,
+    gen_dot_cfg: u8,
 }
 
 impl<'mm, 'up> ModuleContext<'mm, 'up> {
@@ -127,7 +131,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
 
         for fn_env in self.env.get_functions() {
             let fn_cx = self.create_fn_context(fn_env);
-            fn_cx.translate();
+            fn_cx.translate(self.gen_dot_cfg);
         }
 
         self.llvm_module.verify();
@@ -273,8 +277,27 @@ struct Local {
 }
 
 impl<'mm, 'up> FunctionContext<'mm, 'up> {
-    fn translate(mut self) {
+    fn translate(mut self, gen_dot_cfg: u8) {
         let fn_data = StacklessBytecodeGenerator::new(&self.env).generate_function();
+
+        // Output the control flow graph to a .dot file for viewing.
+        if gen_dot_cfg > 0 {
+            let func_target =
+                move_stackless_bytecode::function_target::FunctionTarget::new(&self.env, &fn_data);
+            let fname = &self.env.llvm_symbol_name();
+            let dot_graph = generate_cfg_in_dot_format(&func_target);
+            let graph_label = format!("digraph {{ label=\"Function: {}\"\n", fname);
+            let dgraph2 = dot_graph.replacen("digraph {", &graph_label, 1);
+            let dot_file = format!("{}_cfg.dot", fname);
+            std::fs::write(&dot_file, &dgraph2).expect("generating dot file for CFG");
+            // If requested by user, also invoke the xdot viewer.
+            if gen_dot_cfg == 2 {
+                std::process::Command::new("xdot")
+                    .arg(dot_file)
+                    .status()
+                    .expect("failed to execute 'xdot'");
+            }
+        }
 
         dbg!(&fn_data);
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -92,7 +92,7 @@ impl<'up> GlobalContext<'up> {
     pub fn create_module_context<'this>(
         &'this self,
         id: mm::ModuleId,
-        gen_dot_cfg: u8,
+        dot_info: &'this String,
     ) -> ModuleContext<'up, 'this> {
         let env = self.env.get_module(id);
         let name = env.llvm_module_name();
@@ -103,7 +103,7 @@ impl<'up> GlobalContext<'up> {
             llvm_builder: self.llvm_cx.create_builder(),
             fn_decls: BTreeMap::new(),
             _target: self.target,
-            gen_dot_cfg,
+            dot_info,
         }
     }
 }
@@ -119,7 +119,7 @@ pub struct ModuleContext<'mm, 'up> {
     /// This includes local functions and dependencies.
     fn_decls: BTreeMap<mm::QualifiedId<mm::FunId>, llvm::Function>,
     _target: Target,
-    gen_dot_cfg: u8,
+    dot_info: &'up String,
 }
 
 impl<'mm, 'up> ModuleContext<'mm, 'up> {
@@ -131,7 +131,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
 
         for fn_env in self.env.get_functions() {
             let fn_cx = self.create_fn_context(fn_env);
-            fn_cx.translate(self.gen_dot_cfg);
+            fn_cx.translate(self.dot_info);
         }
 
         self.llvm_module.verify();
@@ -277,21 +277,23 @@ struct Local {
 }
 
 impl<'mm, 'up> FunctionContext<'mm, 'up> {
-    fn translate(mut self, gen_dot_cfg: u8) {
+    fn translate(mut self, dot_info: &'up String) {
         let fn_data = StacklessBytecodeGenerator::new(&self.env).generate_function();
 
-        // Output the control flow graph to a .dot file for viewing.
-        if gen_dot_cfg > 0 {
+        // Write the control flow graph to a .dot file for viewing.
+        if dot_info != "" {
             let func_target =
                 move_stackless_bytecode::function_target::FunctionTarget::new(&self.env, &fn_data);
             let fname = &self.env.llvm_symbol_name();
             let dot_graph = generate_cfg_in_dot_format(&func_target);
             let graph_label = format!("digraph {{ label=\"Function: {}\"\n", fname);
             let dgraph2 = dot_graph.replacen("digraph {", &graph_label, 1);
-            let dot_file = format!("{}_cfg.dot", fname);
+            let (action, output_path) = dot_info.split_at(2);
+            let path_sep = match output_path { "" => "", _ => "/" };
+            let dot_file = format!("{}{}{}_cfg.dot", output_path, path_sep, fname);
             std::fs::write(&dot_file, &dgraph2).expect("generating dot file for CFG");
             // If requested by user, also invoke the xdot viewer.
-            if gen_dot_cfg == 2 {
+            if action == "v:" {
                 std::process::Command::new("xdot")
                     .arg(dot_file)
                     .status()


### PR DESCRIPTION
By using a new command line option to move-mv-llvm-compiler, the user can generate and view GraphViz dot files for each stackless CFG of each function in a module.

Using "--gen-dot-cfg=write" will only generate a .dot file for each function. Using "--gen-dot-cfg=view" will both generate the files as well as invoke the 'xdot' viewer for each function.