### PR TITLE
Implement dynamic checks for casting, u256 constants, and not operator.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -40,8 +40,21 @@ entry:
   %load_store_tmp = load i32, ptr %local_0, align 4
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
+  %castcond = icmp ugt i32 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i32 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
   ret i8 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -24,6 +24,14 @@ entry:
   %load_store_tmp = load i128, ptr %local_0, align 4
   store i128 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i128, ptr %local_1, align 4
+  %castcond = icmp ugt i128 %cast_src, 65535
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i128 %cast_src to i16
   store i16 %trunc_dst, ptr %local_2, align 2
   %retval = load i16, ptr %local_2, align 2
@@ -54,6 +62,14 @@ entry:
   %load_store_tmp = load i128, ptr %local_0, align 4
   store i128 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i128, ptr %local_1, align 4
+  %castcond = icmp ugt i128 %cast_src, 4294967295
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i128 %cast_src to i32
   store i32 %trunc_dst, ptr %local_2, align 4
   %retval = load i32, ptr %local_2, align 4
@@ -69,6 +85,14 @@ entry:
   %load_store_tmp = load i128, ptr %local_0, align 4
   store i128 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i128, ptr %local_1, align 4
+  %castcond = icmp ugt i128 %cast_src, 18446744073709551615
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i128 %cast_src to i64
   store i64 %trunc_dst, ptr %local_2, align 4
   %retval = load i64, ptr %local_2, align 4
@@ -84,6 +108,14 @@ entry:
   %load_store_tmp = load i128, ptr %local_0, align 4
   store i128 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i128, ptr %local_1, align 4
+  %castcond = icmp ugt i128 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i128 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
@@ -173,6 +205,14 @@ entry:
   %load_store_tmp = load i16, ptr %local_0, align 2
   store i16 %load_store_tmp, ptr %local_1, align 2
   %cast_src = load i16, ptr %local_1, align 2
+  %castcond = icmp ugt i16 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i16 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
@@ -188,6 +228,14 @@ entry:
   %load_store_tmp = load i256, ptr %local_0, align 4
   store i256 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i256, ptr %local_1, align 4
+  %castcond = icmp ugt i256 %cast_src, 340282366920938463463374607431768211455
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i128
   store i128 %trunc_dst, ptr %local_2, align 4
   %retval = load i128, ptr %local_2, align 4
@@ -203,6 +251,14 @@ entry:
   %load_store_tmp = load i256, ptr %local_0, align 4
   store i256 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i256, ptr %local_1, align 4
+  %castcond = icmp ugt i256 %cast_src, 65535
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i16
   store i16 %trunc_dst, ptr %local_2, align 2
   %retval = load i16, ptr %local_2, align 2
@@ -232,6 +288,14 @@ entry:
   %load_store_tmp = load i256, ptr %local_0, align 4
   store i256 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i256, ptr %local_1, align 4
+  %castcond = icmp ugt i256 %cast_src, 4294967295
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i32
   store i32 %trunc_dst, ptr %local_2, align 4
   %retval = load i32, ptr %local_2, align 4
@@ -247,6 +311,14 @@ entry:
   %load_store_tmp = load i256, ptr %local_0, align 4
   store i256 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i256, ptr %local_1, align 4
+  %castcond = icmp ugt i256 %cast_src, 18446744073709551615
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i64
   store i64 %trunc_dst, ptr %local_2, align 4
   %retval = load i64, ptr %local_2, align 4
@@ -262,6 +334,14 @@ entry:
   %load_store_tmp = load i256, ptr %local_0, align 4
   store i256 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i256, ptr %local_1, align 4
+  %castcond = icmp ugt i256 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
@@ -292,6 +372,14 @@ entry:
   %load_store_tmp = load i32, ptr %local_0, align 4
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
+  %castcond = icmp ugt i32 %cast_src, 65535
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i32 %cast_src to i16
   store i16 %trunc_dst, ptr %local_2, align 2
   %retval = load i16, ptr %local_2, align 2
@@ -351,6 +439,14 @@ entry:
   %load_store_tmp = load i32, ptr %local_0, align 4
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
+  %castcond = icmp ugt i32 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i32 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
@@ -381,6 +477,14 @@ entry:
   %load_store_tmp = load i64, ptr %local_0, align 4
   store i64 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i64, ptr %local_1, align 4
+  %castcond = icmp ugt i64 %cast_src, 65535
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i64 %cast_src to i16
   store i16 %trunc_dst, ptr %local_2, align 2
   %retval = load i16, ptr %local_2, align 2
@@ -411,6 +515,14 @@ entry:
   %load_store_tmp = load i64, ptr %local_0, align 4
   store i64 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i64, ptr %local_1, align 4
+  %castcond = icmp ugt i64 %cast_src, 4294967295
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i64 %cast_src to i32
   store i32 %trunc_dst, ptr %local_2, align 4
   %retval = load i32, ptr %local_2, align 4
@@ -440,6 +552,14 @@ entry:
   %load_store_tmp = load i64, ptr %local_0, align 4
   store i64 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i64, ptr %local_1, align 4
+  %castcond = icmp ugt i64 %cast_src, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i64 %cast_src to i8
   store i8 %trunc_dst, ptr %local_2, align 1
   %retval = load i8, ptr %local_2, align 1
@@ -534,3 +654,8 @@ entry:
   %retval = load i8, ptr %local_2, align 1
   ret i8 %retval
 }
+
+; Function Attrs: noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
@@ -168,3 +168,18 @@ entry:
   %retval = load i1, ptr %local_4, align 1
   ret i1 %retval
 }
+
+define i1 @Test__test_not(i1 %0) {
+entry:
+  %local_0 = alloca i1, align 1
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i1, align 1
+  store i1 %0, ptr %local_0, align 1
+  %load_store_tmp = load i1, ptr %local_0, align 1
+  store i1 %load_store_tmp, ptr %local_1, align 1
+  %not_src = load i1, ptr %local_1, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_2, align 1
+  %retval = load i1, ptr %local_2, align 1
+  ret i1 %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical.move
@@ -31,4 +31,8 @@ module 0x100::Test {
     let c = a && b;
     c
   }
+  fun test_not(a: bool): bool {
+    let c = !a;
+    c
+  }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u16-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u16-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu16(a: u128): u16 {
+    (a as u16)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu16(65535u128) == 65535, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu16(65536u128);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u32-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u32-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu32(a: u128): u32 {
+    (a as u32)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu32(4294967295u128) == 4294967295, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu32(4294967296u128);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u64-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u64-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu64(a: u128): u64 {
+    (a as u64)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu64(18446744073709551615u128) == 18446744073709551615, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu64(18446744073709551616u128);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u8-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u128-to-u8-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu8(a: u128): u8 {
+    (a as u8)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu8(255u128) == 255, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu8(256u128);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u16-to-u8-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u16-to-u8-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu8(a: u16): u8 {
+    (a as u8)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu8(255u16) == 255, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu8(256u16);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u128-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u128-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu128(a: u256): u128 {
+    (a as u128)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu128(340282366920938463463374607431768211455u256) == 340282366920938463463374607431768211455, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu128(340282366920938463463374607431768211456u256);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u16-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u16-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu16(a: u256): u16 {
+    (a as u16)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu16(65535u256) == 65535, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu16(65536u256);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u32-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u32-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu32(a: u256): u32 {
+    (a as u32)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu32(4294967295u256) == 4294967295, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu32(4294967296u256);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u64-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u64-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu64(a: u256): u64 {
+    (a as u64)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu64(18446744073709551615u256) == 18446744073709551615, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu64(18446744073709551616u256);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u8-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u256-to-u8-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu8(a: u256): u8 {
+    (a as u8)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu8(255u256) == 255, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu8(256u256);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u32-to-u16-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u32-to-u16-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu16(a: u32): u16 {
+    (a as u16)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu16(65535u32) == 65535, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu16(65536u32);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u32-to-u8-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u32-to-u8-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu8(a: u32): u8 {
+    (a as u8)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu8(255u32) == 255, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu8(256u32);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u16-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u16-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu16(a: u64): u16 {
+    (a as u16)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu16(65535u64) == 65535, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu16(65536u64);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u32-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u32-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu32(a: u64): u32 {
+    (a as u32)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu32(4294967295u64) == 4294967295, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu32(4294967296u64);  // Abort: source too big.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u8-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/cast-u64-to-u8-rangechk-abort.move
@@ -1,0 +1,15 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_castu8(a: u64): u8 {
+    (a as u8)
+  }
+}
+
+script {
+  fun main() {
+    assert!(0x101::Test1::test_castu8(255u64) == 255, 10);  // Ok: source fits in dest.
+
+    0x101::Test1::test_castu8(256u64);  // Abort: source too big.
+  }
+}


### PR DESCRIPTION
This patch implements the runtime checks for all cast operators. This needed actual support for u256 and 256-bit constants.

Also implemented the unary Operation::Not.

Added unit tests for all of the above, including rbpf runtime tests for all combinations of downcasting that can abort.