### PR TITLE
Fix assert in shift IR generation for mismatched source types.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -43,7 +43,97 @@ entry:
   ret i8 %retval
 }
 
-define i8 @Test__test_shl(i8 %0, i8 %1) {
+define i128 @Test__test_shl128(i128 %0, i8 %1) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i128, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i128, align 8
+  store i128 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shl_src_0 = load i128, ptr %local_2, align 4
+  %shl_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shl_src_1 to i128
+  %shl_dst = shl i128 %shl_src_0, %zext_dst
+  store i128 %shl_dst, ptr %local_4, align 4
+  %retval = load i128, ptr %local_4, align 4
+  ret i128 %retval
+}
+
+define i32 @Test__test_shl32(i32 %0, i8 %1) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i32, align 4
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i32, align 4
+  store i32 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shl_src_0 = load i32, ptr %local_2, align 4
+  %shl_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shl_src_1 to i32
+  %shl_dst = shl i32 %shl_src_0, %zext_dst
+  store i32 %shl_dst, ptr %local_4, align 4
+  %retval = load i32, ptr %local_4, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__test_shl64(i64 %0, i8 %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shl_src_0 = load i64, ptr %local_2, align 4
+  %shl_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shl_src_1 to i64
+  %shl_dst = shl i64 %shl_src_0, %zext_dst
+  store i64 %shl_dst, ptr %local_4, align 4
+  %retval = load i64, ptr %local_4, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__test_shl8(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -72,7 +162,97 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_shr(i8 %0, i8 %1) {
+define i128 @Test__test_shr128(i128 %0, i8 %1) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i128, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i128, align 8
+  store i128 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shr_src_0 = load i128, ptr %local_2, align 4
+  %shr_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shr_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shr_src_1 to i128
+  %shr_dst = lshr i128 %shr_src_0, %zext_dst
+  store i128 %shr_dst, ptr %local_4, align 4
+  %retval = load i128, ptr %local_4, align 4
+  ret i128 %retval
+}
+
+define i32 @Test__test_shr32(i32 %0, i8 %1) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i32, align 4
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i32, align 4
+  store i32 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shr_src_0 = load i32, ptr %local_2, align 4
+  %shr_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shr_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shr_src_1 to i32
+  %shr_dst = lshr i32 %shr_src_0, %zext_dst
+  store i32 %shr_dst, ptr %local_4, align 4
+  %retval = load i32, ptr %local_4, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__test_shr64(i64 %0, i8 %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 4
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %shr_src_0 = load i64, ptr %local_2, align 4
+  %shr_src_1 = load i8, ptr %local_3, align 1
+  %rangecond = icmp uge i8 %shr_src_1, 8
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %zext_dst = zext i8 %shr_src_1 to i64
+  %shr_dst = lshr i64 %shr_src_0, %zext_dst
+  store i64 %shr_dst, ptr %local_4, align 4
+  %retval = load i64, ptr %local_4, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__test_shr8(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise.move
@@ -11,11 +11,35 @@ module 0x100::Test {
     let c = a ^ b;
     c
   }
-  fun test_shl(a: u8, b: u8): u8 {
+  fun test_shl8(a: u8, b: u8): u8 {
     let c = a << b;
     c
   }
-  fun test_shr(a: u8, b: u8): u8 {
+  fun test_shr8(a: u8, b: u8): u8 {
+    let c = a >> b;
+    c
+  }
+  fun test_shl32(a: u32, b: u8): u32 {
+    let c = a << b;
+    c
+  }
+  fun test_shr32(a: u32, b: u8): u32 {
+    let c = a >> b;
+    c
+  }
+  fun test_shl64(a: u64, b: u8): u64 {
+    let c = a << b;
+    c
+  }
+  fun test_shr64(a: u64, b: u8): u64 {
+    let c = a >> b;
+    c
+  }
+  fun test_shl128(a: u128, b: u8): u128 {
+    let c = a << b;
+    c
+  }
+  fun test_shr128(a: u128, b: u8): u128 {
     let c = a >> b;
     c
   }


### PR DESCRIPTION
Since LLVM IR requires binary operators to have the same type, and the Move language (and stackless IR) requires that shift operators only take u8 for the shift count, then zero extend src1 to  meet LLVM IR requirements.

Updated bitwise unit test with shifts of 32, 64, and 128 bits to catch regressions.