### PR TITLE
Refactor ir-tests

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
@@ -67,7 +67,7 @@ fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
-    let harness_paths = tc::get_harness_paths()?;
+    let harness_paths = tc::get_harness_paths("move-compiler")?;
     let test_plan = tc::get_test_plan(test_path)?;
 
     if test_plan.should_ignore() {

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -25,7 +25,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
     let sbf_tools = get_sbf_tools()?;
     let runtime = get_runtime(&sbf_tools)?;
 
-    let harness_paths = tc::get_harness_paths()?;
+    let harness_paths = tc::get_harness_paths("move-compiler")?;
     let test_plan = tc::get_test_plan(test_path)?;
 
     if test_plan.should_ignore() {


### PR DESCRIPTION
Fixes #50 

- use test_common::get_harness_paths in ir-tests instead of defining another copy of nearly the same function.
- run a builder for move-compiler and move-ir-compiler before getting the paths of these dependencies in get_harness_paths

## Motivation

Remove duplication in test harness code. Automate building of dependencies currently built manually.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
