### PR TITLE
Implement more dynamic pre- and post-condition checking (add, sub, div).

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -17,6 +17,14 @@ entry:
   %sub_src_0 = load i8, ptr %local_2, align 1
   %sub_src_1 = load i8, ptr %local_3, align 1
   %sub_dst = sub i8 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i8 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i8 %sub_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -17,6 +17,14 @@ entry:
   %add_src_0 = load i128, ptr %local_2, align 4
   %add_src_1 = load i128, ptr %local_3, align 4
   %add_dst = add i128 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i128 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i128 %add_dst, ptr %local_4, align 4
   %retval = load i128, ptr %local_4, align 4
   ret i128 %retval
@@ -37,6 +45,14 @@ entry:
   store i128 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i128, ptr %local_2, align 4
   %div_src_1 = load i128, ptr %local_3, align 4
+  %zerocond = icmp eq i128 %div_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %div_dst = udiv i128 %div_src_0, %div_src_1
   store i128 %div_dst, ptr %local_4, align 4
   %retval = load i128, ptr %local_4, align 4
@@ -101,7 +117,20 @@ entry:
   %sub_src_0 = load i128, ptr %local_2, align 4
   %sub_src_1 = load i128, ptr %local_3, align 4
   %sub_dst = sub i128 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i128 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i128 %sub_dst, ptr %local_4, align 4
   %retval = load i128, ptr %local_4, align 4
   ret i128 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -17,6 +17,14 @@ entry:
   %add_src_0 = load i32, ptr %local_2, align 4
   %add_src_1 = load i32, ptr %local_3, align 4
   %add_dst = add i32 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i32 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i32 %add_dst, ptr %local_4, align 4
   %retval = load i32, ptr %local_4, align 4
   ret i32 %retval
@@ -37,6 +45,14 @@ entry:
   store i32 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i32, ptr %local_2, align 4
   %div_src_1 = load i32, ptr %local_3, align 4
+  %zerocond = icmp eq i32 %div_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %div_dst = udiv i32 %div_src_0, %div_src_1
   store i32 %div_dst, ptr %local_4, align 4
   %retval = load i32, ptr %local_4, align 4
@@ -80,7 +96,20 @@ entry:
   %sub_src_0 = load i32, ptr %local_2, align 4
   %sub_src_1 = load i32, ptr %local_3, align 4
   %sub_dst = sub i32 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i32 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i32 %sub_dst, ptr %local_4, align 4
   %retval = load i32, ptr %local_4, align 4
   ret i32 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -17,6 +17,14 @@ entry:
   %add_src_0 = load i64, ptr %local_2, align 4
   %add_src_1 = load i64, ptr %local_3, align 4
   %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i64 %add_dst, ptr %local_4, align 4
   %retval = load i64, ptr %local_4, align 4
   ret i64 %retval
@@ -37,6 +45,14 @@ entry:
   store i64 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i64, ptr %local_2, align 4
   %div_src_1 = load i64, ptr %local_3, align 4
+  %zerocond = icmp eq i64 %div_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %div_dst = udiv i64 %div_src_0, %div_src_1
   store i64 %div_dst, ptr %local_4, align 4
   %retval = load i64, ptr %local_4, align 4
@@ -80,7 +96,20 @@ entry:
   %sub_src_0 = load i64, ptr %local_2, align 4
   %sub_src_1 = load i64, ptr %local_3, align 4
   %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i64 %sub_dst, ptr %local_4, align 4
   %retval = load i64, ptr %local_4, align 4
   ret i64 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -17,6 +17,14 @@ entry:
   %add_src_0 = load i8, ptr %local_2, align 1
   %add_src_1 = load i8, ptr %local_3, align 1
   %add_dst = add i8 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i8 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i8 %add_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval
@@ -37,6 +45,14 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %div_src_0 = load i8, ptr %local_2, align 1
   %div_src_1 = load i8, ptr %local_3, align 1
+  %zerocond = icmp eq i8 %div_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %div_dst = udiv i8 %div_src_0, %div_src_1
   store i8 %div_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
@@ -101,7 +117,20 @@ entry:
   %sub_src_0 = load i8, ptr %local_2, align 1
   %sub_src_1 = load i8, ptr %local_3, align 1
   %sub_dst = sub i8 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i8 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i8 %sub_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -17,7 +17,20 @@ entry:
   %add_src_0 = load i8, ptr %local_2, align 1
   %add_src_1 = load i8, ptr %local_3, align 1
   %add_dst = add i8 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i8 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   store i8 %add_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu128-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu128-dyn-checks.move
@@ -1,0 +1,17 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_addu128(a: u128, b: u128): u128 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u128 = 340282366920938463463374607431768211454; // UMAX-2
+    assert!(0x101::Test1::test_addu128(a, 1) == 340282366920938463463374607431768211455, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_addu128(a, 3);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu32-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu32-dyn-checks.move
@@ -1,0 +1,17 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_addu32(a: u32, b: u32): u32 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u32 = 4294967294;  // UMAX-2.
+    assert!(0x101::Test1::test_addu32(a, 1) == 4294967295, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_addu32(a, 3);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu64-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu64-dyn-checks.move
@@ -1,0 +1,17 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_addu64(a: u64, b: u64): u64 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u64 = 18446744073709551614; // UMAX-2
+    assert!(0x101::Test1::test_addu64(a, 1) == 18446744073709551615, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_addu64(a, 3);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu8-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/addu8-dyn-checks.move
@@ -1,0 +1,17 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_addu8(a: u8, b: u8): u8 {
+    let c = a + b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u8 = 253;
+    assert!(0x101::Test1::test_addu8(a, 1) == 254, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_addu8(a, 3);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/divu32-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/divu32-dyn-checks.move
@@ -1,0 +1,17 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_divu32(a: u32, b: u32): u32 {
+    let c = a / b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u32 = 32;
+    assert!(0x101::Test1::test_divu32(a, 8) == 4, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_divu32(a, 0);  // Abort: division by zero.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu128-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu128-dyn-checks.move
@@ -1,0 +1,16 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_subu128(a: u128, b: u128): u128 {
+    let c = a - b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_subu128(1, 1) == 0, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_subu128(0, 1);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu32-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu32-dyn-checks.move
@@ -1,0 +1,16 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_subu32(a: u32, b: u32): u32 {
+    let c = a - b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_subu32(1, 1) == 0, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_subu32(0, 1);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu64-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu64-dyn-checks.move
@@ -1,0 +1,16 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_subu64(a: u64, b: u64): u64 {
+    let c = a - b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_subu64(1, 1) == 0, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_subu64(0, 1);  // Abort: overflow.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu8-dyn-checks.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/subu8-dyn-checks.move
@@ -1,0 +1,16 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_subu8(a: u8, b: u8): u8 {
+    let c = a - b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_subu8(1, 1) == 0, 10);  // Ok: no overflow.
+
+    0x101::Test1::test_subu8(0, 1);  // Abort: overflow.
+  }
+}


### PR DESCRIPTION
This covers overflow checking for addition and subtraction, as well as division by zero checking.  Remastered affected IR tests.

Added new runtime rbpf unit tests to cover above: {add*, sub*, divu32}-dyn-checks.move.