### PR TITLE
Run `cargo x lint` and `cargo x fmt`

### DIFF
--- a/language/tools/move-mv-llvm-compiler/docs/TypeInfo.md
+++ b/language/tools/move-mv-llvm-compiler/docs/TypeInfo.md
@@ -6,4 +6,3 @@ Goes in a separate ELF section. For now the compiler emits BTF however this can 
 ## Purpose of type info
 - For debugging
 - For rejecting invalid programs. The type info should not be used to **accept** a program because typeinfo can be manipulated outside of the program.
-

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -177,9 +177,12 @@ fn main() -> anyhow::Result<()> {
         "view" => "v:".to_owned() + &args.dot_file_path,
         "" => "".to_owned(),
         _ => {
-            eprintln!("unexpected gen-dot-cfg option '{}', ignored.", &args.gen_dot_cfg);
+            eprintln!(
+                "unexpected gen-dot-cfg option '{}', ignored.",
+                &args.gen_dot_cfg
+            );
             "".to_owned()
-        },
+        }
     };
 
     {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -282,9 +282,7 @@ impl Drop for Builder {
 
 impl Builder {
     pub fn get_insert_block(&self) -> BasicBlock {
-        unsafe {
-            BasicBlock(LLVMGetInsertBlock(self.0))
-        }
+        unsafe { BasicBlock(LLVMGetInsertBlock(self.0)) }
     }
 
     pub fn position_at_end(&self, bb: BasicBlock) {
@@ -423,15 +421,8 @@ impl Builder {
         args: &[LLVMValueRef],
         resname: &str,
     ) -> LLVMValueRef {
-
-        let mut tys = types
-            .iter()
-            .map(|ty| ty.0)
-            .collect::<Vec<_>>();
-        let mut args = args
-            .iter()
-            .map(|val| *val)
-            .collect::<Vec<_>>();
+        let mut tys = types.iter().map(|ty| ty.0).collect::<Vec<_>>();
+        let mut args = args.iter().map(|val| *val).collect::<Vec<_>>();
 
         unsafe {
             let iid = LLVMLookupIntrinsicID(iname.cstr(), iname.len());
@@ -479,7 +470,12 @@ impl Builder {
         }
     }
 
-    pub fn load_call_store(&self, fnval: Function, args: &[(Type, Alloca)], dst: &[(Type, Alloca)]) {
+    pub fn load_call_store(
+        &self,
+        fnval: Function,
+        args: &[(Type, Alloca)],
+        dst: &[(Type, Alloca)],
+    ) {
         let fnty = fnval.llvm_type();
 
         unsafe {
@@ -505,7 +501,7 @@ impl Builder {
                 return;
             } else if dst.len() == 1 {
                 // Single return value.
-                LLVMBuildStore(self.0, ret, dst[0].1.0);
+                LLVMBuildStore(self.0, ret, dst[0].1 .0);
             } else {
                 // Multiple return values-- unwrap the struct.
                 let extracts = dst
@@ -516,7 +512,7 @@ impl Builder {
                         let ev = LLVMBuildExtractValue(self.0, ret, i as libc::c_uint, name.cstr());
                         (ev, dval)
                     })
-                .collect::<Vec<_>>();
+                    .collect::<Vec<_>>();
                 for (ev, dval) in extracts {
                     LLVMBuildStore(self.0, ev, dval.0);
                 }
@@ -716,9 +712,7 @@ impl Function {
     }
 
     pub fn llvm_return_type(&self) -> Type {
-        unsafe {
-            Type(LLVMGetReturnType(LLVMGlobalGetValueType(self.0)))
-        }
+        unsafe { Type(LLVMGetReturnType(LLVMGlobalGetValueType(self.0))) }
     }
 
     pub fn verify(&self) {
@@ -820,7 +814,9 @@ impl Constant {
             }
         }
     }
-    pub fn get0(&self) -> LLVMValueRef { self.0 }
+    pub fn get0(&self) -> LLVMValueRef {
+        self.0
+    }
 
     pub fn llvm_type(&self) -> Type {
         unsafe { Type(LLVMTypeOf(self.0)) }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -1,3 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! The type descriptor accepted by runtime functions.
 //!
 //! Corresponds to `move_native::rt_types::MoveType`.

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -32,8 +32,7 @@
 
 use crate::stackless::{extensions::*, llvm, rttydesc};
 use llvm_sys::prelude::LLVMValueRef;
-use move_core_types::u256;
-use move_core_types::vm_status::StatusCode::ARITHMETIC_ERROR;
+use move_core_types::{u256, vm_status::StatusCode::ARITHMETIC_ERROR};
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_stackless_bytecode::{
     stackless_bytecode as sbc, stackless_bytecode_generator::StacklessBytecodeGenerator,
@@ -192,8 +191,11 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     1 => self.llvm_type(&fn_data.return_types[0]),
                     _ => {
                         // Wrap multiple return values in a struct.
-                        let tys: Vec<_> =
-                            fn_data.return_types.iter().map(|f| self.llvm_type(f)).collect();
+                        let tys: Vec<_> = fn_data
+                            .return_types
+                            .iter()
+                            .map(|f| self.llvm_type(f))
+                            .collect();
                         let rty = self.llvm_cx.get_anonymous_struct_type(&tys);
                         rty
                     }
@@ -374,7 +376,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             let graph_label = format!("digraph {{ label=\"Function: {}\"\n", fname);
             let dgraph2 = dot_graph.replacen("digraph {", &graph_label, 1);
             let (action, output_path) = dot_info.split_at(2);
-            let path_sep = match output_path { "" => "", _ => "/" };
+            let path_sep = match output_path {
+                "" => "",
+                _ => "/",
+            };
             let dot_file = format!("{}{}{}_cfg.dot", output_path, path_sep, fname);
             std::fs::write(&dot_file, &dgraph2).expect("generating dot file for CFG");
             // If requested by user, also invoke the xdot viewer.
@@ -538,7 +543,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     let ll_fn = &self.fn_decls[&self.env.get_qualified_id()];
                     let ret_ty = ll_fn.llvm_return_type();
                     self.llvm_builder.load_multi_return(ret_ty, &nvals);
-                },
+                }
             },
             sbc::Bytecode::Load(_, idx, val) => {
                 let local_llval = self.locals[*idx].llval;
@@ -747,12 +752,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         assert_eq!(src.len(), 2);
         let src0_reg = self.load_reg(src[0], &format!("{name}_src_0"));
         let src1_reg = self.load_reg(src[1], &format!("{name}_src_1"));
-        let dst_reg = self.llvm_builder.build_compare(
-            pred,
-            src0_reg,
-            src1_reg,
-            &format!("{name}_dst"),
-        );
+        let dst_reg =
+            self.llvm_builder
+                .build_compare(pred, src0_reg, src1_reg, &format!("{name}_dst"));
         self.store_reg(dst[0], dst_reg);
     }
 
@@ -935,10 +937,22 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 self.llvm_builder.load_store(src_llty, src_llval, dst_llval);
             }
             Operation::Add => {
-                self.translate_arithm_impl(dst, src, "add", llvm_sys::LLVMOpcode::LLVMAdd, (Self::emit_postcond_for_add, EmitterFnKind::PostCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "add",
+                    llvm_sys::LLVMOpcode::LLVMAdd,
+                    (Self::emit_postcond_for_add, EmitterFnKind::PostCheck),
+                );
             }
             Operation::Sub => {
-                self.translate_arithm_impl(dst, src, "sub", llvm_sys::LLVMOpcode::LLVMSub, (Self::emit_postcond_for_sub, EmitterFnKind::PostCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "sub",
+                    llvm_sys::LLVMOpcode::LLVMSub,
+                    (Self::emit_postcond_for_sub, EmitterFnKind::PostCheck),
+                );
             }
             Operation::Mul => {
                 let src0_reg = self.load_reg(src[0], &format!("mul_src_0"));
@@ -958,25 +972,67 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 self.store_reg(dst[0], prod_reg);
             }
             Operation::Div => {
-                self.translate_arithm_impl(dst, src, "div", llvm_sys::LLVMOpcode::LLVMUDiv, (Self::emit_precond_for_div, EmitterFnKind::PreCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "div",
+                    llvm_sys::LLVMOpcode::LLVMUDiv,
+                    (Self::emit_precond_for_div, EmitterFnKind::PreCheck),
+                );
             }
             Operation::Mod => {
-                self.translate_arithm_impl(dst, src, "mod", llvm_sys::LLVMOpcode::LLVMURem, (Self::emit_precond_for_div, EmitterFnKind::PreCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "mod",
+                    llvm_sys::LLVMOpcode::LLVMURem,
+                    (Self::emit_precond_for_div, EmitterFnKind::PreCheck),
+                );
             }
             Operation::BitOr => {
-                self.translate_arithm_impl(dst, src, "or", llvm_sys::LLVMOpcode::LLVMOr, emitter_nop);
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "or",
+                    llvm_sys::LLVMOpcode::LLVMOr,
+                    emitter_nop,
+                );
             }
             Operation::BitAnd => {
-                self.translate_arithm_impl(dst, src, "and", llvm_sys::LLVMOpcode::LLVMAnd, emitter_nop);
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "and",
+                    llvm_sys::LLVMOpcode::LLVMAnd,
+                    emitter_nop,
+                );
             }
             Operation::Xor => {
-                self.translate_arithm_impl(dst, src, "xor", llvm_sys::LLVMOpcode::LLVMXor, emitter_nop);
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "xor",
+                    llvm_sys::LLVMOpcode::LLVMXor,
+                    emitter_nop,
+                );
             }
             Operation::Shl => {
-                self.translate_arithm_impl(dst, src, "shl", llvm_sys::LLVMOpcode::LLVMShl, (Self::emit_precond_for_shift, EmitterFnKind::PreCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "shl",
+                    llvm_sys::LLVMOpcode::LLVMShl,
+                    (Self::emit_precond_for_shift, EmitterFnKind::PreCheck),
+                );
             }
             Operation::Shr => {
-                self.translate_arithm_impl(dst, src, "shr", llvm_sys::LLVMOpcode::LLVMLShr, (Self::emit_precond_for_shift, EmitterFnKind::PreCheck));
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "shr",
+                    llvm_sys::LLVMOpcode::LLVMLShr,
+                    (Self::emit_precond_for_shift, EmitterFnKind::PreCheck),
+                );
             }
             Operation::Lt => {
                 self.translate_comparison_impl(dst, src, "lt", llvm::LLVMIntPredicate::LLVMIntULT);
@@ -990,11 +1046,25 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             Operation::Ge => {
                 self.translate_comparison_impl(dst, src, "ge", llvm::LLVMIntPredicate::LLVMIntUGE);
             }
-            Operation::Or => { // Logical Or
-                self.translate_arithm_impl(dst, src, "or", llvm_sys::LLVMOpcode::LLVMOr, emitter_nop);
+            Operation::Or => {
+                // Logical Or
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "or",
+                    llvm_sys::LLVMOpcode::LLVMOr,
+                    emitter_nop,
+                );
             }
-            Operation::And => { // Logical And
-                self.translate_arithm_impl(dst, src, "and", llvm_sys::LLVMOpcode::LLVMAnd, emitter_nop);
+            Operation::And => {
+                // Logical And
+                self.translate_arithm_impl(
+                    dst,
+                    src,
+                    "and",
+                    llvm_sys::LLVMOpcode::LLVMAnd,
+                    emitter_nop,
+                );
             }
             Operation::Eq => {
                 self.translate_comparison_impl(dst, src, "eq", llvm::LLVMIntPredicate::LLVMIntEQ);
@@ -1152,7 +1222,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             Constant::U256(val) => {
                 let llty = self.llvm_cx.int256_type();
                 let as_str = format!("{}", *val);
-                let newval = u256::U256::from_str_radix(&as_str, 10).expect("cannot convert to U256");
+                let newval =
+                    u256::U256::from_str_radix(&as_str, 10).expect("cannot convert to U256");
                 llvm::Constant::int256(llty, newval)
             }
             _ => todo!(),

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals.move
@@ -14,4 +14,3 @@ module 0x100::Test {
         let _t4 = d;
     }
 }
-

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/return-multiple-values1.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/return-multiple-values1.move
@@ -29,4 +29,3 @@ script {
         assert!(is_equal, 0xf05);
     }
 }
-

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/return-multiple-values2.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/return-multiple-values2.move
@@ -15,4 +15,3 @@ script {
         assert!(x6 == 6, 0xf05);
     }
 }
-


### PR DESCRIPTION
Just keeping the code up to upstream standards.

`cargo x clippy` is currently broken for multiple reasons, including one upstream failure.
