### PR TITLE
Fix shift range check defect; add more runtime tests.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -58,7 +58,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shl_src_0 = load i128, ptr %local_2, align 4
   %shl_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shl_src_1, 8
+  %rangecond = icmp uge i8 %shl_src_1, -128
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry
@@ -88,7 +88,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shl_src_0 = load i32, ptr %local_2, align 4
   %shl_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shl_src_1, 8
+  %rangecond = icmp uge i8 %shl_src_1, 32
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry
@@ -118,7 +118,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shl_src_0 = load i64, ptr %local_2, align 4
   %shl_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shl_src_1, 8
+  %rangecond = icmp uge i8 %shl_src_1, 64
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry
@@ -177,7 +177,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shr_src_0 = load i128, ptr %local_2, align 4
   %shr_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shr_src_1, 8
+  %rangecond = icmp uge i8 %shr_src_1, -128
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry
@@ -207,7 +207,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shr_src_0 = load i32, ptr %local_2, align 4
   %shr_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shr_src_1, 8
+  %rangecond = icmp uge i8 %shr_src_1, 32
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry
@@ -237,7 +237,7 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %shr_src_0 = load i64, ptr %local_2, align 4
   %shr_src_1 = load i8, ptr %local_3, align 1
-  %rangecond = icmp uge i8 %shr_src_1, 8
+  %rangecond = icmp uge i8 %shr_src_1, 64
   br i1 %rangecond, label %then_bb, label %join_bb
 
 then_bb:                                          ; preds = %entry

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise128-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise128-rangechk-abort.move
@@ -1,0 +1,21 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_shlu128(a: u128, b: u8): u128 {
+    let c = a << b;
+    c
+  }
+  public fun test_shru128(a: u128, b: u8): u128 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u128 = 1;
+    let b: u8 = 127;
+    assert!(0x101::Test1::test_shlu128(a, b) == 0x80000000000000000000000000000000, 20);  // Ok: count in range.
+    0x101::Test1::test_shru128(a, 128);  // Abort: count out of range.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise16-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise16-rangechk-abort.move
@@ -1,0 +1,21 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_shlu16(a: u16, b: u8): u16 {
+    let c = a << b;
+    c
+  }
+  public fun test_shru16(a: u16, b: u8): u16 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u16 = 1;
+    let b: u8 = 15;
+    assert!(0x101::Test1::test_shlu16(a, b) == 0x8000, 20);  // Ok: count in range.
+    0x101::Test1::test_shru16(a, 16);  // Abort: count out of range.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise256-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise256-rangechk-abort.move
@@ -1,0 +1,21 @@
+
+module 0x101::Test1 {
+  public fun test_shlu256(a: u256, b: u8): u256 {
+    let c = a << b;
+    c
+  }
+  public fun test_shru256(a: u256, b: u8): u256 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u256 = 1;
+    let b: u8 = 255;
+    assert!(0x101::Test1::test_shlu256(a, b) == 0x8000000000000000000000000000000000000000000000000000000000000000, 20);  // Ok: count in range.
+
+    // u256 shift count always legal today in Move since count is restricted to u8.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise32-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise32-rangechk-abort.move
@@ -1,0 +1,21 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_shlu32(a: u32, b: u8): u32 {
+    let c = a << b;
+    c
+  }
+  public fun test_shru32(a: u32, b: u8): u32 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u32 = 1;
+    let b: u8 = 31;
+    assert!(0x101::Test1::test_shlu32(a, b) == 0x80000000, 20);  // Ok: count in range.
+    0x101::Test1::test_shru32(a, 32);  // Abort: count out of range.
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise64-rangechk-abort.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/bitwise64-rangechk-abort.move
@@ -1,0 +1,21 @@
+// abort 4017
+
+module 0x101::Test1 {
+  public fun test_shlu64(a: u64, b: u8): u64 {
+    let c = a << b;
+    c
+  }
+  public fun test_shru64(a: u64, b: u8): u64 {
+    let c = a >> b;
+    c
+  }
+}
+
+script {
+  fun main() {
+    let a: u64 = 1;
+    let b: u8 = 63;
+    assert!(0x101::Test1::test_shlu64(a, b) == 0x8000000000000000, 20);  // Ok: count in range.
+    0x101::Test1::test_shru64(a, 64);  // Abort: count out of range.
+  }
+}


### PR DESCRIPTION
Elide range check for u256 since the shift count is limited to u8 in Move. For others, compare against the width of the first operand.

Add more coverage for u8, u16, u32, u64, u128, u256.