### PR TITLE
Fix defect in cast support. Also add support for all casts.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -71,6 +71,10 @@ impl Context {
         unsafe { Type(LLVMInt8TypeInContext(self.0)) }
     }
 
+    pub fn int16_type(&self) -> Type {
+        unsafe { Type(LLVMInt16TypeInContext(self.0)) }
+    }
+
     pub fn int32_type(&self) -> Type {
         unsafe { Type(LLVMInt32TypeInContext(self.0)) }
     }
@@ -80,6 +84,9 @@ impl Context {
     }
     pub fn int128_type(&self) -> Type {
         unsafe { Type(LLVMInt128TypeInContext(self.0)) }
+    }
+    pub fn int256_type(&self) -> Type {
+        unsafe { Type(LLVMIntTypeInContext(self.0, 256)) }
     }
 }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -203,9 +203,11 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         match mty {
             Type::Primitive(PrimitiveType::Bool) => self.llvm_cx.int1_type(),
             Type::Primitive(PrimitiveType::U8) => self.llvm_cx.int8_type(),
+            Type::Primitive(PrimitiveType::U16) => self.llvm_cx.int16_type(),
             Type::Primitive(PrimitiveType::U32) => self.llvm_cx.int32_type(),
             Type::Primitive(PrimitiveType::U64) => self.llvm_cx.int64_type(),
             Type::Primitive(PrimitiveType::U128) => self.llvm_cx.int128_type(),
+            Type::Primitive(PrimitiveType::U256) => self.llvm_cx.int256_type(),
             Type::Reference(_, referent_mty) => {
                 let referent_llty = self.llvm_type(referent_mty);
                 let llty = referent_llty.ptr_type();
@@ -223,6 +225,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         match mty {
             Type::Primitive(PrimitiveType::Bool) => 1,
             Type::Primitive(PrimitiveType::U8) => 8,
+            Type::Primitive(PrimitiveType::U16) => 16,
             Type::Primitive(PrimitiveType::U32) => 32,
             Type::Primitive(PrimitiveType::U64) => 64,
             Type::Primitive(PrimitiveType::U128) => 128,
@@ -387,9 +390,11 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     mty::Type::Primitive(
                         mty::PrimitiveType::Bool
                         | mty::PrimitiveType::U8
+                        | mty::PrimitiveType::U16
                         | mty::PrimitiveType::U32
                         | mty::PrimitiveType::U64
-                        | mty::PrimitiveType::U128,
+                        | mty::PrimitiveType::U128
+                        | mty::PrimitiveType::U256,
                     ) => {
                         self.llvm_builder.load_store(llty, src_llval, dst_llval);
                     }
@@ -672,6 +677,48 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         self.store_reg(dst[0], dst_reg);
     }
 
+    fn emit_precond_for_cast(
+        &self,
+        _args: &[Option<(mast::TempIndex, LLVMValueRef)>], // src0, src1, dst.
+    ) {
+        // TODO. Add casting checks from https://move-language.github.io/move/integers.html#casting.
+    }
+
+    fn translate_cast_impl(
+        &self,
+        dst: &[mast::TempIndex],
+        src: &[mast::TempIndex],
+        dyncheck_emitter_fn: CheckEmitterFn<'mm, 'up>,
+    ) {
+        assert_eq!(dst.len(), 1);
+        assert_eq!(src.len(), 1);
+        let src_idx = src[0];
+        let src_mty = &self.locals[src_idx].mty;
+        let dst_idx = dst[0];
+        let dst_mty = &self.locals[dst_idx].mty;
+        assert!(src_mty.is_number());
+        assert!(dst_mty.is_number());
+        let src_width = self.get_bitwidth(src_mty);
+        let dst_width = self.get_bitwidth(dst_mty);
+        let src_reg = self.load_reg(src_idx, "cast_src");
+
+        // Emit dynamic pre-condition check.
+        assert!(dyncheck_emitter_fn.1 == EmitterFnKind::PreCheck);
+        let args = [Some((src_idx, src_reg)), None, None];
+        dyncheck_emitter_fn.0(self, &args);
+
+        let dst_reg = if src_width < dst_width {
+            // Widen
+            self.llvm_builder
+                .build_zext(src_reg, self.llvm_type(dst_mty).0, "zext_dst")
+        } else {
+            // Truncate
+            self.llvm_builder
+                .build_trunc(src_reg, self.llvm_type(dst_mty).0, "trunc_dst")
+        };
+        self.store_reg(dst[0], dst_reg);
+    }
+
     fn translate_call(
         &self,
         dst: &[mast::TempIndex],
@@ -859,62 +906,17 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 );
                 self.store_reg(dst[0], dst_reg);
             }
-            Operation::CastU32 => {
-                assert_eq!(dst.len(), 1);
-                assert_eq!(src.len(), 1);
-                let src_idx = src[0];
-                let src_mty = &self.locals[src_idx].mty;
-                assert!(src_mty.is_number());
-                let src_width = self.get_bitwidth(src_mty);
-                let src_reg = self.load_reg(src_idx, "cast_src");
-                let dst_reg = if src_width < 32 {
-                    // Widen
-                    self.llvm_builder
-                        .build_zext(src_reg, self.llvm_type(src_mty).0, "zext_dst")
-                } else {
-                    // Truncate
-                    self.llvm_builder
-                        .build_trunc(src_reg, self.llvm_type(src_mty).0, "trunc_dst")
-                };
-                self.store_reg(dst[0], dst_reg);
-            }
-            Operation::CastU8 => {
-                assert_eq!(dst.len(), 1);
-                assert_eq!(src.len(), 1);
-                let src_idx = src[0];
-                let src_mty = &self.locals[src_idx].mty;
-                assert!(src_mty.is_number());
-                let src_width = self.get_bitwidth(src_mty);
-                let src_reg = self.load_reg(src_idx, "cast_src");
-                let dst_reg = if src_width < 8 {
-                    // Widen
-                    self.llvm_builder
-                        .build_zext(src_reg, self.llvm_type(src_mty).0, "zext_dst")
-                } else {
-                    // Truncate
-                    self.llvm_builder
-                        .build_trunc(src_reg, self.llvm_type(src_mty).0, "trunc_dst")
-                };
-                self.store_reg(dst[0], dst_reg);
-            }
-            Operation::CastU64 => {
-                assert_eq!(dst.len(), 1);
-                assert_eq!(src.len(), 1);
-                let src_idx = src[0];
-                let src_mty = &self.locals[src_idx].mty;
-                assert!(src_mty.is_number());
-                let src_width = self.get_bitwidth(src_mty);
-                let src_reg = self.load_reg(src_idx, "cast_src");
-                let dst_reg = if src_width < 64 {
-                    // Widen
-                    self.llvm_builder
-                        .build_zext(src_reg, self.llvm_type(src_mty).0, "zext_dst")
-                } else {
-                    // Truncate
-                    self.llvm_builder
-                        .build_trunc(src_reg, self.llvm_type(src_mty).0, "trunc_dst")
-                };
-                self.store_reg(dst[0], dst_reg);
+            Operation::CastU8
+            | Operation::CastU16
+            | Operation::CastU32
+            | Operation::CastU64
+            | Operation::CastU128
+            | Operation::CastU256 => {
+                self.translate_cast_impl(
+                    dst,
+                    src,
+                    (Self::emit_precond_for_cast, EmitterFnKind::PreCheck),
+                );
             }
             _ => todo!("{op:?}"),
         }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -10,7 +10,8 @@ entry:
   %load_store_tmp = load i8, ptr %local_0, align 1
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
-  store i8 %cast_src, ptr %local_2, align 1
+  %zext_dst = zext i8 %cast_src to i32
+  store i32 %zext_dst, ptr %local_2, align 4
   %retval = load i32, ptr %local_2, align 4
   ret i32 %retval
 }
@@ -24,7 +25,8 @@ entry:
   %load_store_tmp = load i8, ptr %local_0, align 1
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
-  store i8 %cast_src, ptr %local_2, align 1
+  %zext_dst = zext i8 %cast_src to i64
+  store i64 %zext_dst, ptr %local_2, align 4
   %retval = load i64, ptr %local_2, align 4
   ret i64 %retval
 }
@@ -38,7 +40,8 @@ entry:
   %load_store_tmp = load i32, ptr %local_0, align 4
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
-  store i32 %cast_src, ptr %local_2, align 4
+  %trunc_dst = trunc i32 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
   ret i8 %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -1,0 +1,536 @@
+; ModuleID = '0x100__Test'
+source_filename = "<unknown>"
+
+define i128 @Test__cast_u128_as_u128(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i128, align 8
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %cast_src, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u128_as_u16(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i16, align 2
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  %trunc_dst = trunc i128 %cast_src to i16
+  store i16 %trunc_dst, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u128_as_u256(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i256, align 8
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  %zext_dst = zext i128 %cast_src to i256
+  store i256 %zext_dst, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u128_as_u32(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i32, align 4
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  %trunc_dst = trunc i128 %cast_src to i32
+  store i32 %trunc_dst, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u128_as_u64(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i64, align 8
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  %trunc_dst = trunc i128 %cast_src to i64
+  store i64 %trunc_dst, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u128_as_u8(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i8, align 1
+  store i128 %0, ptr %local_0, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 4
+  store i128 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i128, ptr %local_1, align 4
+  %trunc_dst = trunc i128 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i128 @Test__cast_u16_as_u128(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i128, align 8
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  %zext_dst = zext i16 %cast_src to i128
+  store i128 %zext_dst, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u16_as_u16(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i16, align 2
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  store i16 %cast_src, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u16_as_u256(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i256, align 8
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  %zext_dst = zext i16 %cast_src to i256
+  store i256 %zext_dst, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u16_as_u32(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i32, align 4
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  %zext_dst = zext i16 %cast_src to i32
+  store i32 %zext_dst, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u16_as_u64(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i64, align 8
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  %zext_dst = zext i16 %cast_src to i64
+  store i64 %zext_dst, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u16_as_u8(i16 %0) {
+entry:
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i16, align 2
+  %local_2 = alloca i8, align 1
+  store i16 %0, ptr %local_0, align 2
+  %load_store_tmp = load i16, ptr %local_0, align 2
+  store i16 %load_store_tmp, ptr %local_1, align 2
+  %cast_src = load i16, ptr %local_1, align 2
+  %trunc_dst = trunc i16 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i128 @Test__cast_u256_as_u128(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i128, align 8
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  %trunc_dst = trunc i256 %cast_src to i128
+  store i128 %trunc_dst, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u256_as_u16(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i16, align 2
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  %trunc_dst = trunc i256 %cast_src to i16
+  store i16 %trunc_dst, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u256_as_u256(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i256, align 8
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %cast_src, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u256_as_u32(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i32, align 4
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  %trunc_dst = trunc i256 %cast_src to i32
+  store i32 %trunc_dst, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u256_as_u64(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i64, align 8
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  %trunc_dst = trunc i256 %cast_src to i64
+  store i64 %trunc_dst, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u256_as_u8(i256 %0) {
+entry:
+  %local_0 = alloca i256, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i8, align 1
+  store i256 %0, ptr %local_0, align 4
+  %load_store_tmp = load i256, ptr %local_0, align 4
+  store i256 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i256, ptr %local_1, align 4
+  %trunc_dst = trunc i256 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i128 @Test__cast_u32_as_u128(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i128, align 8
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  %zext_dst = zext i32 %cast_src to i128
+  store i128 %zext_dst, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u32_as_u16(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i16, align 2
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  %trunc_dst = trunc i32 %cast_src to i16
+  store i16 %trunc_dst, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u32_as_u256(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i256, align 8
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  %zext_dst = zext i32 %cast_src to i256
+  store i256 %zext_dst, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u32_as_u32(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i32, align 4
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  store i32 %cast_src, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u32_as_u64(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i64, align 8
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  %zext_dst = zext i32 %cast_src to i64
+  store i64 %zext_dst, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u32_as_u8(i32 %0) {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca i8, align 1
+  store i32 %0, ptr %local_0, align 4
+  %load_store_tmp = load i32, ptr %local_0, align 4
+  store i32 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i32, ptr %local_1, align 4
+  %trunc_dst = trunc i32 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i128 @Test__cast_u64_as_u128(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i128, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  %zext_dst = zext i64 %cast_src to i128
+  store i128 %zext_dst, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u64_as_u16(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i16, align 2
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  %trunc_dst = trunc i64 %cast_src to i16
+  store i16 %trunc_dst, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u64_as_u256(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i256, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  %zext_dst = zext i64 %cast_src to i256
+  store i256 %zext_dst, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u64_as_u32(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i32, align 4
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  %trunc_dst = trunc i64 %cast_src to i32
+  store i32 %trunc_dst, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u64_as_u64(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %cast_src, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u64_as_u8(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %cast_src = load i64, ptr %local_1, align 4
+  %trunc_dst = trunc i64 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i128 @Test__cast_u8_as_u128(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i128, align 8
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  %zext_dst = zext i8 %cast_src to i128
+  store i128 %zext_dst, ptr %local_2, align 4
+  %retval = load i128, ptr %local_2, align 4
+  ret i128 %retval
+}
+
+define i16 @Test__cast_u8_as_u16(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i16, align 2
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  %zext_dst = zext i8 %cast_src to i16
+  store i16 %zext_dst, ptr %local_2, align 2
+  %retval = load i16, ptr %local_2, align 2
+  ret i16 %retval
+}
+
+define i256 @Test__cast_u8_as_u256(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i256, align 8
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  %zext_dst = zext i8 %cast_src to i256
+  store i256 %zext_dst, ptr %local_2, align 4
+  %retval = load i256, ptr %local_2, align 4
+  ret i256 %retval
+}
+
+define i32 @Test__cast_u8_as_u32(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i32, align 4
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  %zext_dst = zext i8 %cast_src to i32
+  store i32 %zext_dst, ptr %local_2, align 4
+  %retval = load i32, ptr %local_2, align 4
+  ret i32 %retval
+}
+
+define i64 @Test__cast_u8_as_u64(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i64, align 8
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  %zext_dst = zext i8 %cast_src to i64
+  store i64 %zext_dst, ptr %local_2, align 4
+  %retval = load i64, ptr %local_2, align 4
+  ret i64 %retval
+}
+
+define i8 @Test__cast_u8_as_u8(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %cast_src = load i8, ptr %local_1, align 1
+  store i8 %cast_src, ptr %local_2, align 1
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting.move
@@ -1,0 +1,159 @@
+module 0x100::Test {
+  // u8 to everything else.
+  fun cast_u8_as_u8(a: u8): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u8_as_u16(a: u8): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u8_as_u32(a: u8): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u8_as_u64(a: u8): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u8_as_u128(a: u8): u128 {
+    let c = (a as u128);
+    c
+  }
+  fun cast_u8_as_u256(a: u8): u256 {
+    let c = (a as u256);
+    c
+  }
+
+  // u16 to everything else.
+  fun cast_u16_as_u8(a: u16): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u16_as_u16(a: u16): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u16_as_u32(a: u16): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u16_as_u64(a: u16): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u16_as_u128(a: u16): u128 {
+    let c = (a as u128);
+    c
+  }
+  fun cast_u16_as_u256(a: u16): u256 {
+    let c = (a as u256);
+    c
+  }
+
+  // u32 to everything else.
+  fun cast_u32_as_u8(a: u32): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u32_as_u16(a: u32): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u32_as_u32(a: u32): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u32_as_u64(a: u32): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u32_as_u128(a: u32): u128 {
+    let c = (a as u128);
+    c
+  }
+  fun cast_u32_as_u256(a: u32): u256 {
+    let c = (a as u256);
+    c
+  }
+
+  // u64 to everything else.
+  fun cast_u64_as_u8(a: u64): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u64_as_u16(a: u64): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u64_as_u32(a: u64): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u64_as_u64(a: u64): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u64_as_u128(a: u64): u128 {
+    let c = (a as u128);
+    c
+  }
+  fun cast_u64_as_u256(a: u64): u256 {
+    let c = (a as u256);
+    c
+  }
+
+  // u128 to everything else.
+  fun cast_u128_as_u8(a: u128): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u128_as_u16(a: u128): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u128_as_u32(a: u128): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u128_as_u64(a: u128): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u128_as_u128(a: u128): u128 {
+    let c = (a as u128);
+    c
+  }
+
+  fun cast_u128_as_u256(a: u128): u256 {
+    let c = (a as u256);
+    c
+  }
+
+  // u256 to everything else.
+  fun cast_u256_as_u8(a: u256): u8 {
+    let c = (a as u8);
+    c
+  }
+  fun cast_u256_as_u16(a: u256): u16 {
+    let c = (a as u16);
+    c
+  }
+  fun cast_u256_as_u32(a: u256): u32 {
+    let c = (a as u32);
+    c
+  }
+  fun cast_u256_as_u64(a: u256): u64 {
+    let c = (a as u64);
+    c
+  }
+  fun cast_u256_as_u128(a: u256): u128 {
+    let c = (a as u128);
+    c
+  }
+  fun cast_u256_as_u256(a: u256): u256 {
+    let c = (a as u256);
+    c
+  }
+
+}


### PR DESCRIPTION
Fix defect where we were passing the source rather than dest type to the zext/trunc builders, resulting in incorrect code. Remaster cast.move test results accordingly.

Implement support for all missing cast operators:
Operation::{CastU16, CastU128, CastU256}.

The above also required adding support in a few places for types: Type::Primitive(PrimitiveType::{U16,U128,U256}.

Deduplicated the cast codegen and factored into translate_cast_impl.

Finally, added new unit test move-ir-tests/casting.move to test every combination of types for casting. Eyeball-checked every single generated combination.