### PR TITLE
Implement support for Move `address` type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,6 +3459,7 @@ dependencies = [
  "move-model",
  "move-native",
  "move-stackless-bytecode",
+ "num-traits 0.2.14",
  "once_cell",
  "parking_lot 0.11.1",
  "semver 1.0.14",

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -32,6 +32,7 @@ semver = "1.0.13"
 llvm-sys = "150.0.3"
 llvm-extra-sys = { path = "./llvm-extra-sys" }
 extension-trait = "1.0.1"
+num-traits = "0.2"
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -675,10 +675,6 @@ impl Builder {
         unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr()) }
     }
 
-    pub fn build_load2(&self, ty: Type, src0_reg: LLVMValueRef, name: &str) -> LLVMValueRef {
-        unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg, name.cstr()) }
-    }
-
     pub fn build_load_global_const(&self, gval: Global) -> Constant {
         unsafe {
             let ty = LLVMGlobalGetValueType(gval.0);

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -693,7 +693,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                         | mty::PrimitiveType::U32
                         | mty::PrimitiveType::U64
                         | mty::PrimitiveType::U128
-                        | mty::PrimitiveType::U256, //| mty::PrimitiveType::Address,
+                        | mty::PrimitiveType::U256,
                     ) => {
                         self.llvm_builder.load_store(llty, src_llval, dst_llval);
                     }
@@ -988,26 +988,17 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             .llvm_cx
             .vector_type(src0_llty.get_element_type(), num_elts);
 
-        let op0_reg =
-            self.llvm_builder
-                .build_load(vec_src_ty, local0.llval, &format!("{name}_op0"));
-        let op1_reg =
-            self.llvm_builder
-                .build_load(vec_src_ty, local1.llval, &format!("{name}_op1"));
-        let cmp_vecs_reg = self
-            .llvm_builder
-            .build_compare(pred, op0_reg, op1_reg, "addrcmp_dst");
+        let builder = self.llvm_builder;
+        let op0_reg = builder.build_load(vec_src_ty, local0.llval, &format!("{name}_op0"));
+        let op1_reg = builder.build_load(vec_src_ty, local1.llval, &format!("{name}_op1"));
+        let cmp_vecs_reg = builder.build_compare(pred, op0_reg, op1_reg, "addrcmp_dst");
 
         let cmp_int_ty = self.llvm_cx.int_arbitrary_type(num_elts);
-        let bc_val = self
-            .llvm_builder
-            .build_unary_bitcast(cmp_vecs_reg, cmp_int_ty.0, "v2i");
+        let bc_val = builder.build_unary_bitcast(cmp_vecs_reg, cmp_int_ty.0, "v2i");
 
         let inv_pred = llvm::LLVMIntPredicate::LLVMIntNE;
         let zero_val = llvm::Constant::get_const_null(cmp_int_ty).get0();
-        let dst_reg =
-            self.llvm_builder
-                .build_compare(inv_pred, bc_val, zero_val, &format!("{name}_dst"));
+        let dst_reg = builder.build_compare(inv_pred, bc_val, zero_val, &format!("{name}_dst"));
         self.store_reg(dst[0], dst_reg);
     }
 

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/empty-module.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/empty-module.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/friend.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/friend.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x42__A'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct-pair.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct-pair.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct_arguments.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct_arguments.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x42__M'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -1,0 +1,75 @@
+; ModuleID = '0x100__M3'
+source_filename = "<unknown>"
+
+define i1 @M3__eq_address([32 x i8] %0, [32 x i8] %1) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  %local_2 = alloca [32 x i8], align 1
+  %local_3 = alloca [32 x i8], align 1
+  %local_4 = alloca i1, align 1
+  store [32 x i8] %0, ptr %local_0, align 1
+  store [32 x i8] %1, ptr %local_1, align 1
+  %eq_op0 = load <32 x i8>, ptr %local_0, align 32
+  %eq_op1 = load <32 x i8>, ptr %local_1, align 32
+  %addrcmp_dst = icmp eq <32 x i8> %eq_op0, %eq_op1
+  %v2i = bitcast <32 x i1> %addrcmp_dst to i32
+  %eq_dst = icmp ne i32 %v2i, 0
+  store i1 %eq_dst, ptr %local_4, align 1
+  %retval = load i1, ptr %local_4, align 1
+  ret i1 %retval
+}
+
+define i1 @M3__ne_address([32 x i8] %0, [32 x i8] %1) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  %local_2 = alloca [32 x i8], align 1
+  %local_3 = alloca [32 x i8], align 1
+  %local_4 = alloca i1, align 1
+  store [32 x i8] %0, ptr %local_0, align 1
+  store [32 x i8] %1, ptr %local_1, align 1
+  %ne_op0 = load <32 x i8>, ptr %local_0, align 32
+  %ne_op1 = load <32 x i8>, ptr %local_1, align 32
+  %addrcmp_dst = icmp ne <32 x i8> %ne_op0, %ne_op1
+  %v2i = bitcast <32 x i1> %addrcmp_dst to i32
+  %ne_dst = icmp ne i32 %v2i, 0
+  store i1 %ne_dst, ptr %local_4, align 1
+  %retval = load i1, ptr %local_4, align 1
+  ret i1 %retval
+}
+
+define ptr @M3__ret_address_ref(ptr %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %retval = load ptr, ptr %local_1, align 8
+  ret ptr %retval
+}
+
+define [32 x i8] @M3__use_address_ref(ptr %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca [32 x i8], align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_1, align 8
+  %load_deref_store_tmp2 = load [32 x i8], ptr %load_deref_store_tmp1, align 1
+  store [32 x i8] %load_deref_store_tmp2, ptr %local_2, align 1
+  %retval = load [32 x i8], ptr %local_2, align 1
+  ret [32 x i8] %retval
+}
+
+define [32 x i8] @M3__use_address_val([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  store [32 x i8] %0, ptr %local_0, align 1
+  %retval = load [32 x i8], ptr %local_0, align 1
+  ret [32 x i8] %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__M3'
 source_filename = "<unknown>"
 
+@acct.addr = internal constant [32 x i8] c"\1F\1E\1D\1C\1B\1A\19\18\17\16\15\14\13\12\11\10\0F\0E\0D\0C\0B\0A\09\08\07\06\05\04\03\02\01\00"
+
 define i1 @M3__eq_address([32 x i8] %0, [32 x i8] %1) {
 entry:
   %local_0 = alloca [32 x i8], align 1
@@ -18,6 +20,15 @@ entry:
   store i1 %eq_dst, ptr %local_4, align 1
   %retval = load i1, ptr %local_4, align 1
   ret i1 %retval
+}
+
+define [32 x i8] @M3__fixed_address() {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %0 = load [32 x i8], ptr @acct.addr, align 1
+  store [32 x i8] %0, ptr %local_0, align 1
+  %retval = load [32 x i8], ptr %local_0, align 1
+  ret [32 x i8] %retval
 }
 
 define i1 @M3__ne_address([32 x i8] %0, [32 x i8] %1) {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -3,6 +3,8 @@ source_filename = "<unknown>"
 
 @acct.addr = internal constant [32 x i8] c"\1F\1E\1D\1C\1B\1A\19\18\17\16\15\14\13\12\11\10\0F\0E\0D\0C\0B\0A\09\08\07\06\05\04\03\02\01\00"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i1 @M3__eq_address([32 x i8] %0, [32 x i8] %1) {
 entry:
   %local_0 = alloca [32 x i8], align 1
@@ -12,11 +14,8 @@ entry:
   %local_4 = alloca i1, align 1
   store [32 x i8] %0, ptr %local_0, align 1
   store [32 x i8] %1, ptr %local_1, align 1
-  %eq_op0 = load <32 x i8>, ptr %local_0, align 32
-  %eq_op1 = load <32 x i8>, ptr %local_1, align 32
-  %addrcmp_dst = icmp eq <32 x i8> %eq_op0, %eq_op1
-  %v2i = bitcast <32 x i1> %addrcmp_dst to i32
-  %eq_dst = icmp ne i32 %v2i, 0
+  %2 = call i32 @memcmp(ptr %local_0, ptr %local_1, i64 32)
+  %eq_dst = icmp eq i32 %2, 0
   store i1 %eq_dst, ptr %local_4, align 1
   %retval = load i1, ptr %local_4, align 1
   ret i1 %retval
@@ -40,11 +39,8 @@ entry:
   %local_4 = alloca i1, align 1
   store [32 x i8] %0, ptr %local_0, align 1
   store [32 x i8] %1, ptr %local_1, align 1
-  %ne_op0 = load <32 x i8>, ptr %local_0, align 32
-  %ne_op1 = load <32 x i8>, ptr %local_1, align 32
-  %addrcmp_dst = icmp ne <32 x i8> %ne_op0, %ne_op1
-  %v2i = bitcast <32 x i1> %addrcmp_dst to i32
-  %ne_dst = icmp ne i32 %v2i, 0
+  %2 = call i32 @memcmp(ptr %local_0, ptr %local_1, i64 32)
+  %ne_dst = icmp ne i32 %2, 0
   store i1 %ne_dst, ptr %local_4, align 1
   %retval = load i1, ptr %local_4, align 1
   ret i1 %retval

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01.move
@@ -21,4 +21,8 @@ module 0x100::M3 {
     public fun ne_address(a: address, b: address): bool {
         a != b
     }
+
+    public fun fixed_address(): address {
+        @0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F
+    }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01.move
@@ -1,0 +1,24 @@
+
+module 0x100::M3 {
+    public fun use_address_val(a: address): address  {
+        let a2 = move a;
+        a2
+    }
+
+    public fun use_address_ref(a: &address): address  {
+        let a2 = *a;
+        a2
+    }
+
+    public fun ret_address_ref(a: &address): &address  {
+        a
+    }
+
+    public fun eq_address(a: address, b: address): bool {
+        a == b
+    }
+
+    public fun ne_address(a: address, b: address): bool {
+        a != b
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assign-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assign-build/scripts/main.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @main() {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test__test_and(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test__get_sub(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i32 @Test__cast_u32(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i128 @Test__cast_u128_as_u128(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i128 @Test__takes_u128(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x10__debug'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 declare void @move_native_debug_print(ptr, ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
@@ -7,6 +7,8 @@ source_filename = "<unknown>"
 @__move_rttydesc_u64_name = constant [3 x i8] c"u64"
 @__move_rttydesc_NOTHING_info = constant i8 -1
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @main() {
 entry:
   %local_0 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/empty-module-build/modules/0_Empty.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/empty-module-build/modules/0_Empty.expected.ll
@@ -1,2 +1,4 @@
 ; ModuleID = '0x100__Empty'
 source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i1 @Test__test(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test__test(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i1 @Test__test_eq(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i128 @Test__test(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i32 @Test__test(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i64 @Test__test(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test__test_add(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x101__Test2'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test2__test2(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test1'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test1__test1(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @main() {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define { i1, i1 } @Test__ret_2vals() {
 entry:
   %local_0 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Test__test() {
 entry:
   %local_0 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script-build/scripts/main.expected.ll
@@ -1,6 +1,8 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @main() {
 entry:
   ret void

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -4,6 +4,8 @@ source_filename = "<unknown>"
 %struct.M__MyStruct = type { i32, i1, %struct.M__EmptyStruct, i8 }
 %struct.M__EmptyStruct = type { i1, i8 }
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define %struct.M__MyStruct @M__boofun() {
 entry:
   %local_0 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -4,6 +4,8 @@ source_filename = "<unknown>"
 %struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
 %struct.Country__Dunno = type { i64, i8 }
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define i8 @Country__dropit(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -4,6 +4,8 @@ source_filename = "<unknown>"
 %struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
 %struct.Country__Dunno = type { i64, i8 }
 
+declare i32 @memcmp(ptr, ptr, i64)
+
 define void @UseIt__getit() {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/acct-address01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/acct-address01.move
@@ -27,13 +27,14 @@ script {
     use 0x100::M3;
 
     fun main() {
-        let a = @0x2;
-        let b = @0x2;
+        let a = @0x2A3B;
+        let b = @0x2A3B;
         assert!(M3::eq_address(a, b), 0xf00);
 
-        let a = @0x5;
-        let b = @0x6;
+        let a = @0x55AA1122334455;
+        let b = @0x55AA1122334456;
         assert!(M3::ne_address(a, b), 0xf01);
+        assert!(!M3::eq_address(a, b), 0xf01);
 
         let a = @0x42;
         let t1 = M3::use_address_val(a);

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/acct-address01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/acct-address01.move
@@ -1,0 +1,52 @@
+
+module 0x100::M3 {
+    public fun use_address_val(a: address): address  {
+        let a2 = move a;
+        a2
+    }
+
+    public fun use_address_ref(a: &address): address  {
+        let a2 = *a;
+        a2
+    }
+
+    public fun ret_address_ref(a: &address): &address  {
+        a
+    }
+
+    public fun eq_address(a: address, b: address): bool {
+        a == b
+    }
+
+    public fun ne_address(a: address, b: address): bool {
+        a != b
+    }
+}
+
+script {
+    use 0x100::M3;
+
+    fun main() {
+        let a = @0x2;
+        let b = @0x2;
+        assert!(M3::eq_address(a, b), 0xf00);
+
+        let a = @0x5;
+        let b = @0x6;
+        assert!(M3::ne_address(a, b), 0xf01);
+
+        let a = @0x42;
+        let t1 = M3::use_address_val(a);
+        assert!(t1 == @0x42, 0xf02);
+
+        let b = @0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F;
+        let t2 = M3::use_address_ref(&b);
+        assert!(M3::eq_address(t2, @0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F), 0xf03);
+
+        let c = @0xc0ffee;
+        let t3 = M3::ret_address_ref(&c);
+        assert!(M3::eq_address(*t3, @0xc0ffee), 0xf04);
+
+        assert!(M3::ne_address(@0xabba, @0xc0ffee), 0xf05);
+    }
+}


### PR DESCRIPTION
This patch adds support for `address` and a few LLVM bits to
support it. Each address is represented in a target agnostic way
as an LLVM [AccountAddress::LENGTH x i8] array.