### PR TITLE
Generate unsigned div and rem for Move (not signed).

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -632,10 +632,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 self.translate_arithm_impl(dst, src, "mul", llvm_sys::LLVMOpcode::LLVMMul, |_,_,_| ());
             }
             Operation::Div => {
-                self.translate_arithm_impl(dst, src, "div", llvm_sys::LLVMOpcode::LLVMSDiv, |_,_,_| ());
+                self.translate_arithm_impl(dst, src, "div", llvm_sys::LLVMOpcode::LLVMUDiv, |_,_,_| ());
             }
             Operation::Mod => {
-                self.translate_arithm_impl(dst, src, "mod", llvm_sys::LLVMOpcode::LLVMSRem, |_,_,_| ());
+                self.translate_arithm_impl(dst, src, "mod", llvm_sys::LLVMOpcode::LLVMURem, |_,_,_| ());
             }
             Operation::BitOr => {
                 self.translate_arithm_impl(dst, src, "or", llvm_sys::LLVMOpcode::LLVMOr, |_,_,_| ());

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -37,7 +37,7 @@ entry:
   store i128 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i128, ptr %local_2, align 4
   %div_src_1 = load i128, ptr %local_3, align 4
-  %div_dst = sdiv i128 %div_src_0, %div_src_1
+  %div_dst = udiv i128 %div_src_0, %div_src_1
   store i128 %div_dst, ptr %local_4, align 4
   %retval = load i128, ptr %local_4, align 4
   ret i128 %retval
@@ -58,7 +58,7 @@ entry:
   store i128 %load_store_tmp1, ptr %local_3, align 4
   %mod_src_0 = load i128, ptr %local_2, align 4
   %mod_src_1 = load i128, ptr %local_3, align 4
-  %mod_dst = srem i128 %mod_src_0, %mod_src_1
+  %mod_dst = urem i128 %mod_src_0, %mod_src_1
   store i128 %mod_dst, ptr %local_4, align 4
   %retval = load i128, ptr %local_4, align 4
   ret i128 %retval

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -37,7 +37,7 @@ entry:
   store i32 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i32, ptr %local_2, align 4
   %div_src_1 = load i32, ptr %local_3, align 4
-  %div_dst = sdiv i32 %div_src_0, %div_src_1
+  %div_dst = udiv i32 %div_src_0, %div_src_1
   store i32 %div_dst, ptr %local_4, align 4
   %retval = load i32, ptr %local_4, align 4
   ret i32 %retval

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -37,7 +37,7 @@ entry:
   store i64 %load_store_tmp1, ptr %local_3, align 4
   %div_src_0 = load i64, ptr %local_2, align 4
   %div_src_1 = load i64, ptr %local_3, align 4
-  %div_dst = sdiv i64 %div_src_0, %div_src_1
+  %div_dst = udiv i64 %div_src_0, %div_src_1
   store i64 %div_dst, ptr %local_4, align 4
   %retval = load i64, ptr %local_4, align 4
   ret i64 %retval

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -37,7 +37,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %div_src_0 = load i8, ptr %local_2, align 1
   %div_src_1 = load i8, ptr %local_3, align 1
-  %div_dst = sdiv i8 %div_src_0, %div_src_1
+  %div_dst = udiv i8 %div_src_0, %div_src_1
   store i8 %div_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval
@@ -58,7 +58,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %mod_src_0 = load i8, ptr %local_2, align 1
   %mod_src_1 = load i8, ptr %local_3, align 1
-  %mod_dst = srem i8 %mod_src_0, %mod_src_1
+  %mod_dst = urem i8 %mod_src_0, %mod_src_1
   store i8 %mod_dst, ptr %local_4, align 1
   %retval = load i8, ptr %local_4, align 1
   ret i8 %retval


### PR DESCRIPTION
To match the Move VM's interpreter, we generate udiv/urem rather than sdiv/srem. The interpreter invokes  IntegerValue::div_checked and IntegerValue::rem_checked on its' primitive unsigned types. These routines then respectively invoke Rust's u<n>::checked_div and u32::checked_rem which are unsigned operations.

Remastered test results accordingly.