### PR TITLE
Add CI workflow for move-llvm

### DIFF
--- a/.github/actions/acquire-solana-tools/action.yml
+++ b/.github/actions/acquire-solana-tools/action.yml
@@ -1,0 +1,37 @@
+name: "Acquire Solana Tools"
+description: |
+  Get Solana's Build of LLVM and platform-tools from GitHub Actions artifacts.
+inputs:
+  github-token:
+    description: GitHub token
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download LLVM
+      shell: bash
+      run: |
+        export ARTIFACT_ID=616328335
+        export GITHUB_TOKEN=${{ inputs.github-token }}
+        mkdir ../llvm
+        curl -L -H "Accept: application/vnd.github+json" \
+             -H "Authorization: Bearer $GITHUB_TOKEN" \
+             -H "X-GitHub-Api-Version: 2022-11-28" \
+             https://api.github.com/repos/solana-labs/platform-tools/actions/artifacts/$ARTIFACT_ID/zip \
+             -o ../llvm/llvm.zip
+        ls -lh ../llvm
+        (cd ../llvm && unzip llvm.zip)
+        ls -lh ../llvm
+        (cd ../llvm && tar xjf move-dev-linux-x86_64.tar.bz2)
+        ls -lh ../llvm
+        # llvm is at ../llvm/move-dev
+    - name: Download platform-tools
+      shell: bash
+      run: |
+        mkdir ../platform-tools
+        curl -L https://github.com/solana-labs/platform-tools/releases/download/v1.36/platform-tools-linux-x86_64.tar.bz2 \
+             -o ../platform-tools/platform-tools.tar.bz2
+        ls -lh ../platform-tools
+        (cd ../platform-tools && tar xjf platform-tools.tar.bz2)
+        ls -lh ../platform-tools
+        # platform-tools is at ../platform-tools

--- a/.github/workflows/llvm-ci-pre-land.yml
+++ b/.github/workflows/llvm-ci-pre-land.yml
@@ -1,0 +1,94 @@
+# CI jobs to be run upon the code lands to the main branch or GitHub Action test branches.
+
+name: llvm-ci-pre-land
+
+on:
+  pull_request:
+    branches: [main, llvm-sys, gha-test-*]
+  workflow_dispatch:
+
+# The environment variables required by move-mv-llvm-compiler.
+# The tools in these dirs are downloaded by the acquire-solana-tools action.
+env:
+  LLVM_SYS_150_PREFIX: /home/runner/work/move/llvm/move-dev
+  PLATFORM_TOOLS_ROOT: /home/runner/work/move/platform-tools
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      changes-target-branch: ${{ steps.changes.outputs.changes-target-branch }}
+      any-changes-founds: ${{ steps.any-changes-found.outputs.changes-found }}
+      test-rust: ${{ steps.rust-changes.outputs.changes-found }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Git Hooks and Checks
+        run: ./scripts/git-checks.sh
+      - id: changes
+        name: determine changes
+        uses: diem/actions/changes@faadd16607b77dfa2231a8f366883e01717b3225
+        with:
+          workflow-file: ci.yml
+          github-token: ${{secrets.GITHUB_TOKEN}}
+      - id: any-changes-found
+        name: determine if there are any files listed in the CHANGES_CHANGED_FILE_OUTPUTFILE.
+        run: |
+          res=true
+          if [[ ! -f "$CHANGES_CHANGED_FILE_OUTPUTFILE" ]] || [[ "$(cat "$CHANGES_CHANGED_FILE_OUTPUTFILE" | wc -l)" == 0 ]]; then
+            res=false;
+          fi
+          echo "::set-output name=changes-found::$(echo $res)";
+      - id: rust-changes
+        name: find rust/cargo changes.
+        uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
+        with:
+          pattern: '^documentation\|^docker\|^scripts'
+          invert: "true"
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: prepare
+    # if: ${{ needs.prepare.outputs.any-changes-founds == 'true' }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+      - id: acquire-solana-tools
+        uses: ./.github/actions/acquire-solana-tools
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+      - name: cargo lint
+        run: cargo x lint
+      # - name: cargo clippy
+      #   run: cargo xclippy --workspace --all-targets
+      - name: cargo fmt
+        run: cargo xfmt --check
+      - uses: ./.github/actions/build-teardown
+
+  unit-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: prepare
+    # if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+      - id: acquire-solana-tools
+        uses: ./.github/actions/acquire-solana-tools
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+      - name: move-native tests
+        run: cargo test --profile ci -p move-native
+      - name: build move-ir-compiler
+        run: cargo build --profile ci -p move-ir-compiler
+      - name: build move-compiler
+        run: cargo build --profile ci -p move-compiler
+      - name: move-mv-llvm-compiler tests
+        run: cargo test --profile ci -p move-mv-llvm-compiler
+      - uses: ./.github/actions/build-teardown


### PR DESCRIPTION
This adds two files:

`.github/workflow/llvm-ci-pre-land.yml` is based off of upstream [ci-pre-land.yml](https://github.com/solana-labs/move/blob/llvm-sys/.github/workflows/ci-pre-land.yml). It defines three jobs: "prepare", "lint", and "unit-test".

`.github/actions/acquire-solana-tools/action.yml` is used by the above and downloads Solana's LLVM build and platform-tools.

I don't know what everything in the the workflow does, as it is copied from upstream.

The lint job runs these commands:

- `cargo x lint`
- `cargo x fmt`

These are special upstream Move-specific drivers for `cargo fmt` and a custom linter. This configuration also should, but does not, run `cargo x clippy` - there are several clippy failures, and while I think I know how to fix them, it's too much to do in this PR. I will file a followup issue.

The unit-test job runs these commands:

- `cargo test --profile ci -p move-native`
- `cargo build --profile ci -p move-ir-compiler`
- `cargo build --profile ci -p move-compiler`
- `cargo test --profile ci -p move-mv-llvm-compiler`

I don`t know what the "ci" profile is - it's what upstream uses for CI, but I haven't looked at it.

This configuration doesn't bother to run the full move test suite - so far we have made very few changes to move code, and I hope we will continue that way.

To enable this we need to:

- merge this pr - I don't think it can be tested without landing the worflow first
- turn on github actions
- disable all workflows except this one

I have tested this on my branch. The most recent run is here: https://github.com/brson/move/actions/runs/4823958088

I think the LLVM artifacts being uploaded for us by the platform-tools CI (https://github.com/solana-labs/platform-tools/actions/runs/4519378834) are only stored for 90 days, so as it is we will occasionally need to ask them to be rebuilt and change the ARTIFACT_ID that is hard-coded here. But it's a start.

Fixes https://github.com/solana-labs/move/issues/80