### PR TITLE
Ensure an abort actually occurs when test plan expects it.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -257,6 +257,13 @@ fn run_rbpf(test_plan: &tc::TestPlan, exe: &Path) -> anyhow::Result<()> {
 
     let result = Result::from(result);
 
+    // If that test plan expected an abort, make sure an abort actually occurred.
+    if let Some(_) = test_plan.abort_code() {
+        if let Ok(_) = result {
+            panic!("test plan expected an abort, but it did not occur.");
+        }
+    }
+
     match result {
         Ok(0) => {}
         Ok(_) => {


### PR DESCRIPTION
This fixes a defect where a test case that expects an abort code would pass even if no abort actually occurred at runtime.

For example, before this patch, the below rbpf test passes when it should not:
  // abort 10
  script {
    fun main() {
    }
  }