### PR TITLE
Translate the debug_print native function.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "move-coverage",
  "move-ir-types",
  "move-model",
+ "move-native",
  "move-stackless-bytecode",
  "once_cell",
  "parking_lot 0.11.1",
@@ -3463,6 +3464,15 @@ dependencies = [
  "similar",
  "solana_rbpf",
  "thiserror",
+]
+
+[[package]]
+name = "move-native"
+version = "0.1.1"
+dependencies = [
+ "serde 1.0.145",
+ "sha2",
+ "sha3 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,11 @@ default-members = [
     "language/tools/move-unit-test",
 ]
 
+exclude = [
+    # this is a no-std staticlib that does not build for the host platform
+    "language/move-native",
+]
+
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 bcs = "0.1.4"

--- a/language/move-native/Cargo.lock
+++ b/language/move-native/Cargo.lock
@@ -4,12 +4,19 @@ version = 3
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "cfg-if"
@@ -27,23 +34,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
+name = "digest"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -81,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,23 +90,27 @@ checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
+ "block-buffer",
  "cfg-if",
  "cpufeatures",
  "digest",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
+ "block-buffer",
  "digest",
  "keccak",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/language/move-native/Cargo.toml
+++ b/language/move-native/Cargo.toml
@@ -13,12 +13,12 @@ publish = false
 members = ["."]
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [features]
 solana = []
 
 [dependencies]
 serde = { version = "1.0.124", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-sha3 = { version = "0.10.6", default-features = false }
+sha2 = { version = "0.9.3", default-features = false }
+sha3 = { version = "0.9.1", default-features = false }

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -275,6 +275,11 @@
 
 extern crate alloc;
 
+/// Types literally shared with the compiler through crate linkage.
+pub mod shared {
+    pub use crate::rt_types::TypeDesc;
+}
+
 /// Types known to the compiler.
 pub(crate) mod rt_types {
     use crate::target_defs;

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -327,13 +327,21 @@ pub(crate) mod rt_types {
     /// type.
     ///
     /// cc runtime_types::Type
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be to static memory and never mutated.
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct MoveType {
         pub name: StaticTypeName,
         pub type_desc: TypeDesc,
-        pub type_info: TypeInfo,
+        pub type_info: *const TypeInfo,
     }
+
+    // Needed to make the MoveType, which contains raw pointers,
+    // Sync, so that it can be stored in statics for test cases.
+    unsafe impl Sync for MoveType { }
 
     impl core::fmt::Debug for MoveType {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -704,7 +712,7 @@ mod std {
             let byte_type = MoveType {
                 name: DUMMY_TYPE_NAME,
                 type_desc: TypeDesc::U8,
-                type_info: TypeInfo { nothing: 0 },
+                type_info: &TypeInfo { nothing: 0 },
             };
             let mut byte_vector = super::vector::empty(&byte_type);
             {
@@ -783,9 +791,9 @@ mod std {
                     //
                     // This should be the only location in this crate where we
                     // need to fabricate a pointer from an integer.
-                    let size = type_r.type_info.struct_.size;
+                    let size = (*type_r.type_info).struct_.size;
                     let size = usize::try_from(size).expect("overflow");
-                    let alignment = type_r.type_info.struct_.alignment;
+                    let alignment = (*type_r.type_info).struct_.alignment;
                     let alignment = usize::try_from(alignment).expect("overflow");
 
                     assert!(size != 0); // can't handle ZSTs
@@ -968,9 +976,9 @@ mod std {
                     // Note that this function can only be called on empty vecs,
                     // so we don't need to care about dropping elements.
 
-                    let size = type_ve.type_info.struct_.size;
+                    let size = (*type_ve.type_info).struct_.size;
                     let size = usize::try_from(size).expect("overflow");
-                    let alignment = type_ve.type_info.struct_.alignment;
+                    let alignment = (*type_ve.type_info).struct_.alignment;
                     let alignment = usize::try_from(alignment).expect("overflow");
                     let capacity = usize::try_from(v.capacity).expect("overflow");
 
@@ -1403,16 +1411,16 @@ pub(crate) mod conv {
             TypeDesc::Address => BorrowedTypedMoveValue::Address(mem::transmute(value)),
             TypeDesc::Signer => BorrowedTypedMoveValue::Signer(mem::transmute(value)),
             TypeDesc::Vector => {
-                let element_type = *type_.type_info.vector.element_type;
+                let element_type = *(*type_.type_info).vector.element_type;
                 let move_ref = mem::transmute(value);
                 BorrowedTypedMoveValue::Vector(element_type, move_ref)
             }
             TypeDesc::Struct => {
-                let struct_info = type_.type_info.struct_;
+                let struct_info = (*type_.type_info).struct_;
                 BorrowedTypedMoveValue::Struct(struct_info, value)
             }
             TypeDesc::Reference => {
-                let element_type = *type_.type_info.reference.element_type;
+                let element_type = *(*type_.type_info).reference.element_type;
                 let move_ref = mem::transmute(value);
                 BorrowedTypedMoveValue::Reference(element_type, move_ref)
             }
@@ -1472,7 +1480,7 @@ pub(crate) mod conv {
             }
             TypeDesc::Vector => {
                 TypedMoveBorrowedRustVec::Vector(
-                    *type_.type_info.vector.element_type,
+                    *(*type_.type_info).vector.element_type,
                     borrow_move_vec_as_rust_vec::<MoveUntypedVector>(mv),
                 )
             }
@@ -1481,13 +1489,13 @@ pub(crate) mod conv {
                     MoveBorrowedRustVecOfStruct {
                         inner: mv,
                         name: type_.name,
-                        type_: &type_.type_info.struct_,
+                        type_: &(*type_.type_info).struct_,
                     }
                 )
             }
             TypeDesc::Reference => {
                 TypedMoveBorrowedRustVec::Reference(
-                    *type_.type_info.reference.element_type,
+                    *(*type_.type_info).reference.element_type,
                     borrow_move_vec_as_rust_vec::<MoveUntypedReference>(mv),
                 )
             }
@@ -1520,7 +1528,7 @@ pub(crate) mod conv {
             }
             TypeDesc::Vector => {
                 TypedMoveBorrowedRustVecMut::Vector(
-                    *type_.type_info.vector.element_type,
+                    *(*type_.type_info).vector.element_type,
                     borrow_move_vec_as_rust_vec_mut::<MoveUntypedVector>(mv),
                 )
             }
@@ -1529,13 +1537,13 @@ pub(crate) mod conv {
                     MoveBorrowedRustVecOfStructMut {
                         inner: mv,
                         name: type_.name,
-                        type_: &type_.type_info.struct_,
+                        type_: &(*type_.type_info).struct_,
                     }
                 )
             }
             TypeDesc::Reference => {
                 TypedMoveBorrowedRustVecMut::Reference(
-                    *type_.type_info.reference.element_type,
+                    *(*type_.type_info).reference.element_type,
                     borrow_move_vec_as_rust_vec_mut::<MoveUntypedReference>(mv),
                 )
             }
@@ -1661,7 +1669,7 @@ pub(crate) mod conv {
                             let type_ = MoveType {
                                 name: s.name,
                                 type_desc: TypeDesc::Struct,
-                                type_info: TypeInfo { struct_: *s.type_ },
+                                type_info: &TypeInfo { struct_: *s.type_ },
                             };
                             let e = borrow_move_value_as_rust_value(&type_, vref);
                             seq.serialize_element(&e)?;
@@ -1740,7 +1748,7 @@ pub(crate) mod conv {
                             let type_ = MoveType {
                                 name: s.name,
                                 type_desc: TypeDesc::Struct,
-                                type_info: TypeInfo { struct_: *s.type_ },
+                                type_info: &TypeInfo { struct_: *s.type_ },
                             };
                             let e = borrow_move_value_as_rust_value(&type_, vref);
                             dbg.entry(&e);
@@ -1789,7 +1797,9 @@ pub(crate) mod target_defs {
     pub const ACCOUNT_ADDRESS_LENGTH: usize = 32;
 
     pub fn print_string(s: &str) {
-        todo!()
+        unsafe {
+            syscalls::sol_log_(s.as_ptr(), s.len() as u64);
+        }
     }
 
     pub fn print_stack_trace() {
@@ -1809,6 +1819,7 @@ pub(crate) mod target_defs {
     mod syscalls {
         extern "C" {
             pub fn abort() -> !;
+            pub fn sol_log_(msg: *const u8, len: u64);
             pub fn sol_log_64_(_: u64, _: u64, _: u64, _: u64, _: u64);
         }
     }

--- a/language/move-native/src/tests.rs
+++ b/language/move-native/src/tests.rs
@@ -78,7 +78,7 @@ fn test_vec_with_bool() {
     static ELEMENT_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Bool,
-        type_info: TypeInfo { nothing: 0 },
+        type_info: &TypeInfo { nothing: 0 },
     };
 
     let mut move_vec = vector::empty(&ELEMENT_TYPE);
@@ -108,13 +108,13 @@ fn test_vec_with_vector() {
     static INNER_ELEMENT_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Bool,
-        type_info: TypeInfo { nothing: 0 },
+        type_info: &TypeInfo { nothing: 0 },
     };
 
     static VECTORTYPEINFO: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Vector,
-        type_info: TypeInfo {
+        type_info: &TypeInfo {
             vector: VectorTypeInfo {
                 element_type: &INNER_ELEMENT_TYPE,
             },
@@ -124,7 +124,7 @@ fn test_vec_with_vector() {
     static OUTER_ELEMENT_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Vector,
-        type_info: TypeInfo {
+        type_info: &TypeInfo {
             vector: VectorTypeInfo {
                 element_type: &VECTORTYPEINFO,
             },
@@ -203,7 +203,7 @@ fn test_vec_with_signer() {
     static ELEMENT_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Signer,
-        type_info: TypeInfo { nothing: 0 },
+        type_info: &TypeInfo { nothing: 0 },
     };
 
     let mut move_vec = vector::empty(&ELEMENT_TYPE);
@@ -233,7 +233,7 @@ fn test_vec_with_struct() {
     static STRUCT_FIELD_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Bool,
-        type_info: TypeInfo { nothing: 0 },
+        type_info: &TypeInfo { nothing: 0 },
     };
 
     static STRUCT_FIELD_INFO: [StructFieldInfo; 2] = [
@@ -250,7 +250,7 @@ fn test_vec_with_struct() {
     static ELEMENT_TYPE: MoveType = MoveType {
         name: DUMMY_TYPE_NAME,
         type_desc: TypeDesc::Struct,
-        type_info: TypeInfo {
+        type_info: &TypeInfo {
             struct_: StructTypeInfo {
                 field_array_ptr: &STRUCT_FIELD_INFO[0],
                 field_array_len: 2,

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -23,6 +23,7 @@ move-binary-format = { path = "../../move-binary-format" }
 move-coverage = { path = "../move-coverage" }
 move-compiler = { path = "../../move-compiler" }
 move-model = { path = "../../move-model" }
+move-native = { path = "../../move-native" }
 move-stackless-bytecode = { path = "../../move-prover/bytecode" }
 
 clap = { version = "3.1.8", features = ["derive"] }

--- a/language/tools/move-mv-llvm-compiler/docs/Development.md
+++ b/language/tools/move-mv-llvm-compiler/docs/Development.md
@@ -97,6 +97,33 @@ PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test move-ir-tests
 Most new tests should be `move-ir-tests` or `rbpf-tests`,
 as the Move IR is not stable nor easy to work with.
 
+
+## Test directives
+
+Tests support "directives", written as comments at the top of the file,
+that are interpreted by the test runner to determine if the test is successful:
+
+They look like this:
+
+```move
+// abort 10
+
+script {
+  fun main() {
+    assert!(1 == 2, 10);
+  }
+}
+```
+
+Supported directives include:
+
+- `// ignore` - don't run the test, for broken tests.
+- `// abort {code}` - expect an abort with code.
+- `// log {string}` - expect a string to be logged by the `debug::print` function.
+
+`abort` and `log` are only supported by the `rbpf-tests` runner.
+
+
 ## Debugging
 
 ### Setting up llvm, llvm-sys for debugging

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -27,6 +27,13 @@ pub impl<'a> FunctionEnvExt for mm::FunctionEnv<'a> {
             name
         }
     }
+
+    /// Native functions follow their own naming convention
+    fn llvm_native_fn_symbol_name(&self) -> String {
+        let name = self.get_full_name_str();
+        let name = name.replace("::", "_");
+        format!("move_native_{name}")
+    }
 }
 
 #[extension_trait]

--- a/language/tools/move-mv-llvm-compiler/src/stackless/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/mod.rs
@@ -4,6 +4,7 @@
 
 mod extensions;
 mod llvm;
+mod rttydesc;
 mod translate;
 
 pub use translate::*;

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -6,6 +6,7 @@
 
 use crate::stackless::llvm;
 use move_model::{ast as mast, model as mm, ty as mty};
+use move_native::shared::TypeDesc;
 
 static TD_NAME: &'static str = "__move_rt_type";
 static TD_TYPE_NAME_NAME: &'static str = "__move_rt_type_name";
@@ -127,7 +128,7 @@ fn type_name(mty: &mty::Type) -> String {
 fn type_descrim(mty: &mty::Type) -> u64 {
     use mty::{PrimitiveType, Type};
     match mty {
-        Type::Primitive(PrimitiveType::U64) => 3,
+        Type::Primitive(PrimitiveType::U64) => TypeDesc::U64 as u64,
         _ => todo!(),
     }
 }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -1,0 +1,209 @@
+//! The type descriptor accepted by runtime functions.
+//!
+//! Corresponds to `move_native::rt_types::MoveType`.
+
+#![allow(unused)]
+
+use crate::stackless::llvm;
+use move_model::{ast as mast, model as mm, ty as mty};
+
+static TD_NAME: &'static str = "__move_rt_type";
+static TD_TYPE_NAME_NAME: &'static str = "__move_rt_type_name";
+static TD_TYPE_INFO_NAME: &'static str = "__move_rt_type_info";
+static TD_VECTOR_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_vec";
+static TD_STRUCT_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_struct";
+static TD_REFERENCE_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_ref";
+
+pub fn get_llvm_tydesc_type(llcx: &llvm::Context) -> llvm::StructType {
+    match llcx.named_struct_type(TD_NAME) {
+        Some(t) => t,
+        None => {
+            declare_llvm_tydesc_type(llcx);
+            llcx.named_struct_type(TD_NAME).expect(".")
+        }
+    }
+}
+
+fn declare_llvm_tydesc_type(llcx: &llvm::Context) {
+    let td_llty = llcx.create_opaque_named_struct(TD_NAME);
+    let field_tys = {
+        let type_name_ty = llcx
+            .anonymous_struct_type(&[llcx.int8_type().ptr_type(), llcx.int64_type()])
+            .as_any_type();
+        let type_descrim_ty = llcx.int32_type();
+        // This is a pointer to a statically-defined union of type infos
+        let type_info_ptr_ty = llcx.int8_type().ptr_type();
+        &[type_name_ty, type_descrim_ty, type_info_ptr_ty]
+    };
+
+    td_llty.set_struct_body(field_tys);
+}
+
+pub fn define_llvm_tydesc(
+    llcx: &llvm::Context,
+    llmod: &llvm::Module,
+    mty: &mty::Type,
+) -> llvm::Global {
+    let name = global_tydesc_name(mty);
+    match llmod.get_global(&name) {
+        Some(g) => g,
+        None => {
+            let ll_tydesc_ty = get_llvm_tydesc_type(llcx);
+            let ll_tydesc_ty = ll_tydesc_ty.as_any_type();
+            let ll_global = llmod.add_global(ll_tydesc_ty, &name);
+            ll_global.set_constant();
+            let ll_constant = tydesc_constant(llcx, llmod, mty);
+            let ll_constant_ty = ll_constant.llvm_type();
+            ll_global.set_initializer(ll_constant);
+            ll_global
+        }
+    }
+}
+
+fn tydesc_constant(llcx: &llvm::Context, llmod: &llvm::Module, mty: &mty::Type) -> llvm::Constant {
+    let ll_const_type_name = type_name_constant(llcx, llmod, mty);
+    let ll_const_type_descrim = {
+        let ll_ty = llcx.int32_type();
+        llvm::Constant::int(ll_ty, type_descrim(mty))
+    };
+    let ll_const_type_info_ptr = {
+        let ll_global_type_info = define_type_info_global(llcx, llmod, mty);
+        ll_global_type_info.ptr()
+    };
+    let ll_const = llcx.const_named_struct(
+        &[
+            ll_const_type_name,
+            ll_const_type_descrim,
+            ll_const_type_info_ptr,
+        ],
+        TD_NAME,
+    );
+    ll_const
+}
+
+fn type_name_constant(
+    llcx: &llvm::Context,
+    llmod: &llvm::Module,
+    mty: &mty::Type,
+) -> llvm::Constant {
+    let name = type_name(mty);
+    let len = name.len();
+
+    // Create a static string and take a constant pointer to it.
+    let ll_static_bytes_ptr = {
+        let global_name = global_tydesc_name_name(mty);
+        match llmod.get_global(&global_name) {
+            Some(g) => g.ptr(),
+            None => {
+                let ll_const_string = llcx.const_string(&name);
+                let ll_array_ty = ll_const_string.llvm_type();
+                let ll_global = llmod.add_global(ll_array_ty, &global_name);
+                ll_global.set_constant();
+                ll_global.set_initializer(ll_const_string.as_const());
+                ll_global.ptr()
+            }
+        }
+    };
+
+    let ll_ty_u64 = llcx.int64_type();
+    let ll_const_len = llvm::Constant::int(ll_ty_u64, len as u64);
+
+    let ll_const_struct = llcx.const_struct(&[ll_static_bytes_ptr, ll_const_len]);
+
+    ll_const_struct
+}
+
+fn type_name(mty: &mty::Type) -> String {
+    use mty::{PrimitiveType, Type};
+    let name = match mty {
+        Type::Primitive(PrimitiveType::U64) => "u64",
+        _ => todo!(),
+    };
+
+    format!("{name}")
+}
+
+/// The values here correspond to `move_native::rt_types::TypeDesc`.
+fn type_descrim(mty: &mty::Type) -> u64 {
+    use mty::{PrimitiveType, Type};
+    match mty {
+        Type::Primitive(PrimitiveType::U64) => 3,
+        _ => todo!(),
+    }
+}
+
+/// The "type info" for a Move type.
+///
+/// This is the type-specific metadata interpreted by the runtime.
+/// It is a union.
+/// It corresponds to `move_native:rt_types::TypeInfo`.
+fn define_type_info_global(
+    llcx: &llvm::Context,
+    llmod: &llvm::Module,
+    mty: &mty::Type,
+) -> llvm::Global {
+    let symbol_name = global_tydesc_info_name(mty);
+
+    match llmod.get_global(&symbol_name) {
+        Some(g) => g,
+        None => {
+            use mty::{PrimitiveType, Type};
+            match mty {
+                Type::Primitive(PrimitiveType::U64) => {
+                    define_type_info_global_nil(llcx, llmod, &symbol_name)
+                }
+                _ => todo!(),
+            }
+        }
+    }
+}
+
+/// A special type info for all types that don't need type info.
+fn define_type_info_global_nil(
+    llcx: &llvm::Context,
+    llmod: &llvm::Module,
+    symbol_name: &str,
+) -> llvm::Global {
+    let ll_ty = llcx.int8_type();
+    let ll_global = llmod.add_global(ll_ty, symbol_name);
+    ll_global.set_constant();
+    // just an eye-catching marker value
+    let value = 255;
+    let ll_const = llvm::Constant::int(ll_ty, value);
+    ll_global.set_initializer(ll_const);
+    ll_global
+}
+
+fn global_tydesc_name(mty: &mty::Type) -> String {
+    use mty::{PrimitiveType, Type};
+    let name = match mty {
+        Type::Primitive(PrimitiveType::U64) => "u64",
+        _ => todo!(),
+    };
+
+    format!("__move_rttydesc_{name}")
+}
+
+// fixme this function name is not amazing!
+fn global_tydesc_name_name(mty: &mty::Type) -> String {
+    use mty::{PrimitiveType, Type};
+    let name = match mty {
+        Type::Primitive(PrimitiveType::U64) => "u64",
+        _ => todo!(),
+    };
+
+    format!("__move_rttydesc_{name}_name")
+}
+
+fn global_tydesc_info_name(mty: &mty::Type) -> String {
+    use mty::{PrimitiveType, Type};
+    let name = match mty {
+        Type::Primitive(PrimitiveType::U64) => {
+            // A special name for types that don't need type info.
+            "NOTHING"
+        }
+        _ => todo!(),
+    };
+
+    format!("__move_rttydesc_{name}_info")
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
@@ -1,0 +1,4 @@
+; ModuleID = '0x10__debug'
+source_filename = "<unknown>"
+
+declare void @move_native_debug_print(ptr, ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
@@ -1,0 +1,24 @@
+; ModuleID = '<SELF>'
+source_filename = "<unknown>"
+
+%__move_rt_type = type { { ptr, i64 }, i32, ptr }
+
+@__move_rttydesc_u64 = constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i32 3, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u64_name = constant [3 x i8] c"u64"
+@__move_rttydesc_NOTHING_info = constant i8 -1
+
+define void @main() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 10, ptr %local_1, align 4
+  %load_store_tmp = load i64, ptr %local_1, align 4
+  store i64 %load_store_tmp, ptr %local_0, align 4
+  store ptr %local_0, ptr %local_2, align 8
+  %loaded_alloca = load ptr, ptr %local_2, align 8
+  call void @move_native_debug_print(ptr @__move_rttydesc_u64, ptr %loaded_alloca)
+  ret void
+}
+
+declare void @move_native_debug_print(ptr, ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print.move
@@ -1,0 +1,11 @@
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+script {
+  use 0x10::debug;
+
+  fun main() {
+    debug::print(&10);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/debug-print.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/debug-print.move
@@ -1,0 +1,13 @@
+// log 10
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+script {
+  use 0x10::debug;
+
+  fun main() {
+    debug::print(&10);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -60,6 +60,7 @@ pub struct TestPlan {
 pub enum TestDirective {
     Ignore,
     Abort(u64),
+    Log(String),
 }
 
 impl TestPlan {
@@ -73,6 +74,17 @@ impl TestPlan {
             TestDirective::Abort(code) => Some(*code),
             _ => None,
         })
+    }
+
+    #[allow(unused)]
+    pub fn expected_logs(&self) -> Vec<String> {
+        self.directives
+            .iter()
+            .filter_map(|d| match d {
+                TestDirective::Log(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
     }
 }
 
@@ -112,6 +124,10 @@ fn load_directives(test_path: &Path) -> anyhow::Result<Vec<TestDirective>> {
             let code = line.split(" ").skip(1).next().expect("abort code");
             let code = code.parse().expect("u64");
             directives.push(TestDirective::Abort(code));
+        }
+        if line.starts_with("log ") {
+            let s = line.split(" ").skip(1).next().expect("log value");
+            directives.push(TestDirective::Log(s.to_string()));
         }
     }
 


### PR DESCRIPTION
This adds the most basic translation of generic native functions.

It does a bunch of things:

It adds an `rttydesc` module for translating runtime type descriptors as needed by move-native. At the moment it can generate type descriptors for `u64`. They look like this in LLVM IR:

```llvm
%__move_rt_type = type { { ptr, i64 }, i32, ptr }

@__move_rttydesc_u64 = constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i32 3, ptr @__move_rttydesc_NOTHING_info }
@__move_rttydesc_u64_name = constant [3 x i8] c"u64"
@__move_rttydesc_NOTHING_info = constant i8 -1
```

The runtime can accept these type descriptors as `&MoveType`, as in the `debug_print` function:

```rust
        #[export_name = "move_native_debug_print"]
        unsafe extern "C" fn print(type_x: &MoveType, x: &AnyValue) {
            let v = borrow_move_value_as_rust_value(type_x, x);
            target_defs::print_string(&format!("{:?}", v));
        }
```

This patch additionally adds code to the `translate` module to translate declarations of native functions and calls to native functions, and supporting methods in the `llvm` module.

The code in these two modules needs some cleanup in the future. Here I e.g. added a new `Builder::call` method that doesn't load allocas itself like the `Builder::load_call` method; and I introduced an `llvm::AnyValue` type that can be cast from the more specific value types like `Alloca`. It's a bit of a mess, but I don't want to sort it out yet.

I additionally modified the rbpf-test harness to support the `sol_log_` syscall, and the `// log {foo}` test directive. The one new test case here uses it to verify that `debug_print` works. I also added the ability to dump the VM memory mapping and the recorded syscall events. The test harness does this when a test fails, and also when the `DUMP` environment variable is set.