### PR TITLE
Fix clippy errors and turn on clippy CI

### DIFF
--- a/.github/workflows/llvm-ci-pre-land.yml
+++ b/.github/workflows/llvm-ci-pre-land.yml
@@ -60,8 +60,8 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
       - name: cargo lint
         run: cargo x lint
-      # - name: cargo clippy
-      #   run: cargo xclippy --workspace --all-targets
+      - name: cargo clippy
+        run: cargo xclippy --workspace --all-targets
       - name: cargo fmt
         run: cargo xfmt --check
       - uses: ./.github/actions/build-teardown

--- a/language/evm/exec-utils/src/compile.rs
+++ b/language/evm/exec-utils/src/compile.rs
@@ -98,6 +98,8 @@ pub fn solc_yul(source: &str, return_optimized_yul: bool) -> Result<(Vec<u8>, Op
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
+    // (solana) this clippy failure mysteriously does not trigger upstream
+    #[allow(clippy::or_fun_call)]
     let pipe = child.stdin.as_mut().ok_or(anyhow!("cannot create pipe"))?;
     pipe.write_all(source.as_bytes())?;
     let out = child.wait_with_output()?;

--- a/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
+++ b/language/tools/move-mv-llvm-compiler/llvm-extra-sys/src/lib.rs
@@ -11,7 +11,10 @@
 use libc::{c_uint, size_t};
 use llvm_sys::prelude::*;
 
-pub fn AddFunctionAttributes<'ll>(
+/// # Safety
+///
+/// `llfn` and `attrs` must be valid references within the same LLVM module.
+pub unsafe fn AddFunctionAttributes(
     llfn: LLVMValueRef,
     idx: AttributePlace,
     attrs: &[LLVMAttributeRef],
@@ -21,7 +24,10 @@ pub fn AddFunctionAttributes<'ll>(
     }
 }
 
-pub fn AddCallSiteAttributes<'ll>(
+/// # Safety
+///
+/// `llfn` and `attrs` must be valid references within the same LLVM module.
+pub unsafe fn AddCallSiteAttributes(
     llfn: LLVMValueRef,
     idx: AttributePlace,
     attrs: &[LLVMAttributeRef],

--- a/language/tools/move-mv-llvm-compiler/src/disassembler.rs
+++ b/language/tools/move-mv-llvm-compiler/src/disassembler.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(unused)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use anyhow::{bail, Error, Result};
 use clap::Parser;
@@ -216,7 +217,7 @@ impl<'a> Disassembler<'a> {
         function_source_map: &FunctionSourceMap,
         default_location: &Loc,
     ) -> Result<String> {
-        return Ok("Ok".to_string());
+        Ok("Ok".to_string())
     }
 
     pub fn disassemble_bytecode(
@@ -249,7 +250,7 @@ impl<'a> Disassembler<'a> {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        return Ok(vec!["".to_string()]);
+        Ok(vec!["".to_string()])
     }
 
     pub fn disassemble(&mut self) -> Result<LLVMModuleRef> {
@@ -273,7 +274,7 @@ impl<'a> Disassembler<'a> {
         let mut move_module = MoveBPFModule::new(
             &self.llvm_context,
             &header,
-            &*llvm_module_name,
+            &llvm_module_name,
             opt,
             &self.source_mapper,
         );
@@ -347,7 +348,7 @@ impl<'a> Disassembler<'a> {
                     let mut err_string = ptr::null_mut();
                     let res = LLVMPrintModuleToFile(
                         module,
-                        to_c_str(&output_file_name).as_ptr(),
+                        to_c_str(output_file_name).as_ptr(),
                         &mut err_string,
                     );
 
@@ -368,7 +369,7 @@ impl<'a> Disassembler<'a> {
                 if output_file_name == "-" {
                     anyhow::bail!("Not writing bitcode to stdout");
                 }
-                let bc_file = File::create(&output_file_name)?;
+                let bc_file = File::create(output_file_name)?;
                 let res =
                     LLVMWriteBitcodeToFD(module, bc_file.as_raw_fd(), false as i32, true as i32);
 

--- a/language/tools/move-mv-llvm-compiler/src/errors.rs
+++ b/language/tools/move-mv-llvm-compiler/src/errors.rs
@@ -23,6 +23,6 @@ impl std::fmt::Display for DisassemblerError {
 
 impl std::error::Error for DisassemblerError {
     fn description(&self) -> &str {
-        &self.message.as_ref().unwrap()
+        self.message.as_ref().unwrap()
     }
 }

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -228,11 +228,7 @@ fn llvm_write_to_file(
             if output_file_name != "-" {
                 let mut err_string = ptr::null_mut();
                 let filename = to_c_str(output_file_name);
-                let res = LLVMPrintModuleToFile(
-                    module,
-                    filename.as_ptr(),
-                    &mut err_string,
-                );
+                let res = LLVMPrintModuleToFile(module, filename.as_ptr(), &mut err_string);
 
                 if res != 0 {
                     assert!(!err_string.is_null());

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -227,9 +227,10 @@ fn llvm_write_to_file(
         if llvm_ir {
             if output_file_name != "-" {
                 let mut err_string = ptr::null_mut();
+                let filename = to_c_str(output_file_name);
                 let res = LLVMPrintModuleToFile(
                     module,
-                    to_c_str(output_file_name).as_ptr(),
+                    filename.as_ptr(),
                     &mut err_string,
                 );
 

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -211,7 +211,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn llvm_write_to_file(
+fn llvm_write_to_file(
     module: LLVMModuleRef,
     llvm_ir: bool,
     output_file_name: &String,
@@ -229,7 +229,7 @@ pub fn llvm_write_to_file(
                 let mut err_string = ptr::null_mut();
                 let res = LLVMPrintModuleToFile(
                     module,
-                    to_c_str(&output_file_name).as_ptr(),
+                    to_c_str(output_file_name).as_ptr(),
                     &mut err_string,
                 );
 
@@ -250,7 +250,7 @@ pub fn llvm_write_to_file(
             if output_file_name == "-" {
                 anyhow::bail!("Not writing bitcode to stdout");
             }
-            let bc_file = File::create(&output_file_name)?;
+            let bc_file = File::create(output_file_name)?;
             let res = LLVMWriteBitcodeToFD(module, bc_file.as_raw_fd(), false as i32, true as i32);
 
             if res != 0 {

--- a/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
+++ b/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 use llvm_sys::core::{
     LLVMAddModuleFlag, LLVMAppendBasicBlockInContext, LLVMBuildRet, LLVMBuildRetVoid, LLVMConstInt,
     LLVMCreateBuilderInContext, LLVMGetBasicBlockParent, LLVMGetNextBasicBlock, LLVMGetTypeKind,
@@ -214,7 +216,7 @@ impl<'a> MoveBPFModule<'a> {
         };
 
         assert!(!target_machine.is_null());
-        return Some(target_machine);
+        Some(target_machine)
     }
 
     pub fn add_basic_value_flag(
@@ -230,7 +232,7 @@ impl<'a> MoveBPFModule<'a> {
         unsafe {
             LLVMAddModuleFlag(
                 module,
-                behavior.into(),
+                behavior,
                 key.as_ptr() as *mut ::libc::c_char,
                 key.len(),
                 md,
@@ -343,7 +345,7 @@ impl<'a> MoveBPFModule<'a> {
             SignatureToken::Address => self.address_type,
             SignatureToken::Signer => self.signer_type,
             SignatureToken::Reference(inner) => unsafe {
-                LLVMPointerType(self.llvm_type_for_sig_tok(&**inner), 0)
+                LLVMPointerType(self.llvm_type_for_sig_tok(inner), 0)
             },
             SignatureToken::StructInstantiation(idx, type_arguments) => {
                 self.llvm_struct_from_instance(idx, type_arguments)
@@ -358,12 +360,12 @@ impl<'a> MoveBPFModule<'a> {
     ) -> Vec<LLVMTypeRef> {
         let mut vec = Vec::new();
         for v in sig_tokens {
-            vec.push(self.llvm_type_for_sig_tok(&v));
+            vec.push(self.llvm_type_for_sig_tok(v));
         }
-        return vec;
+        vec
     }
     pub fn llvm_make_single_return_type(&mut self, mut types: Vec<LLVMTypeRef>) -> LLVMTypeRef {
-        if types.len() == 0 {
+        if types.is_empty() {
             unsafe { LLVMVoidType() }
         } else if types.len() == 1 {
             types[0]
@@ -394,7 +396,7 @@ impl<'a> MoveBPFModule<'a> {
         Some(next_bb)
     }
 
-    pub fn append_basic_block<'ctx>(
+    pub fn append_basic_block(
         &self,
         function: LLVMValueRef,
         name: &str,
@@ -439,10 +441,9 @@ impl<'a> MoveBPFModule<'a> {
     }
     pub fn llvm_struct_from_index(&mut self, struct_handle_idx: &StructHandleIndex) -> LLVMTypeRef {
         let index = struct_handle_idx.0 as i32;
-        match self.struct_mapper.get(&index) {
-            Some(x) => return *x,
-            None => (),
-        };
+        if let Some(x) = self.struct_mapper.get(&index) {
+            return *x;
+        }
         let struct_handle = self
             .source_mapper
             .bytecode
@@ -481,10 +482,9 @@ impl<'a> MoveBPFModule<'a> {
         elem_types: &Vec<SignatureToken>,
     ) -> LLVMTypeRef {
         let index = struct_handle_idx.0 as i32;
-        match self.struct_mapper.get(&index) {
-            Some(x) => return *x,
-            None => (),
-        };
+        if let Some(x) = self.struct_mapper.get(&index) {
+            return *x;
+        }
         let mut v = self.llvm_type_for_sig_tokens(elem_types);
         let s = unsafe {
             LLVMStructTypeInContext(
@@ -503,10 +503,9 @@ impl<'a> MoveBPFModule<'a> {
         type_param_idx: &TypeParameterIndex,
     ) -> LLVMTypeRef {
         let index = *type_param_idx as i32;
-        match self.type_param_mapper.get(&index) {
-            Some(x) => return *x,
-            None => (),
-        };
+        if let Some(x) = self.type_param_mapper.get(&index) {
+            return *x;
+        }
         let name = format!("type_param_{}", index);
         let s = unsafe { LLVMStructCreateNamed(*self.context, to_c_str(name.as_str()).as_ptr()) };
         self.type_param_mapper.insert(index, s);

--- a/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
+++ b/language/tools/move-mv-llvm-compiler/src/move_bpf_module.rs
@@ -396,11 +396,7 @@ impl<'a> MoveBPFModule<'a> {
         Some(next_bb)
     }
 
-    pub fn append_basic_block(
-        &self,
-        function: LLVMValueRef,
-        name: &str,
-    ) -> LLVMBasicBlockRef {
+    pub fn append_basic_block(&self, function: LLVMValueRef, name: &str) -> LLVMBasicBlockRef {
         let c_string = to_c_str(name);
         unsafe { LLVMAppendBasicBlockInContext(*self.context, function, c_string.as_ptr()) }
     }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -23,8 +23,7 @@ pub impl<'a> FunctionEnvExt for mm::FunctionEnv<'a> {
             // we might want to preserve the actual names
             "main".to_string()
         } else {
-            let name = name.replace(':', "_");
-            name
+            name.replace(':', "_")
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -12,12 +12,12 @@ use crate::stackless::llvm;
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_native::shared::TypeDesc;
 
-static TD_NAME: & str = "__move_rt_type";
-static TD_TYPE_NAME_NAME: & str = "__move_rt_type_name";
-static TD_TYPE_INFO_NAME: & str = "__move_rt_type_info";
-static TD_VECTOR_TYPE_INFO_NAME: & str = "__move_rt_type_info_vec";
-static TD_STRUCT_TYPE_INFO_NAME: & str = "__move_rt_type_info_struct";
-static TD_REFERENCE_TYPE_INFO_NAME: & str = "__move_rt_type_info_ref";
+static TD_NAME: &str = "__move_rt_type";
+static TD_TYPE_NAME_NAME: &str = "__move_rt_type_name";
+static TD_TYPE_INFO_NAME: &str = "__move_rt_type_info";
+static TD_VECTOR_TYPE_INFO_NAME: &str = "__move_rt_type_info_vec";
+static TD_STRUCT_TYPE_INFO_NAME: &str = "__move_rt_type_info_struct";
+static TD_REFERENCE_TYPE_INFO_NAME: &str = "__move_rt_type_info_ref";
 
 pub fn get_llvm_tydesc_type(llcx: &llvm::Context) -> llvm::StructType {
     match llcx.named_struct_type(TD_NAME) {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -12,12 +12,12 @@ use crate::stackless::llvm;
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_native::shared::TypeDesc;
 
-static TD_NAME: &'static str = "__move_rt_type";
-static TD_TYPE_NAME_NAME: &'static str = "__move_rt_type_name";
-static TD_TYPE_INFO_NAME: &'static str = "__move_rt_type_info";
-static TD_VECTOR_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_vec";
-static TD_STRUCT_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_struct";
-static TD_REFERENCE_TYPE_INFO_NAME: &'static str = "__move_rt_type_info_ref";
+static TD_NAME: & str = "__move_rt_type";
+static TD_TYPE_NAME_NAME: & str = "__move_rt_type_name";
+static TD_TYPE_INFO_NAME: & str = "__move_rt_type_info";
+static TD_VECTOR_TYPE_INFO_NAME: & str = "__move_rt_type_info_vec";
+static TD_STRUCT_TYPE_INFO_NAME: & str = "__move_rt_type_info_struct";
+static TD_REFERENCE_TYPE_INFO_NAME: & str = "__move_rt_type_info_ref";
 
 pub fn get_llvm_tydesc_type(llcx: &llvm::Context) -> llvm::StructType {
     match llcx.named_struct_type(TD_NAME) {
@@ -75,15 +75,14 @@ fn tydesc_constant(llcx: &llvm::Context, llmod: &llvm::Module, mty: &mty::Type) 
         let ll_global_type_info = define_type_info_global(llcx, llmod, mty);
         ll_global_type_info.ptr()
     };
-    let ll_const = llcx.const_named_struct(
+    llcx.const_named_struct(
         &[
             ll_const_type_name,
             ll_const_type_descrim,
             ll_const_type_info_ptr,
         ],
         TD_NAME,
-    );
-    ll_const
+    )
 }
 
 fn type_name_constant(
@@ -113,9 +112,7 @@ fn type_name_constant(
     let ll_ty_u64 = llcx.int64_type();
     let ll_const_len = llvm::Constant::int(ll_ty_u64, len as u64);
 
-    let ll_const_struct = llcx.const_struct(&[ll_static_bytes_ptr, ll_const_len]);
-
-    ll_const_struct
+    llcx.const_struct(&[ll_static_bytes_ptr, ll_const_len])
 }
 
 fn type_name(mty: &mty::Type) -> String {
@@ -125,7 +122,7 @@ fn type_name(mty: &mty::Type) -> String {
         _ => todo!(),
     };
 
-    format!("{name}")
+    name.to_string()
 }
 
 /// The values here correspond to `move_native::rt_types::TypeDesc`.

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -1251,8 +1251,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 }
             };
 
-            self
-                .llvm_module
+            self.llvm_module
                 .add_function_with_attrs(&name, llty, &attrs)
         }
     }
@@ -1272,9 +1271,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 (llty, attrs)
             };
 
-            self
-                .llvm_module
-                .add_function_with_attrs(name, llty, &attrs)
+            self.llvm_module.add_function_with_attrs(name, llty, &attrs)
         };
         //
         let param_ty = self.llvm_cx.int64_type();

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -182,7 +182,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
     }
 
     fn declare_move_function(&mut self, fn_env: &mm::FunctionEnv) {
-        let fn_data = StacklessBytecodeGenerator::new(&fn_env).generate_function();
+        let fn_data = StacklessBytecodeGenerator::new(fn_env).generate_function();
 
         let ll_fn = {
             let ll_fnty = {
@@ -196,8 +196,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                             .iter()
                             .map(|f| self.llvm_type(f))
                             .collect();
-                        let rty = self.llvm_cx.get_anonymous_struct_type(&tys);
-                        rty
+                        self.llvm_cx.get_anonymous_struct_type(&tys)
                     }
                 };
 
@@ -221,7 +220,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
     fn declare_native_function(&mut self, fn_env: &mm::FunctionEnv) {
         assert!(fn_env.is_native());
 
-        let fn_data = StacklessBytecodeGenerator::new(&fn_env).generate_function();
+        let fn_data = StacklessBytecodeGenerator::new(fn_env).generate_function();
 
         let ll_fn = {
             let ll_fnty = {
@@ -277,8 +276,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             Type::Primitive(PrimitiveType::U256) => self.llvm_cx.int256_type(),
             Type::Reference(_, referent_mty) => {
                 let referent_llty = self.llvm_type(referent_mty);
-                let llty = referent_llty.ptr_type();
-                llty
+                referent_llty.ptr_type()
             }
             Type::TypeParameter(_) => {
                 // this is ok for now, while type params are only passed by reference,
@@ -315,7 +313,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         let locals = Vec::with_capacity(fn_env.get_local_count());
         FunctionContext {
             env: fn_env,
-            llvm_cx: &self.llvm_cx,
+            llvm_cx: self.llvm_cx,
             llvm_module: &self.llvm_module,
             llvm_builder: &self.llvm_builder,
             llvm_type: Box::new(|ty| self.llvm_type(ty)),
@@ -353,7 +351,7 @@ struct Local {
     llval: llvm::Alloca,
 }
 
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub enum EmitterFnKind {
     PreCheck,
     PostCheck,
@@ -368,7 +366,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let fn_data = StacklessBytecodeGenerator::new(&self.env).generate_function();
 
         // Write the control flow graph to a .dot file for viewing.
-        if dot_info != "" {
+        if !dot_info.is_empty() {
             let func_target =
                 move_stackless_bytecode::function_target::FunctionTarget::new(&self.env, &fn_data);
             let fname = &self.env.llvm_symbol_name();
@@ -399,13 +397,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
 
             // Create basic blocks for move labels
             for instr in &fn_data.code {
-                match instr {
-                    sbc::Bytecode::Label(_, label) => {
-                        let name = format!("bb_{}", label.as_usize());
-                        let llbb = ll_fn.append_basic_block(&name);
-                        self.label_blocks.insert(*label, llbb);
-                    }
-                    _ => {}
+                if let sbc::Bytecode::Label(_, label) = instr {
+                    let name = format!("bb_{}", label.as_usize());
+                    let llbb = ll_fn.append_basic_block(&name);
+                    self.label_blocks.insert(*label, llbb);
                 }
             }
 
@@ -953,11 +948,11 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 );
             }
             Operation::Mul => {
-                let src0_reg = self.load_reg(src[0], &format!("mul_src_0"));
-                let src1_reg = self.load_reg(src[1], &format!("mul_src_1"));
+                let src0_reg = self.load_reg(src[0], "mul_src_0");
+                let src1_reg = self.load_reg(src[1], "mul_src_1");
                 let src0_llty = &self.locals[src[0]].llty;
                 let dst_val = self.llvm_builder.build_intrinsic_call(
-                    &self.llvm_module,
+                    self.llvm_module,
                     "llvm.umul.with.overflow",
                     &[*src0_llty],
                     &[src0_reg, src1_reg],
@@ -1256,17 +1251,16 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 }
             };
 
-            let llfn = self
+            self
                 .llvm_module
-                .add_function_with_attrs(&name, llty, &attrs);
-            llfn
+                .add_function_with_attrs(&name, llty, &attrs)
         }
     }
 
     fn emit_rtcall_abort_raw(&self, val: u64) {
         // TODO: Refactor get_runtime_function to avoid the below partial duplication.
         let name = "move_rt_abort";
-        let llfn = self.llvm_module.get_named_function(&name);
+        let llfn = self.llvm_module.get_named_function(name);
         let thefn = if let Some(llfn) = llfn {
             llfn
         } else {
@@ -1278,10 +1272,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 (llty, attrs)
             };
 
-            let llfn = self
+            self
                 .llvm_module
-                .add_function_with_attrs(&name, llty, &attrs);
-            llfn
+                .add_function_with_attrs(name, llty, &attrs)
         };
         //
         let param_ty = self.llvm_cx.int64_type();

--- a/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
@@ -30,6 +30,10 @@ use crate::LLVMReference;
 // }
 // and will be called before LLVM calls C exit()
 /// Installs an error handler to be called before LLVM exits.
+///
+/// # Safety
+///
+/// Unclear.
 pub unsafe fn install_fatal_error_handler(handler: extern "C" fn(*const ::libc::c_char)) {
     LLVMInstallFatalErrorHandler(Some(handler))
 }
@@ -54,10 +58,7 @@ impl DiagnosticInfo {
 
     pub(crate) fn severity_is_error(&self) -> bool {
         unsafe {
-            match LLVMGetDiagInfoSeverity(self.diagnostic_info) {
-                LLVMDiagnosticSeverity::LLVMDSError => true,
-                _ => false,
-            }
+            matches!(LLVMGetDiagInfoSeverity(self.diagnostic_info), LLVMDiagnosticSeverity::LLVMDSError)
         }
     }
 }

--- a/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/error_handling.rs
@@ -58,7 +58,10 @@ impl DiagnosticInfo {
 
     pub(crate) fn severity_is_error(&self) -> bool {
         unsafe {
-            matches!(LLVMGetDiagInfoSeverity(self.diagnostic_info), LLVMDiagnosticSeverity::LLVMDSError)
+            matches!(
+                LLVMGetDiagInfoSeverity(self.diagnostic_info),
+                LLVMDiagnosticSeverity::LLVMDSError
+            )
         }
     }
 }

--- a/language/tools/move-mv-llvm-compiler/src/support/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/mod.rs
@@ -37,7 +37,7 @@ impl LLVMString {
     /// as much as possible to save memory since it is allocated by
     /// LLVM. It's essentially a `CString` with a custom LLVM
     /// deallocator
-    pub fn to_string(&self) -> String {
+    pub fn to_rust_string(&self) -> String {
         (*self).to_string_lossy().into_owned()
     }
 
@@ -124,6 +124,8 @@ impl PartialEq for LLVMStringOrRaw {
     }
 }
 
+/// # Safety
+///
 /// This function is very unsafe. Any reference to LLVM data after this function is called will likey segfault.
 /// Probably only ever useful to call before your program ends. Might not even be absolutely necessary.
 pub unsafe fn shutdown_llvm() {
@@ -155,13 +157,13 @@ pub fn enable_llvm_pretty_stack_trace() {
 /// A) Finds a terminating null byte in the Rust string and can reference it directly like a C string.
 ///
 /// B) Finds no null byte and allocates a new C string based on the input Rust string.
-pub fn to_c_str<'s>(mut s: &'s str) -> Cow<'s, CStr> {
+pub fn to_c_str(mut s: &str) -> Cow<'_, CStr> {
     if s.is_empty() {
         s = "\0";
     }
 
     // Start from the end of the string as it's the most likely place to find a null byte
-    if s.chars().rev().find(|&ch| ch == '\0').is_none() {
+    if !s.chars().rev().any(|ch| ch == '\0') {
         return Cow::from(CString::new(s).expect("unreachable since null bytes are checked"));
     }
 

--- a/language/tools/move-mv-llvm-compiler/src/support/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/support/mod.rs
@@ -157,6 +157,16 @@ pub fn enable_llvm_pretty_stack_trace() {
 /// A) Finds a terminating null byte in the Rust string and can reference it directly like a C string.
 ///
 /// B) Finds no null byte and allocates a new C string based on the input Rust string.
+///
+/// # Safety
+///
+/// This function is extremely prone to use after free:
+///
+/// If `as_ptr` is called on the return value, and the return value is not assigned
+/// to a stack variable first, then the return value is freed as a temporary while
+/// the pointer dangles.
+///
+/// This function should not be used. Use the `SafeCStr` extension trait instead.
 pub fn to_c_str(mut s: &str) -> Cow<'_, CStr> {
     if s.is_empty() {
         s = "\0";

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -113,7 +113,6 @@ fn get_test_plan(test_path: &Path) -> anyhow::Result<TestPlan> {
     let mvir_file = Path::new(&manifest_dir).join(test_path);
 
     let name = test_path.to_string_lossy().to_string();
-    let mvir_file = mvir_file.to_owned();
     let mvbc_file = mvir_file.with_extension("mv");
     let llir_file = mvir_file.with_extension("actual.ll");
     let llir_file_expected = mvir_file.with_extension("expected.ll");

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
@@ -109,7 +109,7 @@ fn compile_all_bytecode_to_llvm_ir(
 fn maybe_promote_actual_llvm_ir_to_expected(
     compilation_units: &[tc::CompilationUnit],
 ) -> anyhow::Result<()> {
-    if !std::env::var("PROMOTE_LLVM_IR").is_ok() {
+    if std::env::var("PROMOTE_LLVM_IR").is_err() {
         return Ok(());
     }
 

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -203,7 +203,7 @@ fn link_object_files(
     cmd.arg("--threads=1");
     cmd.arg("-znotext");
     cmd.arg("-znoexecstack");
-    cmd.args(&["--script", &link_script]);
+    cmd.args(["--script", &link_script]);
     cmd.arg("--gc-sections");
     cmd.arg("-shared");
     cmd.arg("--Bstatic");
@@ -260,10 +260,8 @@ fn run_rbpf(test_plan: &tc::TestPlan, exe: &Path) -> anyhow::Result<()> {
     let result = Result::from(result);
 
     // If that test plan expected an abort, make sure an abort actually occurred.
-    if let Some(_) = test_plan.abort_code() {
-        if let Ok(_) = result {
-            panic!("test plan expected an abort, but it did not occur.");
-        }
+    if test_plan.abort_code().is_some() && result.is_ok() {
+        panic!("test plan expected an abort, but it did not occur.");
     }
 
     let events = vm.env.context_object_pointer.events.clone();

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -56,7 +56,7 @@ pub fn get_harness_paths(dep: &str) -> anyhow::Result<HarnessPaths> {
 
 pub fn build_crate(crate_name: &str) {
     assert!(Command::new("cargo")
-        .args(&["build", "-p", crate_name])
+        .args(["build", "-p", crate_name])
         .status()
         .expect("Failed to build {crate_name}")
         .success());
@@ -111,7 +111,6 @@ pub fn get_test_plan(test_path: &Path) -> anyhow::Result<TestPlan> {
     let move_file = Path::new(&manifest_dir).join(test_path);
 
     let name = test_path.to_string_lossy().to_string();
-    let move_file = move_file.to_owned();
     let stem = move_file.file_stem().expect("stem").to_string_lossy();
     let build_dir = move_file.with_file_name(format!("{}-build", stem));
     let directives = load_directives(test_path)?;
@@ -139,12 +138,12 @@ fn load_directives(test_path: &Path) -> anyhow::Result<Vec<TestDirective>> {
             directives.push(TestDirective::Ignore);
         }
         if line.starts_with("abort ") {
-            let code = line.split(" ").skip(1).next().expect("abort code");
+            let code = line.split(' ').nth(1).expect("abort code");
             let code = code.parse().expect("u64");
             directives.push(TestDirective::Abort(code));
         }
         if line.starts_with("log ") {
-            let s = line.split(" ").skip(1).next().expect("log value");
+            let s = line.split(' ').nth(1).expect("log value");
             directives.push(TestDirective::Log(s.to_string()));
         }
     }
@@ -157,7 +156,7 @@ pub fn run_move_build(harness_paths: &HarnessPaths, test_plan: &TestPlan) -> any
     let mut cmd = Command::new(&harness_paths.dep);
     cmd.arg(&test_plan.move_file);
     cmd.args(["--flavor", "none"]);
-    cmd.args(["--out-dir", &test_plan.build_dir.to_str().expect("utf-8")]);
+    cmd.args(["--out-dir", test_plan.build_dir.to_str().expect("utf-8")]);
 
     let output = cmd.output()?;
     if !output.status.success() {
@@ -207,7 +206,7 @@ pub fn find_compilation_units(test_plan: &TestPlan) -> anyhow::Result<Vec<Compil
         for dirent in fs::read_dir(&dir)? {
             let dirent = dirent?;
             let path = dirent.path();
-            if path.extension() != Some(&OsStr::new("mv")) {
+            if path.extension() != Some(OsStr::new("mv")) {
                 continue;
             }
 
@@ -239,7 +238,7 @@ fn clean_build_dir(test_plan: &TestPlan) -> anyhow::Result<()> {
         for dirent in fs::read_dir(&dir)? {
             let dirent = dirent?;
             let path = dirent.path();
-            if path.extension() == Some(&OsStr::new("mv")) {
+            if path.extension() == Some(OsStr::new("mv")) {
                 fs::remove_file(&path)?;
             }
         }
@@ -270,8 +269,8 @@ pub fn compile_all_bytecode(
         cmd.arg("-b");
         cmd.arg(&cu.bytecode);
         cmd.arg("-o");
-        cmd.arg(&outfile(&cu));
-        cmd.arg(&outtype_flag);
+        cmd.arg(&outfile(cu));
+        cmd.arg(outtype_flag);
 
         if cu.type_ == CompilationUnitType::Script {
             cmd.arg("-s");


### PR DESCRIPTION
Upstream runs a custom `x clippy` command to drive `cargo clippy` that does a bunch of customization to how clippy is invoked. This PR makes `cargo x clippy` work again and enables it on CI.

For the most part I have just accepted all of clippy's suggestions as configured by upstream, with two exceptions:

`evm-exec-utils` contains a line that does not trigger clippy on upstream's main branch, but surprisingly does on ours. I can find no reason for the discrepancy and currently attribute it to a bug in clippy. I have resolved this problem in a way that will make it obvious to future rebasers:

```
    // (solana) this clippy failure mysteriously does not trigger upstream
    #[allow(clippy::or_fun_call)]
    let pipe = child.stdin.as_mut().ok_or(anyhow!("cannot create pipe"))?;
```

The `move_bpf_module` and `disassembler` modules contain a number of public functions that dereference raw pointers but are not declared unsafe. This is unsound because external callers could pass in a bad pointer and cause memory unsafety. I have opted not to fix these because these two modules are unused in the stackless translation; and instead marked them `#[allow(clippy::not_unsafe_ptr_arg)]`. If desired these modules can be removed in the future.

Also, the llvm-extra-sys bindings contain some definitions translated from the Rust source tree. These translations contained some unbound lifetimes that stem from differences between Rust's LLVM bindings and llvm-sys, specifically that llvm-sys does not expose a non-ref LLVMAttribute type, which Rust was using to tie the lifetimes of an LLVMValue and an LLVMAttribute:

Rust's:

```
pub fn AddFunctionAttributes<'ll>(llfn: &'ll Value, idx: AttributePlace, attrs: &[&'ll Attribute]) {
    unsafe {
        LLVMRustAddFunctionAttributes(llfn, idx.as_uint(), attrs.as_ptr(), attrs.len());
    }
}
```

Ours:

```
pub unsafe fn AddFunctionAttributes<'ll>(
    llfn: LLVMValueRef,
    idx: AttributePlace,
    attrs: &[LLVMAttributeRef],
) {
    unsafe {
        LLVMRustAddFunctionAttributes(llfn, idx.as_uint(), attrs.as_ptr(), attrs.len());
    }
}
```

Since we don't have an `LLVMAttribute` to attach a lifetime to I just removed the `'ll` lifetime.

Fixes https://github.com/solana-labs/move/issues/110