### PR TITLE
Add codegen for native function calls to support vectors.

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -385,8 +385,8 @@ pub(crate) mod rt_types {
 
     unsafe impl Sync for StaticTypeName {}
 
-    #[repr(u32)]
-    #[derive(Copy, Clone)]
+    #[repr(u64)]
+    #[derive(Copy, Clone, Debug)]
     pub enum TypeDesc {
         Bool = 1,
         U8 = 2,
@@ -547,9 +547,17 @@ pub(crate) mod rt_types {
 /// Runtime calls emitted by the compiler.
 /// Reference: move/language/documentation/book/src/abort-and-assert.md
 mod rt {
+    use crate::rt_types::{MoveType, MoveUntypedVector};
+
     #[export_name = "move_rt_abort"]
     fn abort(code: u64) -> ! {
         crate::target_defs::abort(code);
+    }
+
+    #[export_name = "move_rt_vec_destroy"]
+    unsafe fn vec_destroy(type_ve: &MoveType, v: MoveUntypedVector) {
+        assert_eq!(0, v.length, "can't destroy vectors with elements yet");
+        crate::std::vector::destroy_empty(type_ve, v);
     }
 }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -5,7 +5,7 @@
 //! Extension traits for foreign types.
 
 use extension_trait::extension_trait;
-use move_model::model as mm;
+use move_model::{model as mm, ty as mty};
 
 #[extension_trait]
 pub impl<'a> ModuleEnvExt for mm::ModuleEnv<'a> {
@@ -42,5 +42,14 @@ pub impl FunIdExt for mm::FunId {
             module_id: m,
             id: *self,
         }
+    }
+}
+
+#[extension_trait]
+pub impl TypeExt for mty::Type {
+    /// Used by rttydesc to name type descriptors.
+    fn sanitized_display_name(&self, type_display_ctx: &mty::TypeDisplayContext) -> String {
+        let name = format!("{}", self.display(type_display_ctx));
+        name.replace(['<', '>'], "_")
     }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
@@ -1,11 +1,11 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
 
-%__move_rt_type = type { { ptr, i64 }, i32, ptr }
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
 
-@__move_rttydesc_u64 = constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i32 3, ptr @__move_rttydesc_NOTHING_info }
-@__move_rttydesc_u64_name = constant [3 x i8] c"u64"
-@__move_rttydesc_NOTHING_info = constant i8 -1
+@__move_rttydesc_u64 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i64 3, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u64_name = private unnamed_addr constant [3 x i8] c"u64"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/vec.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/vec.move
@@ -1,0 +1,41 @@
+module 0x10::vector {
+  native public fun empty<Element>(): vector<Element>;
+  native public fun length<Element>(v: &vector<Element>): u64;
+  native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+  native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+  native public fun destroy_empty<Element>(v: vector<Element>);
+  native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+  native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+  native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+}
+
+script {
+  use 0x10::vector;
+
+  fun main() {
+    let v: vector<u64> = vector::empty();
+
+    let len = vector::length(&v);
+    assert!(len == 0, 10);
+
+    vector::push_back(&mut v, 2);
+    vector::push_back(&mut v, 3);
+
+    let len = vector::length(&v);
+    assert!(len == 2, 10);
+
+    vector::swap(&mut v, 0, 1);
+
+    let elt = vector::borrow(&v, 0);
+    assert!(*elt == 3, 10);
+    let elt = vector::borrow_mut(&mut v, 0);
+    assert!(*elt == 3, 10);
+
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 2, 10);
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 3, 10);
+
+    vector::destroy_empty(v);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -380,13 +380,20 @@ pub fn compile_all_bytecode(
         }
 
         debug!("Running {cmd:?}");
-        let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "move-mv-llvm-compiler failed. stderr:\n\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        if !std::env::args().any(|arg| arg == "--nocapture") {
+            let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
+            if !output.status.success() {
+                anyhow::bail!(
+                    "move-mv-llvm-compiler failed. stderr:\n\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        } else {
+            let status = cmd.status().context("run move-mv-llvm-compiler failed")?;
+            if !status.success() {
+                anyhow::bail!("move-mv-llvm-compiler failed");
+            }
+        };
     }
 
     Ok(())


### PR DESCRIPTION
This patch implements the codegen to support all of the native functions in `std::vector`.

It is primarily concerned with making `declare_native_function` and `translate_native_fun_call` implement the parts of the C ABI, and the runtime-specific ABI convensions for generics, needed to call the vector functions.

It also makes some incidental fixes. Most importantly, per https://github.com/solana-labs/move/issues/135, the global runtime type descriptors were previously filled with bogus data. It's not obvious to me why, but what seems to have been happening was that the dynamic relocations of the pointers in these types was being mangled (possibly inside rbpf - rustc doesn't seem to emit globals with the exact formulation we were previously emitting, so maybe there was a pattern rbpf hadn't seen before). I fixed this by marking these globals as 'private', as rustc does. After this the runtime type descriptors appear correct. As part of these fixes I made `debug::print` work for `vector<u64>`.

This adds a `move_rt_vec_destroy` runtime call, emitted when Move bytecode asks to destroy a vector. There is a bug here: the stackless bytecode to make this call does not appear in most examples, and I don't know why. I have only seen it when a vector is created but then not used. So for now vectors tend to be super leaky! I'll file a bug about this.

There are a few changes here that are not strictly needed, but seem fine:

- The `TypeDesc` runtime type is now `repr(u64)` instead of `repr(u32)`. This makes the struct field packing slightly more obvious. The MoveType struct is still the same size.
- The global runtime types are now tagged `unnamed_addr`, which means their address is not required to be unique and llvm can merge identical definitions. This will probably end up more efficient in the future, and is how rustc treats most globals.

This also makes the test harness interpret a new env var, `PRINT_STDIO`: when this is set, it will call the move-mv-llvm-compiler process in a way that prints stdio to the terminal. I found this necessary to get info out of the compiler in cases where it wasn't failing. Along with the `DUMP` env var, it's currently undocumented.

Fixes https://github.com/solana-labs/move/issues/53
Fixes https://github.com/solana-labs/move/issues/135