### PR TITLE
Fix a defect in Move's move-model and enable address32.

### DIFF
--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -37,5 +37,5 @@ arbitrary = { version = "1.1.7", features = [ "derive_arbitrary"] }
 [features]
 address20 = []
 address32 = []
-default = []
+default = ["address32"]
 fuzzing = ["proptest", "proptest-derive", "arbitrary"]

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -1107,7 +1107,8 @@ impl ModuleName {
     /// for pseudo modules created from scripts, so use this address to check.
     pub fn is_script(&self) -> bool {
         static MAX_ADDR: Lazy<BigUint> = Lazy::new(|| {
-            BigUint::from_str_radix("ffffffffffffffffffffffffffffffff", 16).expect("valid hex")
+            let v: Vec<u8> = vec![0xff; move_core_types::account_address::AccountAddress::LENGTH];
+            BigUint::from_bytes_le(&v)
         });
         self.0 == *MAX_ADDR
     }

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -43,7 +43,8 @@ git = "https://github.com/solana-labs/rbpf.git"
 rev = "c03dbfef82487396fc6f96d2cfeca409d6181192"
 
 [features]
-default = []
+solana = []
+default = ["solana"]
 
 [[test]]
 name = "ir-tests"


### PR DESCRIPTION
Upon trying a simple example with the Move address data type (spurred by a discussion yesterday with Jan), I discovered that:
 - The move-model/input-IR had bogus 16-byte addresses throughout.
 - Our move-native crate was built (for the move-mv-llvm-compiler scenario) with non-Solana target_defs (e.g., bogus 16-byte address lengths, among other things).

And in fact, all Move components were being built without feature "address32". Likewise (probably accidentally) the move-native crate was built for 16-byte addresses.

This patch enables address32, which should have been trivial if not for above. Moreover, it revealed a defect in the move-model when testing for script vs module which this patch also fixes.

The defect was related to assuming 16-byte addresses instead of relying on the target-agnostic move_core_types::account_address::AccountAddress::LENGTH.

I suspect we'll find more such gremlins in the upstream Move code since they don't use 32-byte addresses and we (now) do.