### PR TITLE
Implement initial support for Move structs.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -327,14 +327,19 @@ impl Builder {
                 struct_ty.0,
                 tmp_reg,
                 offset as libc::c_uint,
-                "fld_ref".cstr()
+                "fld_ref".cstr(),
             );
             LLVMBuildStore(self.0, field_ptr, dst.0);
         }
     }
 
     // Load the source fields, insert them into a new struct value, then store the struct value.
-    pub fn insert_fields_and_store(&self, src: &[(Type, Alloca)], dst: (Type, Alloca), stype: StructType) {
+    pub fn insert_fields_and_store(
+        &self,
+        src: &[(Type, Alloca)],
+        dst: (Type, Alloca),
+        stype: StructType,
+    ) {
         unsafe {
             let loads = src
                 .iter()
@@ -351,23 +356,31 @@ impl Builder {
                 agg_val = LLVMBuildInsertValue(self.0, agg_val, loads[i], i as libc::c_uint, s);
             }
 
-            assert_eq!(LLVMTypeOf(agg_val), dst.0.0);
-            LLVMBuildStore(self.0, agg_val, dst.1.0);
+            assert_eq!(LLVMTypeOf(agg_val), dst.0 .0);
+            LLVMBuildStore(self.0, agg_val, dst.1 .0);
         }
     }
 
     // Load the source struct, extract fields , then store each field in a local.
-    pub fn load_and_extract_fields(&self, src: (Type, Alloca), dst: &[(Type, Alloca)], stype: StructType) {
+    pub fn load_and_extract_fields(
+        &self,
+        src: (Type, Alloca),
+        dst: &[(Type, Alloca)],
+        stype: StructType,
+    ) {
         unsafe {
             //let tmp_reg = LLVMBuildLoad2(self.0, src.0.ptr_type().0, src.1.0, "tmp".cstr());
             //let srcval = LLVMBuildLoad2(self.0, stype.0, tmp_reg, "srcval".cstr());
-            assert_eq!(src.0.0, stype.0);
-            let srcval = LLVMBuildLoad2(self.0, stype.0, src.1.0, "srcval".cstr());
+            assert_eq!(src.0 .0, stype.0);
+            let srcval = LLVMBuildLoad2(self.0, stype.0, src.1 .0, "srcval".cstr());
 
             // The LLVM struct currently has one additional compiler-generated field. We won't
             // extract that for an unpack.
             let user_field_count = dst.len();
-            assert_eq!(user_field_count + 1, LLVMCountStructElementTypes(stype.0) as usize);
+            assert_eq!(
+                user_field_count + 1,
+                LLVMCountStructElementTypes(stype.0) as usize
+            );
 
             let mut extracts = Vec::with_capacity(user_field_count);
             for i in 0..user_field_count {
@@ -377,8 +390,11 @@ impl Builder {
             }
 
             for i in 0..user_field_count {
-                assert_eq!(dst[i].0.0, LLVMStructGetTypeAtIndex(stype.0, i as libc::c_uint));
-                LLVMBuildStore(self.0, extracts[i], dst[i].1.0);
+                assert_eq!(
+                    dst[i].0 .0,
+                    LLVMStructGetTypeAtIndex(stype.0, i as libc::c_uint)
+                );
+                LLVMBuildStore(self.0, extracts[i], dst[i].1 .0);
             }
         }
     }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -351,9 +351,9 @@ impl Builder {
                 .collect::<Vec<_>>();
 
             let mut agg_val = LLVMGetUndef(stype.0);
-            for i in 0..loads.len() {
+            for (i, ld) in loads.iter().enumerate() {
                 let s = format!("insert_{i}").cstr();
-                agg_val = LLVMBuildInsertValue(self.0, agg_val, loads[i], i as libc::c_uint, s);
+                agg_val = LLVMBuildInsertValue(self.0, agg_val, *ld, i as libc::c_uint, s);
             }
 
             assert_eq!(LLVMTypeOf(agg_val), dst.0 .0);

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -369,8 +369,6 @@ impl Builder {
         stype: StructType,
     ) {
         unsafe {
-            //let tmp_reg = LLVMBuildLoad2(self.0, src.0.ptr_type().0, src.1.0, "tmp".cstr());
-            //let srcval = LLVMBuildLoad2(self.0, stype.0, tmp_reg, "srcval".cstr());
             assert_eq!(src.0 .0, stype.0);
             let srcval = LLVMBuildLoad2(self.0, stype.0, src.1 .0, "srcval".cstr());
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -317,6 +317,72 @@ impl Builder {
         }
     }
 
+    /// Load a struct pointer alloca, add a field offset to it, and store the new pointer value.
+    pub fn field_ref_store(&self, src: Alloca, dst: Alloca, struct_ty: StructType, offset: usize) {
+        unsafe {
+            let ty = src.llvm_type().0;
+            let tmp_reg = LLVMBuildLoad2(self.0, ty, src.0, "tmp".cstr());
+            let field_ptr = LLVMBuildStructGEP2(
+                self.0,
+                struct_ty.0,
+                tmp_reg,
+                offset as libc::c_uint,
+                "fld_ref".cstr()
+            );
+            LLVMBuildStore(self.0, field_ptr, dst.0);
+        }
+    }
+
+    // Load the source fields, insert them into a new struct value, then store the struct value.
+    pub fn insert_fields_and_store(&self, src: &[(Type, Alloca)], dst: (Type, Alloca), stype: StructType) {
+        unsafe {
+            let loads = src
+                .iter()
+                .enumerate()
+                .map(|(i, (ty, val))| {
+                    let name = format!("fv.{i}");
+                    LLVMBuildLoad2(self.0, ty.0, val.0, name.cstr())
+                })
+                .collect::<Vec<_>>();
+
+            let mut agg_val = LLVMGetUndef(stype.0);
+            for i in 0..loads.len() {
+                let s = format!("insert_{i}").cstr();
+                agg_val = LLVMBuildInsertValue(self.0, agg_val, loads[i], i as libc::c_uint, s);
+            }
+
+            assert_eq!(LLVMTypeOf(agg_val), dst.0.0);
+            LLVMBuildStore(self.0, agg_val, dst.1.0);
+        }
+    }
+
+    // Load the source struct, extract fields , then store each field in a local.
+    pub fn load_and_extract_fields(&self, src: (Type, Alloca), dst: &[(Type, Alloca)], stype: StructType) {
+        unsafe {
+            //let tmp_reg = LLVMBuildLoad2(self.0, src.0.ptr_type().0, src.1.0, "tmp".cstr());
+            //let srcval = LLVMBuildLoad2(self.0, stype.0, tmp_reg, "srcval".cstr());
+            assert_eq!(src.0.0, stype.0);
+            let srcval = LLVMBuildLoad2(self.0, stype.0, src.1.0, "srcval".cstr());
+
+            // The LLVM struct currently has one additional compiler-generated field. We won't
+            // extract that for an unpack.
+            let user_field_count = dst.len();
+            assert_eq!(user_field_count + 1, LLVMCountStructElementTypes(stype.0) as usize);
+
+            let mut extracts = Vec::with_capacity(user_field_count);
+            for i in 0..user_field_count {
+                let name = format!("ext_{i}");
+                let ev = LLVMBuildExtractValue(self.0, srcval, i as libc::c_uint, name.cstr());
+                extracts.push(ev);
+            }
+
+            for i in 0..user_field_count {
+                assert_eq!(dst[i].0.0, LLVMStructGetTypeAtIndex(stype.0, i as libc::c_uint));
+                LLVMBuildStore(self.0, extracts[i], dst[i].1.0);
+            }
+        }
+    }
+
     /// Load a pointer alloca, dereference, and store the value.
     pub fn load_deref_store(&self, ty: Type, src: Alloca, dst: Alloca) {
         unsafe {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -39,7 +39,7 @@ use move_stackless_bytecode::{
     stackless_control_flow_graph::generate_cfg_in_dot_format,
 };
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     iter,
 };
 
@@ -131,6 +131,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         let filename = self.env.get_source_path().to_str().expect("utf-8");
         self.llvm_module.set_source_file_name(filename);
 
+        self.declare_structs();
         self.declare_functions();
 
         for fn_env in self.env.get_functions() {
@@ -144,6 +145,145 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         self.llvm_module.verify();
 
         self.llvm_module
+    }
+
+    /// Generate LLVM IR struct declarations for all Move structures.
+    fn declare_structs(&mut self) {
+        use move_binary_format::access::ModuleAccess;
+        use move_binary_format::views::StructHandleView;
+        let m_env = &self.env;
+        let g_env = &m_env.env;
+
+        // Collect all the externally defined structures (transitively) used within this module.
+        //
+        // Note that the ModuleData at ModuleEnv::data is private, while the same ModuleData is
+        // public in GlobalEnv::module_data-- so we obtain it from the latter. We need access to
+        // this to efficiently discover foreign structs. There is not yet a model-provided routine
+        // as there is for foreign called functions.
+        let mut external_sqids = BTreeSet::new();
+        let mut worklist = VecDeque::new();
+        let mut visited = BTreeSet::new();
+        worklist.push_back(m_env.get_id());
+        while let Some(mid) = worklist.pop_front() {
+            let module_data = &g_env.module_data[mid.to_usize()];
+            for shandle in module_data.module.struct_handles().iter() {
+                let struct_view = StructHandleView::new(
+                    &module_data.module,
+                    shandle,
+                );
+                let declaring_module_env = g_env
+                    .find_module(&g_env.to_module_name(&struct_view.module_id()))
+                    .expect("undefined module");
+                let struct_env = declaring_module_env
+                    .find_struct(m_env.symbol_pool().make(struct_view.name().as_str()))
+                    .expect("undefined struct");
+                let qid = struct_env.get_qualified_id();
+                if qid.module_id != m_env.get_id() {
+                    if !visited.contains(&qid.module_id) {
+                        worklist.push_back(qid.module_id);
+                        external_sqids.insert(qid);
+                    }
+                }
+            }
+            visited.insert(mid);
+        }
+
+        // Create a combined list of all structs (external plus local).
+        let mut local_structs: Vec<_> = m_env.get_structs().collect();
+        let mut all_structs: Vec<_> = external_sqids
+            .iter()
+            .map(|q| g_env.get_struct_qid(*q))
+            .collect();
+        all_structs.append(&mut local_structs);
+
+        //self.dump_all_structs(&all_structs, false);
+
+        // Visit each struct definition, creating corresponding LLVM IR struct types.
+        //
+        // Note that struct defintions can depend on other struct definitions. Inconveniently, the
+        // order of structs given to us above by the model are not necessarily in topological order
+        // of dependence.  Since we'll need a structure type to translate structure fields during
+        // the visitation later, we need to ensure any dependent structure types are already
+        // available. One way would be to build a dependence graph of structs and visit the nodes
+        // topologically. A second way, which we adopt here, is to traverse the struct list twice.
+        // That is, on the first traversal, we create opaque structs (i.e., partially formed,
+        // deferring field translation). The second traversal will then fill in the struct bodies
+        // where it will have all structure types previously defined.
+        for s_env in &all_structs {
+            if !s_env.get_type_parameters().is_empty() {
+                todo!("generic structs not yet implemented");
+            }
+            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            self.llvm_cx.create_opaque_named_struct(&ll_name);
+        }
+
+        // Translate input IR representing Move struct MyMod::MyStruct:
+        //   struct MyStruct has { copy, drop, key, store } {
+        //       field1: type1, field2: type2, ..., fieldn: typeN
+        //   }
+        // to a LLVM IR structure type:
+        //   %struct.MyMod__MyStruct = type {
+        //       <llvm_type1>, <llvm_type2>, ..., <llvm_typeN>, <i8>
+        //   }
+        //
+        // Compiler synthesized informational fields are injected following the user fields.
+        //
+        // The target layout is convenient in that the user field offsets [0..N) in the input IR
+        // map one-to-one to values used to index into the LLVM struct with getelementptr,
+        // extractvalue, and insertvalue.
+        //
+        // Compiler synthesized fields:
+        //   <i8>   This Move struct's 'abilities'. A u8 bitvector corresponding to a
+        //          move_binary_format::AbilitySet. These can be used during runtime for various
+        //          safety checks.
+        //
+        // As the compiler evolves and the design comes into focus, additional fields may be added
+        // or existing fields changed or removed.
+        for s_env in &all_structs {
+            if !s_env.get_type_parameters().is_empty() {
+                todo!("generic structs not yet implemented");
+            }
+            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            let ll_sty = self.llvm_cx.named_struct_type(&ll_name).expect("no struct type");
+
+            // Visit each field in this struct, collecting field types.
+            let mut ll_field_tys = Vec::with_capacity(s_env.get_field_count() + 1);
+            for fld_env in s_env.get_fields() {
+              let ll_fld_type = self.llvm_type(&fld_env.get_type());
+              ll_field_tys.push(ll_fld_type);
+            }
+
+            // Append the 'abilities' field.
+            ll_field_tys.push(self.llvm_cx.int8_type());
+            ll_sty.set_struct_body(&ll_field_tys);
+        }
+
+        //self.dump_all_structs(&all_structs, true);
+    }
+
+    fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv) -> String {
+        let raw_name = s_env.get_full_name_str();
+        format!("struct.{}", raw_name.replace(":", "_"))
+    }
+
+    #[allow(dead_code)]
+    fn dump_all_structs(&self, all_structs: &Vec<mm::StructEnv>, is_post_translation: bool) {
+        for s_env in all_structs {
+            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            let prepost = if is_post_translation { "Translated" } else { "Translating" };
+            eprintln!("{} struct '{}' => '%{}'", prepost, s_env.get_full_name_str(), ll_name);
+            for fld_env in s_env.get_fields() {
+                eprintln!("offset {}: '{}', type {:?}", fld_env.get_offset(),
+                    fld_env.get_name().display(s_env.symbol_pool()), fld_env.get_type());
+                if is_post_translation {
+                    eprintln!("=>");
+                    let ll_fld_type = self.llvm_type(&fld_env.get_type());
+                    ll_fld_type.dump();
+                }
+            }
+            eprintln!("with abilities: {:?}", s_env.get_abilities());
+            eprintln!("");
+        }
     }
 
     /// Create LLVM function decls for all local functions and
@@ -283,6 +423,18 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                 // but might end up broken in the future.
                 self.llvm_cx.int8_type()
             }
+            Type::Struct(declaring_module_id, struct_id, _) => {
+                let global_env = &self.env.env;
+                let struct_env = global_env
+                    .get_module(*declaring_module_id)
+                    .into_struct(*struct_id);
+                let struct_name = self.ll_struct_name_from_raw_name(&struct_env);
+                if let Some(stype) = self.llvm_cx.named_struct_type(&struct_name) {
+                    stype.as_any_type()
+                } else {
+                    unreachable!("struct type for '{}' not found", &struct_name);
+                }
+            }
             _ => {
                 todo!("{mty:?}")
             }
@@ -318,6 +470,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             llvm_builder: &self.llvm_builder,
             llvm_type: Box::new(|ty| self.llvm_type(ty)),
             get_bitwidth: Box::new(|ty| self.get_bitwidth(ty)),
+            ll_struct_name_from_raw_name: Box::new(|s_env| self.ll_struct_name_from_raw_name(s_env)),
             fn_decls: &self.fn_decls,
             label_blocks: BTreeMap::new(),
             locals,
@@ -338,6 +491,7 @@ struct FunctionContext<'mm, 'up> {
     /// the effort.
     llvm_type: Box<dyn (Fn(&mty::Type) -> llvm::Type) + 'up>,
     get_bitwidth: Box<dyn (Fn(&mty::Type) -> u64) + 'up>,
+    ll_struct_name_from_raw_name: Box<dyn (Fn(&mm::StructEnv) -> String) + 'up>,
     fn_decls: &'up BTreeMap<mm::QualifiedId<mm::FunId>, llvm::Function>,
     label_blocks: BTreeMap<sbc::Label, llvm::BasicBlock>,
     /// Corresponds to FunctionData:local_types
@@ -345,6 +499,7 @@ struct FunctionContext<'mm, 'up> {
 }
 
 /// A stackless move local variable, translated as an llvm alloca
+#[derive(Clone)]
 struct Local {
     mty: mty::Type,
     llty: llvm::Type,
@@ -362,6 +517,10 @@ type CheckEmitterFn<'mm, 'up> = (
 );
 
 impl<'mm, 'up> FunctionContext<'mm, 'up> {
+    fn get_global_env(&self) -> &'mm mm::GlobalEnv {
+        self.env.module_env.env
+    }
+
     fn translate(mut self, dot_info: &'up String) {
         let fn_data = StacklessBytecodeGenerator::new(&self.env).generate_function();
 
@@ -448,7 +607,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         (self.get_bitwidth)(mty)
     }
 
-    fn translate_instruction(&self, instr: &sbc::Bytecode) {
+    fn translate_instruction(&mut self, instr: &sbc::Bytecode) {
         match instr {
             sbc::Bytecode::Assign(_, dst, src, sbc::AssignKind::Move) => {
                 let mty = &self.locals[*dst].mty;
@@ -470,7 +629,15 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     mty::Type::Reference(_, _) => {
                         self.llvm_builder.load_store(llty, src_llval, dst_llval);
                     }
-                    _ => todo!(),
+                    mty::Type::Struct(_, _, _) => {
+                        // A move renders the source location inaccessible, but the storage is
+                        // to be reused for the target. We simply replace the dest local's slot
+                        // with the source, so that all later references to dest use the original
+                        // space (the alloca) of the source. If the input IR is correct, then
+                        // src local slot should not be accessed again.
+                        self.locals[*dst] = self.locals[*src].clone();
+                    }
+                    _ => todo!("{mty:?}"),
                 }
             }
             sbc::Bytecode::Assign(_, dst, src, sbc::AssignKind::Copy) => {
@@ -490,7 +657,18 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     ) => {
                         self.llvm_builder.load_store(llty, src_llval, dst_llval);
                     }
-                    _ => todo!(),
+                    mty::Type::Struct(_, _, _) => {
+                        self.llvm_builder.load_store(llty, src_llval, dst_llval);
+                    }
+                    mty::Type::Reference(_, referent) => {
+                        match **referent {
+                            mty::Type::Struct(_, _, _) => {
+                                self.llvm_builder.load_store(llty, src_llval, dst_llval);
+                            }
+                            _ => todo!("{mty:?}"),
+                        }
+                    }
+                    _ => todo!("{mty:?}"),
                 }
             }
             sbc::Bytecode::Assign(_, dst, src, sbc::AssignKind::Store) => {
@@ -508,6 +686,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                         | mty::PrimitiveType::U128
                         | mty::PrimitiveType::U256,
                     ) => {
+                        self.llvm_builder.load_store(llty, src_llval, dst_llval);
+                    }
+                    mty::Type::Struct(_, _, _) => {
                         self.llvm_builder.load_store(llty, src_llval, dst_llval);
                     }
                     _ => todo!("{mty:#?}"),
@@ -894,6 +1075,56 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let dst_llval = self.locals[dst_idx].llval;
                 self.llvm_builder.ref_store(src_llval, dst_llval);
             }
+            Operation::BorrowField(mod_id, struct_id, _types, offset) => {
+                // We don't yet translate generic structs, so _types is unused.
+                assert_eq!(src.len(), 1);
+                assert_eq!(dst.len(), 1);
+                let src_llval = self.locals[src[0]].llval;
+                let dst_llval = self.locals[dst[0]].llval;
+                let struct_env = self
+                    .get_global_env()
+                    .get_module(*mod_id)
+                    .into_struct(*struct_id);
+                let struct_name = (self.ll_struct_name_from_raw_name)(&struct_env);
+                let stype = self.llvm_cx.named_struct_type(&struct_name).expect("no struct type");
+                self.llvm_builder.field_ref_store(src_llval, dst_llval, stype, *offset);
+            }
+            Operation::Pack(mod_id, struct_id, _types) => {
+                // We don't yet translate generic structs, so _types is unused.
+                let struct_env = self
+                    .get_global_env()
+                    .get_module(*mod_id)
+                    .into_struct(*struct_id);
+                assert_eq!(dst.len(), 1);
+                assert_eq!(src.len(), struct_env.get_field_count());
+                let struct_name = (self.ll_struct_name_from_raw_name)(&struct_env);
+                let stype = self.llvm_cx.named_struct_type(&struct_name).expect("no struct type");
+                let fvals = src
+                    .iter()
+                    .map(|i| (self.locals[*i].llty, self.locals[*i].llval))
+                    .collect::<Vec<_>>();
+                let dst_idx = dst[0];
+                let ldst = (self.locals[dst_idx].llty, self.locals[dst_idx].llval);
+                self.llvm_builder.insert_fields_and_store(&fvals, ldst, stype);
+            }
+            Operation::Unpack(mod_id, struct_id, _types) => {
+                // We don't yet translate generic structs, so _types is unused.
+                let struct_env = self
+                    .get_global_env()
+                    .get_module(*mod_id)
+                    .into_struct(*struct_id);
+                assert_eq!(src.len(), 1);
+                assert_eq!(dst.len(), struct_env.get_field_count());
+                let struct_name = (self.ll_struct_name_from_raw_name)(&struct_env);
+                let stype = self.llvm_cx.named_struct_type(&struct_name).expect("no struct type");
+                let fdstvals = dst
+                    .iter()
+                    .map(|i| (self.locals[*i].llty, self.locals[*i].llval))
+                    .collect::<Vec<_>>();
+                let src_idx = src[0];
+                let lsrc = (self.locals[src_idx].llty, self.locals[src_idx].llval);
+                self.llvm_builder.load_and_extract_fields(lsrc, &fdstvals, stype);
+            }
             Operation::Destroy => {
                 assert!(dst.is_empty());
                 assert_eq!(src.len(), 1);
@@ -901,7 +1132,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let mty = &self.locals[idx].mty;
                 match mty {
                     mty::Type::Primitive(_) => ( /* nop */ ),
-                    _ => todo!(),
+                    mty::Type::Struct(_, _, _) => ( /* nop */ ),
+                    mty::Type::Reference(_, _) => { /* nop */ },
+                    _ => todo!("{mty:?}"),
                 }
             }
             Operation::ReadRef => {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -190,8 +190,6 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             .collect();
         all_structs.append(&mut local_structs);
 
-        //self.dump_all_structs(&all_structs, false);
-
         // Visit each struct definition, creating corresponding LLVM IR struct types.
         //
         // Note that struct defintions can depend on other struct definitions. Inconveniently, the
@@ -254,8 +252,6 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             ll_field_tys.push(self.llvm_cx.int8_type());
             ll_sty.set_struct_body(&ll_field_tys);
         }
-
-        //self.dump_all_structs(&all_structs, true);
     }
 
     fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv) -> String {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -174,11 +174,9 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     .find_struct(m_env.symbol_pool().make(struct_view.name().as_str()))
                     .expect("undefined struct");
                 let qid = struct_env.get_qualified_id();
-                if qid.module_id != m_env.get_id() {
-                    if !visited.contains(&qid.module_id) {
-                        worklist.push_back(qid.module_id);
-                        external_sqids.insert(qid);
-                    }
+                if qid.module_id != m_env.get_id() && !visited.contains(&qid.module_id) {
+                    worklist.push_back(qid.module_id);
+                    external_sqids.insert(qid);
                 }
             }
             visited.insert(mid);
@@ -209,7 +207,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             if !s_env.get_type_parameters().is_empty() {
                 todo!("generic structs not yet implemented");
             }
-            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            let ll_name = self.ll_struct_name_from_raw_name(s_env);
             self.llvm_cx.create_opaque_named_struct(&ll_name);
         }
 
@@ -239,7 +237,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             if !s_env.get_type_parameters().is_empty() {
                 todo!("generic structs not yet implemented");
             }
-            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            let ll_name = self.ll_struct_name_from_raw_name(s_env);
             let ll_sty = self
                 .llvm_cx
                 .named_struct_type(&ll_name)
@@ -262,13 +260,13 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
 
     fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv) -> String {
         let raw_name = s_env.get_full_name_str();
-        format!("struct.{}", raw_name.replace(":", "_"))
+        format!("struct.{}", raw_name.replace(':', "_"))
     }
 
     #[allow(dead_code)]
     fn dump_all_structs(&self, all_structs: &Vec<mm::StructEnv>, is_post_translation: bool) {
         for s_env in all_structs {
-            let ll_name = self.ll_struct_name_from_raw_name(&s_env);
+            let ll_name = self.ll_struct_name_from_raw_name(s_env);
             let prepost = if is_post_translation {
                 "Translated"
             } else {
@@ -294,7 +292,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                 }
             }
             eprintln!("with abilities: {:?}", s_env.get_abilities());
-            eprintln!("");
+            eprintln!();
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -1,0 +1,29 @@
+; ModuleID = '0x100__M'
+source_filename = "<unknown>"
+
+%struct.M__MyStruct = type { i32, i1, %struct.M__EmptyStruct, i8 }
+%struct.M__EmptyStruct = type { i1, i8 }
+
+define %struct.M__MyStruct @M__boofun() {
+entry:
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca %struct.M__EmptyStruct, align 8
+  %local_4 = alloca %struct.M__MyStruct, align 8
+  store i32 32, ptr %local_0, align 4
+  store i1 true, ptr %local_1, align 1
+  store i1 false, ptr %local_2, align 1
+  %fv.0 = load i1, ptr %local_2, align 1
+  %insert_0 = insertvalue %struct.M__EmptyStruct undef, i1 %fv.0, 0
+  store %struct.M__EmptyStruct %insert_0, ptr %local_3, align 1
+  %fv.01 = load i32, ptr %local_0, align 4
+  %fv.1 = load i1, ptr %local_1, align 1
+  %fv.2 = load %struct.M__EmptyStruct, ptr %local_3, align 1
+  %insert_02 = insertvalue %struct.M__MyStruct undef, i32 %fv.01, 0
+  %insert_1 = insertvalue %struct.M__MyStruct %insert_02, i1 %fv.1, 1
+  %insert_2 = insertvalue %struct.M__MyStruct %insert_1, %struct.M__EmptyStruct %fv.2, 2
+  store %struct.M__MyStruct %insert_2, ptr %local_4, align 4
+  %retval = load %struct.M__MyStruct, ptr %local_4, align 4
+  ret %struct.M__MyStruct %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01.move
@@ -13,4 +13,3 @@ module 0x100::M {
         MyStruct { field1: 32, field2: true, field3: EmptyStruct {} }
     }
 }
-

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01.move
@@ -1,0 +1,16 @@
+
+module 0x100::M {
+
+    struct MyStruct {
+        field1: u32,
+        field2: bool,
+        field3: EmptyStruct
+    }
+
+    struct EmptyStruct {}
+
+    public fun boofun(): 0x100::M::MyStruct {
+        MyStruct { field1: 32, field2: true, field3: EmptyStruct {} }
+    }
+}
+

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -1,0 +1,135 @@
+; ModuleID = '0x100__Country'
+source_filename = "<unknown>"
+
+%struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
+%struct.Country__Dunno = type { i64, i8 }
+
+define i8 @Country__dropit(%struct.Country__Country %0) {
+entry:
+  %local_0 = alloca %struct.Country__Country, align 8
+  %local_1 = alloca %struct.Country__Country, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca %struct.Country__Dunno, align 8
+  store %struct.Country__Country %0, ptr %local_0, align 4
+  %srcval = load %struct.Country__Country, ptr %local_0, align 4
+  %ext_0 = extractvalue %struct.Country__Country %srcval, 0
+  %ext_1 = extractvalue %struct.Country__Country %srcval, 1
+  %ext_2 = extractvalue %struct.Country__Country %srcval, 2
+  store i8 %ext_0, ptr %local_2, align 1
+  store i64 %ext_1, ptr %local_3, align 4
+  store %struct.Country__Dunno %ext_2, ptr %local_4, align 4
+  %retval = load i8, ptr %local_2, align 1
+  ret i8 %retval
+}
+
+define i8 @Country__get_id(ptr %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_2, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_3, align 1
+  %retval = load i8, ptr %local_3, align 1
+  ret i8 %retval
+}
+
+define i64 @Country__get_phony_x(%struct.Country__Country %0) {
+entry:
+  %local_0 = alloca %struct.Country__Country, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i64, align 8
+  store %struct.Country__Country %0, ptr %local_0, align 4
+  store ptr %local_0, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 2
+  store ptr %fld_ref, ptr %local_2, align 8
+  %tmp1 = load ptr, ptr %local_2, align 8
+  %fld_ref2 = getelementptr inbounds %struct.Country__Dunno, ptr %tmp1, i32 0, i32 0
+  store ptr %fld_ref2, ptr %local_3, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_3, align 8
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
+  store i64 %load_deref_store_tmp2, ptr %local_4, align 4
+  %retval = load i64, ptr %local_4, align 4
+  ret i64 %retval
+}
+
+define i64 @Country__get_pop(%struct.Country__Country %0) {
+entry:
+  %local_0 = alloca %struct.Country__Country, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i64, align 8
+  store %struct.Country__Country %0, ptr %local_0, align 4
+  store ptr %local_0, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 1
+  store ptr %fld_ref, ptr %local_2, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_2, align 8
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
+  store i64 %load_deref_store_tmp2, ptr %local_3, align 4
+  %retval = load i64, ptr %local_3, align 4
+  ret i64 %retval
+}
+
+define %struct.Country__Country @Country__new_country(i8 %0, i64 %1) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca %struct.Country__Dunno, align 8
+  %local_6 = alloca %struct.Country__Country, align 8
+  store i8 %0, ptr %local_0, align 1
+  store i64 %1, ptr %local_1, align 4
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load i64, ptr %local_1, align 4
+  store i64 %load_store_tmp1, ptr %local_3, align 4
+  store i64 32, ptr %local_4, align 4
+  %fv.0 = load i64, ptr %local_4, align 4
+  %insert_0 = insertvalue %struct.Country__Dunno undef, i64 %fv.0, 0
+  store %struct.Country__Dunno %insert_0, ptr %local_5, align 4
+  %fv.02 = load i8, ptr %local_2, align 1
+  %fv.1 = load i64, ptr %local_3, align 4
+  %fv.2 = load %struct.Country__Dunno, ptr %local_5, align 4
+  %insert_03 = insertvalue %struct.Country__Country undef, i8 %fv.02, 0
+  %insert_1 = insertvalue %struct.Country__Country %insert_03, i64 %fv.1, 1
+  %insert_2 = insertvalue %struct.Country__Country %insert_1, %struct.Country__Dunno %fv.2, 2
+  store %struct.Country__Country %insert_2, ptr %local_6, align 4
+  %retval = load %struct.Country__Country, ptr %local_6, align 4
+  ret %struct.Country__Country %retval
+}
+
+define void @Country__set_id(ptr %0, i8 %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 %1, ptr %local_1, align 1
+  %load_store_tmp = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_3, align 8
+  %tmp = load ptr, ptr %local_3, align 8
+  %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_4, align 8
+  %load_store_ref_src = load i8, ptr %local_2, align 1
+  %load_store_ref_dst_ptr = load ptr, ptr %local_4, align 8
+  store i8 %load_store_ref_src, ptr %load_store_ref_dst_ptr, align 1
+  ret void
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -1,0 +1,57 @@
+; ModuleID = '0x200__UseIt'
+source_filename = "<unknown>"
+
+%struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
+%struct.Country__Dunno = type { i64, i8 }
+
+define void @UseIt__getit() {
+entry:
+  %local_0 = alloca %struct.Country__Country, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca %struct.Country__Country, align 8
+  %local_4 = alloca %struct.Country__Country, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i8, align 1
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca i8, align 1
+  %local_10 = alloca %struct.Country__Country, align 8
+  %local_11 = alloca i8, align 1
+  store i8 1, ptr %local_1, align 1
+  store i64 1000000, ptr %local_2, align 4
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load i64, ptr %local_2, align 4
+  %retval = call %struct.Country__Country @Country__new_country(i8 %call_arg_0, i64 %call_arg_1)
+  store %struct.Country__Country %retval, ptr %local_3, align 4
+  %load_store_tmp = load %struct.Country__Country, ptr %local_3, align 4
+  store %struct.Country__Country %load_store_tmp, ptr %local_0, align 4
+  %load_store_tmp1 = load %struct.Country__Country, ptr %local_0, align 4
+  store %struct.Country__Country %load_store_tmp1, ptr %local_4, align 4
+  %call_arg_02 = load %struct.Country__Country, ptr %local_4, align 4
+  %retval3 = call i64 @Country__get_pop(%struct.Country__Country %call_arg_02)
+  store i64 %retval3, ptr %local_5, align 4
+  store ptr %local_0, ptr %local_6, align 8
+  %call_arg_04 = load ptr, ptr %local_6, align 8
+  %retval5 = call i8 @Country__get_id(ptr %call_arg_04)
+  store i8 %retval5, ptr %local_7, align 1
+  store ptr %local_0, ptr %local_8, align 8
+  store i8 123, ptr %local_9, align 1
+  %call_arg_06 = load ptr, ptr %local_8, align 8
+  %call_arg_17 = load i8, ptr %local_9, align 1
+  call void @Country__set_id(ptr %call_arg_06, i8 %call_arg_17)
+  %call_arg_08 = load %struct.Country__Country, ptr %local_0, align 4
+  %retval9 = call i8 @Country__dropit(%struct.Country__Country %call_arg_08)
+  store i8 %retval9, ptr %local_11, align 1
+  ret void
+}
+
+declare i8 @Country__dropit(%struct.Country__Country)
+
+declare i8 @Country__get_id(ptr)
+
+declare i64 @Country__get_pop(%struct.Country__Country)
+
+declare %struct.Country__Country @Country__new_country(i8, i64)
+
+declare void @Country__set_id(ptr, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02.move
@@ -40,4 +40,3 @@ module 0x200::UseIt {
         Country::dropit(c2);
     }
 }
-

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02.move
@@ -1,0 +1,43 @@
+
+module 0x100::Country {
+    struct Dunno has drop, copy { x: u64 }
+    struct Country has drop, copy {
+        id: u8,
+        population: u64,
+        phony: Dunno
+    }
+    public fun new_country(i: u8, p: u64): Country {
+        Country { id: i, population: p, phony: Dunno { x: 32 } }
+    }
+    public fun get_pop(cc: Country): u64 {
+        cc.population
+    }
+    public fun get_phony_x(cc: Country): u64 {
+        cc.phony.x
+    }
+    public fun get_id(cc: &Country): u8 {
+        cc.id
+    }
+    public fun set_id(cc: &mut Country, t: u8) {
+        cc.id = t;
+    }
+    public fun dropit(cc: Country): u8 {
+        let Country { id: x, population: _y, phony: _z } = cc;
+        x
+    }
+}
+
+module 0x200::UseIt {
+    struct NotUsed {}
+    use 0x100::Country;
+
+    public fun getit() {
+        let c = Country::new_country(1, 1000000);
+        let c2 = c;
+        Country::get_pop(c2);
+        Country::get_id(&c2);
+        Country::set_id(&mut c2, 123);
+        Country::dropit(c2);
+    }
+}
+

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/multi-module.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/multi-module.move
@@ -17,7 +17,7 @@ script {
   fun main() {
     let a: u8 = 3;
     let b: u8 = 2;
-    let _c = 0x100::Test1::test1(a, b);
-    // assert!(c == 5);
+    let c = 0x100::Test1::test1(a, b);
+    assert!(c == 5, 10);
   }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-coin.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-coin.move
@@ -73,4 +73,3 @@ script {
         m::destroy_zero(mc1);
     }
 }
-

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-coin.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-coin.move
@@ -1,0 +1,76 @@
+
+// A slightly modified example from below, along with a driver script to test it.
+// https://move-language.github.io/move/structs-and-resources.html#example-1-coin
+
+module 0x102::m {
+    struct Coin has store {
+        value: u64,
+    }
+
+    public fun mint(value: u64): Coin {
+        // You would want to gate this function with some form of access control to prevent
+        // anyone using this module from minting an infinite amount of coins.
+        Coin { value }
+    }
+
+    public fun withdraw(coin: &mut Coin, amount: u64): Coin {
+        assert!(coin.value >= amount, 1000);
+        coin.value = coin.value - amount;
+        Coin { value: amount }
+    }
+
+    public fun deposit(coin: &mut Coin, other: Coin) {
+        let Coin { value } = other;
+        coin.value = coin.value + value;
+    }
+
+    public fun split(coin: Coin, amount: u64): (Coin, Coin) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    public fun merge(coin1: Coin, coin2: Coin): Coin {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+
+    public fun destroy_zero(coin: Coin) {
+        let Coin { value } = coin;
+        assert!(value == 0, 1001);
+    }
+
+    public fun get_value(coin: &Coin): u64 {
+      coin.value
+    }
+
+    public fun burn(coin: &mut Coin) {
+      coin.value = 0;
+    }
+}
+
+script {
+    use 0x102::m;
+
+    fun main() {
+        let c1 = m::mint(600);
+        assert!(m::get_value(&c1) == 600, 0xf00);
+
+        let c2 = m::withdraw(&mut c1, 200);
+        assert!(m::get_value(&c1) == 400, 0xf01);
+        assert!(m::get_value(&c2) == 200, 0xf02);
+
+        m::deposit(&mut c1, c2);
+        assert!(m::get_value(&c1) == 600, 0xf03);
+
+        let (sc1, sc2) = m::split(c1, 75);
+        assert!(m::get_value(&sc1) == 525, 0xf04);
+        assert!(m::get_value(&sc2) == 75, 0xf05);
+
+        let mc1 = m::merge(sc1, sc2);
+        assert!(m::get_value(&mc1) == 600, 0xf06);
+
+        m::burn(&mut mc1);
+        m::destroy_zero(mc1);
+    }
+}
+

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-fxpt32.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-fxpt32.move
@@ -1,0 +1,343 @@
+/// This test is taken directly from the Move stdlib, unmodified other
+/// than to add a driver script.
+///
+/// Defines a fixed-point numeric type with a 32-bit integer part and
+/// a 32-bit fractional part.
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+
+module 0x100::fixed_point32 {
+
+    /// Define a fixed-point numeric type with 32 fractional bits.
+    /// This is just a u64 integer but it is wrapped in a struct to
+    /// make a unique type. This is a binary representation, so decimal
+    /// values may not be exactly representable, but it provides more
+    /// than 9 decimal digits of precision both before and after the
+    /// decimal point (18 digits total). For comparison, double precision
+    /// floating-point has less than 16 decimal digits of precision, so
+    /// be careful about using floating-point to convert these values to
+    /// decimal.
+    struct FixedPoint32 has copy, drop, store { value: u64 }
+
+    ///> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
+    const MAX_U64: u128 = 18446744073709551615;
+
+    /// The denominator provided was zero
+    const EDENOMINATOR: u64 = 0x10001;
+    /// The quotient value would be too large to be held in a `u64`
+    const EDIVISION: u64 = 0x20002;
+    /// The multiplied value would be too large to be held in a `u64`
+    const EMULTIPLICATION: u64 = 0x20003;
+    /// A division by zero was encountered
+    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
+    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+
+    /// Multiply a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the product. This will abort if the product
+    /// overflows.
+    public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (val as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // Check whether the value is too large.
+        assert!(product <= MAX_U64, EMULTIPLICATION);
+        (product as u64)
+    }
+    spec multiply_u64 {
+        pragma opaque;
+        include MultiplyAbortsIf;
+        ensures result == spec_multiply_u64(val, multiplier);
+    }
+    spec schema MultiplyAbortsIf {
+        val: num;
+        multiplier: FixedPoint32;
+        aborts_if spec_multiply_u64(val, multiplier) > MAX_U64 with EMULTIPLICATION;
+    }
+    spec fun spec_multiply_u64(val: num, multiplier: FixedPoint32): num {
+        (val * multiplier.value) >> 32
+    }
+
+    /// Divide a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the quotient. This will abort if the divisor
+    /// is zero or if the quotient overflows.
+    public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
+        // Check for division by zero.
+        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (val as u128) << 32;
+        let quotient = scaled_value / (divisor.value as u128);
+        // Check whether the value is too large.
+        assert!(quotient <= MAX_U64, EDIVISION);
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u64)
+    }
+    spec divide_u64 {
+        pragma opaque;
+        include DivideAbortsIf;
+        ensures result == spec_divide_u64(val, divisor);
+    }
+    spec schema DivideAbortsIf {
+        val: num;
+        divisor: FixedPoint32;
+        aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
+        aborts_if spec_divide_u64(val, divisor) > MAX_U64 with EDIVISION;
+    }
+    spec fun spec_divide_u64(val: num, divisor: FixedPoint32): num {
+        (val << 32) / divisor.value
+    }
+
+    /// Create a fixed-point value from a rational number specified by its
+    /// numerator and denominator. Calling this function should be preferred
+    /// for using `Self::create_from_raw_value` which is also available.
+    /// This will abort if the denominator is zero. It will also
+    /// abort if the numerator is nonzero and the ratio is not in the range
+    /// 2^-32 .. 2^32-1. When specifying decimal fractions, be careful about
+    /// rounding errors: if you round to display N digits after the decimal
+    /// point, you can use a denominator of 10^N to avoid numbers where the
+    /// very small imprecision in the binary representation could change the
+    /// rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+    public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32 {
+        // If the denominator is zero, this will abort.
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        assert!(scaled_denominator != 0, EDENOMINATOR);
+        let quotient = scaled_numerator / scaled_denominator;
+        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        // Return the quotient as a fixed-point number. We first need to check whether the cast
+        // can succeed.
+        assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        FixedPoint32 { value: (quotient as u64) }
+    }
+    spec create_from_rational {
+        pragma opaque;
+        include CreateFromRationalAbortsIf;
+        ensures result == spec_create_from_rational(numerator, denominator);
+    }
+    spec schema CreateFromRationalAbortsIf {
+        numerator: u64;
+        denominator: u64;
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        let quotient = scaled_numerator / scaled_denominator;
+        aborts_if scaled_denominator == 0 with EDENOMINATOR;
+        aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
+        aborts_if quotient > MAX_U64 with ERATIO_OUT_OF_RANGE;
+    }
+    spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint32 {
+        FixedPoint32{value: (numerator << 64) / (denominator << 32)}
+    }
+
+    /// Create a fixedpoint value from a raw value.
+    public fun create_from_raw_value(value: u64): FixedPoint32 {
+        FixedPoint32 { value }
+    }
+    spec create_from_raw_value {
+        pragma opaque;
+        aborts_if false;
+        ensures result.value == value;
+    }
+
+    /// Accessor for the raw u64 value. Other less common operations, such as
+    /// adding or subtracting FixedPoint32 values, can be done using the raw
+    /// values directly.
+    public fun get_raw_value(num: FixedPoint32): u64 {
+        num.value
+    }
+
+    /// Returns true if the ratio is zero.
+    public fun is_zero(num: FixedPoint32): bool {
+        num.value == 0
+    }
+
+    /// Returns the smaller of the two FixedPoint32 numbers.
+    public fun min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec min {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_min(num1, num2);
+    }
+    spec fun spec_min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Returns the larger of the two FixedPoint32 numbers.
+    public fun max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec max {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_max(num1, num2);
+    }
+    spec fun spec_max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Create a fixedpoint value from a u64 value.
+    public fun create_from_u64(val: u64): FixedPoint32 {
+        let value = (val as u128) << 32;
+        assert!(value <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        FixedPoint32{value: (value as u64)}
+    }
+    spec create_from_u64 {
+        pragma opaque;
+        include CreateFromU64AbortsIf;
+        ensures result == spec_create_from_u64(val);
+    }
+    spec schema CreateFromU64AbortsIf {
+        val: num;
+        let scaled_value = (val as u128) << 32;
+        aborts_if scaled_value > MAX_U64;
+    }
+    spec fun spec_create_from_u64(val: num): FixedPoint32 {
+        FixedPoint32 {value: val << 32}
+    }
+
+    /// Returns the largest integer less than or equal to a given number.
+    public fun floor(num: FixedPoint32): u64 {
+        num.value >> 32
+    }
+    spec floor {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_floor(num);
+    }
+    spec fun spec_floor(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        if (fractional == 0) {
+            val.value >> 32
+        } else {
+            (val.value - fractional) >> 32
+        }
+    }
+
+    /// Rounds up the given FixedPoint32 to the next largest integer.
+    public fun ceil(num: FixedPoint32): u64 {
+        let floored_num = floor(num) << 32;
+        if (num.value == floored_num) {
+            return floored_num >> 32
+        };
+        let val = ((floored_num as u128) + (1 << 32));
+        (val >> 32 as u64)
+    }
+    spec ceil {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_ceil(num);
+    }
+    spec fun spec_ceil(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        let one = 1 << 32;
+        if (fractional == 0) {
+            val.value >> 32
+        } else {
+            (val.value - fractional + one) >> 32
+        }
+    }
+
+    /// Returns the value of a FixedPoint32 to the nearest integer.
+    public fun round(num: FixedPoint32): u64 {
+        let floored_num = floor(num) << 32;
+        let boundary = floored_num + ((1 << 32) / 2);
+        if (num.value < boundary) {
+            floored_num >> 32
+        } else {
+            ceil(num)
+        }
+    }
+    spec round {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_round(num);
+    }
+    spec fun spec_round(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        let boundary = (1 << 32) / 2;
+        let one = 1 << 32;
+        if (fractional < boundary) {
+            (val.value - fractional) >> 32
+        } else {
+            (val.value - fractional + one) >> 32
+        }
+    }
+
+    // **************** SPECIFICATIONS ****************
+
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+}
+
+script {
+    use 0x100::fixed_point32;
+
+    fun main() {
+        let f1 = fixed_point32::create_from_raw_value(0x00000001_20000000);
+        assert!(fixed_point32::get_raw_value(f1) == 0x00000001_20000000, 0xf01);
+        assert!(!fixed_point32::is_zero(f1), 0xf02);
+
+        let f2 = fixed_point32::create_from_raw_value(0x00000002_00000000);
+        let ft1 = fixed_point32::max(f1, f2);
+        assert!(fixed_point32::get_raw_value(ft1) == 0x00000002_00000000, 0xf03);
+        let ft2 = fixed_point32::min(f1, f2);
+        assert!(fixed_point32::get_raw_value(ft2) == 0x00000001_20000000, 0xf04);
+
+        let f3 = fixed_point32::create_from_raw_value(0x00000001_25000000);
+        let t3 = fixed_point32::floor(f3);
+        assert!(t3 == 1, 0xf05);
+
+        let t4 = fixed_point32::ceil(f1);
+        assert!(t4 == 2, 0xf06);
+
+        let f5 = fixed_point32::create_from_rational(1, 4);
+        let fm1 = fixed_point32::multiply_u64(32, f5);
+        assert!(fm1 == 8, 0xf07);
+
+        let f6 = fixed_point32::create_from_u64(65);
+        assert!(fixed_point32::get_raw_value(f6) == 0x00000041_00000000, 0xf08);
+
+        let f7 = fixed_point32::create_from_rational(2, 1);
+        let t5 = fixed_point32::round(f7);
+        assert!(t5 == 2, 0xf09);
+
+        let f8 = fixed_point32::create_from_rational(3, 4);
+        let t6 = fixed_point32::round(f8);
+        assert!(t6 == 1, 0xf0a);
+
+        let fd1 = fixed_point32::divide_u64(32, f5);
+        assert!(fd1 == 128, 0xf0b);
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-geom.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-geom.move
@@ -1,0 +1,80 @@
+
+// An example taken from:
+// https://move-language.github.io/move/structs-and-resources.html#example-2-geometry
+// Unmodified other than adding a driver script.
+
+module 0x100::point {
+    struct Point has copy, drop, store {
+        x: u64,
+        y: u64,
+    }
+
+    public fun new(x: u64, y: u64): Point {
+        Point {
+            x, y
+        }
+    }
+
+    public fun x(p: &Point): u64 {
+        p.x
+    }
+
+    public fun y(p: &Point): u64 {
+        p.y
+    }
+
+    fun abs_sub(a: u64, b: u64): u64 {
+        if (a < b) {
+            b - a
+        }
+        else {
+            a - b
+        }
+    }
+
+    public fun dist_squared(p1: &Point, p2: &Point): u64 {
+        let dx = abs_sub(p1.x, p2.x);
+        let dy = abs_sub(p1.y, p2.y);
+        dx*dx + dy*dy
+    }
+}
+
+module 0x100::circle {
+    use 0x100::point::{Self, Point};
+
+    struct Circle has copy, drop, store {
+        center: Point,
+        radius: u64,
+    }
+
+    public fun new(center: Point, radius: u64): Circle {
+        Circle { center, radius }
+    }
+
+    public fun overlaps(c1: &Circle, c2: &Circle): bool {
+        let d = point::dist_squared(&c1.center, &c2.center);
+        let r1 = c1.radius;
+        let r2 = c2.radius;
+        d*d <= r1*r1 + 2*r1*r2 + r2*r2
+    }
+}
+
+
+script {
+    use 0x100::circle;
+    use 0x100::point;
+
+    fun main() {
+        let p1 = point::new(12, 34);
+        assert!(point::x(&p1) == 12, 0xf00);
+        assert!(point::y(&p1) == 34, 0xf01);
+
+        let p2 = point::new(0, 10);
+        let p3 = point::new(10, 0);
+        assert!(point::dist_squared(&p2, &p3) == 200, 0xf02);
+
+        let c1 = circle::new(point::new(0, 0), 30);
+        let c2 = circle::new(point::new(10, 0), 100);
+        assert!(circle::overlaps(&c1, &c2), 0xf03);
+    }
+}


### PR DESCRIPTION
This patch implements support for concrete, local struct definitions and usage.
Structs are an involved piece of functionality and consist of 3 main parts:
- Basic concrete structs, defined and used in local scopes (this patch).
- Generic structs (parameterized by types).
- Connection to persistent/global storage.

Generics and global storage are left as future patches. The latter will require
significant discussion and design, as this is where we will need to actually
integrate with the Solana data model.

For local structs, we do the simplest thing possible and treat them as PODs
that are stack-allocated like all other locals. This makes the correspondence
to LLVM IR structs similar to how they would be translated for C++ PODs.

The scheme will need modification or extension to support generics-- at least
if we do not use static instantiations (i.e., when all type parameters are
provided and known to the compiler).

It is not yet clear what modifications will be needed to connect to global
storage. As near as I can tell, Move (at least on Aptos and Sui) always
ser/des global data out/in on access. Under the hood, we can do the same,
where local structs are materialized with the deserialized data, and operated
on as usual. Or any other number of schemes.

One runnable rbpf test is included, where many features have to be correct
for it to possibly run correctly. More runnable and static tests will be
added over time.