### PR TITLE
Add original field names

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -606,11 +606,76 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             self.llvm_builder.position_at_end(entry_block);
         }
 
+        ////////////////////////////////////////////////////////////////////////
+        // Collect some local names from various structure field references.
+        let mut named_locals = BTreeMap::new();
+        for instr in &fn_data.code {
+            use sbc::Operation;
+            match instr {
+                sbc::Bytecode::Call(_, dst, op, src, None) => {
+                    match op {
+                        Operation::BorrowField(mod_id, struct_id, _types, offset) => {
+                            assert_eq!(src.len(), 1);
+                            assert_eq!(dst.len(), 1);
+                            let senv = self
+                                .get_global_env()
+                                .get_module(*mod_id)
+                                .into_struct(*struct_id);
+                            let tmp_idx = dst[0];
+                            let fenv = senv.get_field_by_offset(*offset);
+                            let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                            let n = format!("{}", name);
+                            named_locals.insert(tmp_idx, n);
+                        }
+                        Operation::Pack(mod_id, struct_id, _types) => {
+                            let senv = self
+                                .get_global_env()
+                                .get_module(*mod_id)
+                                .into_struct(*struct_id);
+                            assert_eq!(dst.len(), 1);
+                            assert_eq!(src.len(), senv.get_field_count());
+                            let mut offset = 0;
+                            for tmp_idx in src {
+                                let fenv = senv.get_field_by_offset(offset);
+                                let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                                let n = format!("{}", name);
+                                named_locals.insert(*tmp_idx, n);
+                                offset = offset + 1;
+                            }
+                        }
+                        Operation::Unpack(mod_id, struct_id, _types) => {
+                            let senv = self
+                                .get_global_env()
+                                .get_module(*mod_id)
+                                .into_struct(*struct_id);
+                            assert_eq!(src.len(), 1);
+                            assert_eq!(dst.len(), senv.get_field_count());
+                            let mut offset = 0;
+                            for tmp_idx in dst {
+                                let fenv = senv.get_field_by_offset(offset);
+                                let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                                let n = format!("{}", name);
+                                named_locals.insert(*tmp_idx, n);
+                                offset = offset + 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        dbg!(&named_locals);
+        ////////////////////////////////////////////////////////////////////////
+
         // Declare all the locals as allocas
         {
             for (i, mty) in fn_data.local_types.iter().enumerate() {
                 let llty = self.llvm_type(mty);
-                let name = format!("local_{}", i);
+                let mut name = format!("local_{}", i);
+                if let Some(s) = &named_locals.get(&i) {
+                    name = s.to_string();
+                }
                 let llval = self.llvm_builder.build_alloca(llty, &name);
                 self.locals.push(Local {
                     mty: mty.clone(), // fixme bad clone

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -611,61 +611,50 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let mut named_locals = BTreeMap::new();
         for instr in &fn_data.code {
             use sbc::Operation;
-            match instr {
-                sbc::Bytecode::Call(_, dst, op, src, None) => {
-                    match op {
-                        Operation::BorrowField(mod_id, struct_id, _types, offset) => {
-                            assert_eq!(src.len(), 1);
-                            assert_eq!(dst.len(), 1);
-                            let senv = self
-                                .get_global_env()
-                                .get_module(*mod_id)
-                                .into_struct(*struct_id);
-                            let tmp_idx = dst[0];
-                            let fenv = senv.get_field_by_offset(*offset);
-                            let name = fenv.get_name().display(senv.symbol_pool()).to_string();
-                            let n = format!("{}", name);
-                            named_locals.insert(tmp_idx, n);
-                        }
-                        Operation::Pack(mod_id, struct_id, _types) => {
-                            let senv = self
-                                .get_global_env()
-                                .get_module(*mod_id)
-                                .into_struct(*struct_id);
-                            assert_eq!(dst.len(), 1);
-                            assert_eq!(src.len(), senv.get_field_count());
-                            let mut offset = 0;
-                            for tmp_idx in src {
-                                let fenv = senv.get_field_by_offset(offset);
-                                let name = fenv.get_name().display(senv.symbol_pool()).to_string();
-                                let n = format!("{}", name);
-                                named_locals.insert(*tmp_idx, n);
-                                offset = offset + 1;
-                            }
-                        }
-                        Operation::Unpack(mod_id, struct_id, _types) => {
-                            let senv = self
-                                .get_global_env()
-                                .get_module(*mod_id)
-                                .into_struct(*struct_id);
-                            assert_eq!(src.len(), 1);
-                            assert_eq!(dst.len(), senv.get_field_count());
-                            let mut offset = 0;
-                            for tmp_idx in dst {
-                                let fenv = senv.get_field_by_offset(offset);
-                                let name = fenv.get_name().display(senv.symbol_pool()).to_string();
-                                let n = format!("{}", name);
-                                named_locals.insert(*tmp_idx, n);
-                                offset = offset + 1;
-                            }
-                        }
-                        _ => {}
+            if let sbc::Bytecode::Call(_, dst, op, src, None) = instr {
+                match op {
+                    Operation::BorrowField(mod_id, struct_id, _types, offset) => {
+                        assert_eq!(src.len(), 1);
+                        assert_eq!(dst.len(), 1);
+                        let senv = self
+                            .get_global_env()
+                            .get_module(*mod_id)
+                            .into_struct(*struct_id);
+                        let tmp_idx = dst[0];
+                        let fenv = senv.get_field_by_offset(*offset);
+                        let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                        named_locals.insert(tmp_idx, name);
                     }
+                    Operation::Pack(mod_id, struct_id, _types) => {
+                        let senv = self
+                            .get_global_env()
+                            .get_module(*mod_id)
+                            .into_struct(*struct_id);
+                        assert_eq!(dst.len(), 1);
+                        assert_eq!(src.len(), senv.get_field_count());
+                        for (offset, tmp_idx) in src.iter().enumerate() {
+                            let fenv = senv.get_field_by_offset(offset);
+                            let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                            named_locals.insert(*tmp_idx, name);
+                        }
+                    }
+                    Operation::Unpack(mod_id, struct_id, _types) => {
+                        let senv = self
+                            .get_global_env()
+                            .get_module(*mod_id)
+                            .into_struct(*struct_id);
+                        assert_eq!(src.len(), 1);
+                        assert_eq!(dst.len(), senv.get_field_count());
+                        for (offset, tmp_idx) in dst.iter().enumerate() {
+                            let fenv = senv.get_field_by_offset(offset);
+                            let name = fenv.get_name().display(senv.symbol_pool()).to_string();
+                            named_locals.insert(*tmp_idx, name);
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
-        dbg!(&named_locals);
         ////////////////////////////////////////////////////////////////////////
 
         // Declare all the locals as allocas
@@ -674,7 +663,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let llty = self.llvm_type(mty);
                 let mut name = format!("local_{}", i);
                 if let Some(s) = named_locals.get(&i) {
-                    name = format!("local_{}__{}", i, s.to_string());
+                    name = format!("local_{}__{}", i, s);
                 }
                 let llval = self.llvm_builder.build_alloca(llty, &name);
                 self.locals.push(Local {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -673,8 +673,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             for (i, mty) in fn_data.local_types.iter().enumerate() {
                 let llty = self.llvm_type(mty);
                 let mut name = format!("local_{}", i);
-                if let Some(s) = &named_locals.get(&i) {
-                    name = s.to_string();
+                if let Some(s) = named_locals.get(&i) {
+                    name = format!("local_{}__{}", i, s.to_string());
                 }
                 let llval = self.llvm_builder.build_alloca(llty, &name);
                 self.locals.push(Local {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -8,20 +8,20 @@ declare i32 @memcmp(ptr, ptr, i64)
 
 define %struct.M__MyStruct @M__boofun() {
 entry:
-  %local_0 = alloca i32, align 4
-  %local_1 = alloca i1, align 1
-  %local_2 = alloca i1, align 1
-  %local_3 = alloca %struct.M__EmptyStruct, align 8
+  %local_0__field1 = alloca i32, align 4
+  %local_1__field2 = alloca i1, align 1
+  %local_2__dummy_field = alloca i1, align 1
+  %local_3__field3 = alloca %struct.M__EmptyStruct, align 8
   %local_4 = alloca %struct.M__MyStruct, align 8
-  store i32 32, ptr %local_0, align 4
-  store i1 true, ptr %local_1, align 1
-  store i1 false, ptr %local_2, align 1
-  %fv.0 = load i1, ptr %local_2, align 1
+  store i32 32, ptr %local_0__field1, align 4
+  store i1 true, ptr %local_1__field2, align 1
+  store i1 false, ptr %local_2__dummy_field, align 1
+  %fv.0 = load i1, ptr %local_2__dummy_field, align 1
   %insert_0 = insertvalue %struct.M__EmptyStruct undef, i1 %fv.0, 0
-  store %struct.M__EmptyStruct %insert_0, ptr %local_3, align 1
-  %fv.01 = load i32, ptr %local_0, align 4
-  %fv.1 = load i1, ptr %local_1, align 1
-  %fv.2 = load %struct.M__EmptyStruct, ptr %local_3, align 1
+  store %struct.M__EmptyStruct %insert_0, ptr %local_3__field3, align 1
+  %fv.01 = load i32, ptr %local_0__field1, align 4
+  %fv.1 = load i1, ptr %local_1__field2, align 1
+  %fv.2 = load %struct.M__EmptyStruct, ptr %local_3__field3, align 1
   %insert_02 = insertvalue %struct.M__MyStruct undef, i32 %fv.01, 0
   %insert_1 = insertvalue %struct.M__MyStruct %insert_02, i1 %fv.1, 1
   %insert_2 = insertvalue %struct.M__MyStruct %insert_1, %struct.M__EmptyStruct %fv.2, 2

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -10,18 +10,18 @@ define i8 @Country__dropit(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca %struct.Country__Country, align 8
-  %local_2 = alloca i8, align 1
-  %local_3 = alloca i64, align 8
-  %local_4 = alloca %struct.Country__Dunno, align 8
+  %local_2__id = alloca i8, align 1
+  %local_3__population = alloca i64, align 8
+  %local_4__phony = alloca %struct.Country__Dunno, align 8
   store %struct.Country__Country %0, ptr %local_0, align 4
   %srcval = load %struct.Country__Country, ptr %local_0, align 4
   %ext_0 = extractvalue %struct.Country__Country %srcval, 0
   %ext_1 = extractvalue %struct.Country__Country %srcval, 1
   %ext_2 = extractvalue %struct.Country__Country %srcval, 2
-  store i8 %ext_0, ptr %local_2, align 1
-  store i64 %ext_1, ptr %local_3, align 4
-  store %struct.Country__Dunno %ext_2, ptr %local_4, align 4
-  %retval = load i8, ptr %local_2, align 1
+  store i8 %ext_0, ptr %local_2__id, align 1
+  store i64 %ext_1, ptr %local_3__population, align 4
+  store %struct.Country__Dunno %ext_2, ptr %local_4__phony, align 4
+  %retval = load i8, ptr %local_2__id, align 1
   ret i8 %retval
 }
 
@@ -29,15 +29,15 @@ define i8 @Country__get_id(ptr %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
-  %local_2 = alloca ptr, align 8
+  %local_2__id = alloca ptr, align 8
   %local_3 = alloca i8, align 1
   store ptr %0, ptr %local_0, align 8
   %load_store_tmp = load ptr, ptr %local_0, align 8
   store ptr %load_store_tmp, ptr %local_1, align 8
   %tmp = load ptr, ptr %local_1, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 0
-  store ptr %fld_ref, ptr %local_2, align 8
-  %load_deref_store_tmp1 = load ptr, ptr %local_2, align 8
+  store ptr %fld_ref, ptr %local_2__id, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_2__id, align 8
   %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
   store i8 %load_deref_store_tmp2, ptr %local_3, align 1
   %retval = load i8, ptr %local_3, align 1
@@ -48,18 +48,18 @@ define i64 @Country__get_phony_x(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca ptr, align 8
-  %local_2 = alloca ptr, align 8
-  %local_3 = alloca ptr, align 8
+  %local_2__phony = alloca ptr, align 8
+  %local_3__x = alloca ptr, align 8
   %local_4 = alloca i64, align 8
   store %struct.Country__Country %0, ptr %local_0, align 4
   store ptr %local_0, ptr %local_1, align 8
   %tmp = load ptr, ptr %local_1, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 2
-  store ptr %fld_ref, ptr %local_2, align 8
-  %tmp1 = load ptr, ptr %local_2, align 8
+  store ptr %fld_ref, ptr %local_2__phony, align 8
+  %tmp1 = load ptr, ptr %local_2__phony, align 8
   %fld_ref2 = getelementptr inbounds %struct.Country__Dunno, ptr %tmp1, i32 0, i32 0
-  store ptr %fld_ref2, ptr %local_3, align 8
-  %load_deref_store_tmp1 = load ptr, ptr %local_3, align 8
+  store ptr %fld_ref2, ptr %local_3__x, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_3__x, align 8
   %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
   store i64 %load_deref_store_tmp2, ptr %local_4, align 4
   %retval = load i64, ptr %local_4, align 4
@@ -70,14 +70,14 @@ define i64 @Country__get_pop(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca ptr, align 8
-  %local_2 = alloca ptr, align 8
+  %local_2__population = alloca ptr, align 8
   %local_3 = alloca i64, align 8
   store %struct.Country__Country %0, ptr %local_0, align 4
   store ptr %local_0, ptr %local_1, align 8
   %tmp = load ptr, ptr %local_1, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 1
-  store ptr %fld_ref, ptr %local_2, align 8
-  %load_deref_store_tmp1 = load ptr, ptr %local_2, align 8
+  store ptr %fld_ref, ptr %local_2__population, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_2__population, align 8
   %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
   store i64 %load_deref_store_tmp2, ptr %local_3, align 4
   %retval = load i64, ptr %local_3, align 4
@@ -88,24 +88,24 @@ define %struct.Country__Country @Country__new_country(i8 %0, i64 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i64, align 8
-  %local_2 = alloca i8, align 1
-  %local_3 = alloca i64, align 8
-  %local_4 = alloca i64, align 8
-  %local_5 = alloca %struct.Country__Dunno, align 8
+  %local_2__id = alloca i8, align 1
+  %local_3__population = alloca i64, align 8
+  %local_4__x = alloca i64, align 8
+  %local_5__phony = alloca %struct.Country__Dunno, align 8
   %local_6 = alloca %struct.Country__Country, align 8
   store i8 %0, ptr %local_0, align 1
   store i64 %1, ptr %local_1, align 4
   %load_store_tmp = load i8, ptr %local_0, align 1
-  store i8 %load_store_tmp, ptr %local_2, align 1
+  store i8 %load_store_tmp, ptr %local_2__id, align 1
   %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  store i64 32, ptr %local_4, align 4
-  %fv.0 = load i64, ptr %local_4, align 4
+  store i64 %load_store_tmp1, ptr %local_3__population, align 4
+  store i64 32, ptr %local_4__x, align 4
+  %fv.0 = load i64, ptr %local_4__x, align 4
   %insert_0 = insertvalue %struct.Country__Dunno undef, i64 %fv.0, 0
-  store %struct.Country__Dunno %insert_0, ptr %local_5, align 4
-  %fv.02 = load i8, ptr %local_2, align 1
-  %fv.1 = load i64, ptr %local_3, align 4
-  %fv.2 = load %struct.Country__Dunno, ptr %local_5, align 4
+  store %struct.Country__Dunno %insert_0, ptr %local_5__phony, align 4
+  %fv.02 = load i8, ptr %local_2__id, align 1
+  %fv.1 = load i64, ptr %local_3__population, align 4
+  %fv.2 = load %struct.Country__Dunno, ptr %local_5__phony, align 4
   %insert_03 = insertvalue %struct.Country__Country undef, i8 %fv.02, 0
   %insert_1 = insertvalue %struct.Country__Country %insert_03, i64 %fv.1, 1
   %insert_2 = insertvalue %struct.Country__Country %insert_1, %struct.Country__Dunno %fv.2, 2
@@ -120,7 +120,7 @@ entry:
   %local_1 = alloca i8, align 1
   %local_2 = alloca i8, align 1
   %local_3 = alloca ptr, align 8
-  %local_4 = alloca ptr, align 8
+  %local_4__id = alloca ptr, align 8
   store ptr %0, ptr %local_0, align 8
   store i8 %1, ptr %local_1, align 1
   %load_store_tmp = load i8, ptr %local_1, align 1
@@ -129,9 +129,9 @@ entry:
   store ptr %load_store_tmp1, ptr %local_3, align 8
   %tmp = load ptr, ptr %local_3, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 0
-  store ptr %fld_ref, ptr %local_4, align 8
+  store ptr %fld_ref, ptr %local_4__id, align 8
   %load_store_ref_src = load i8, ptr %local_2, align 1
-  %load_store_ref_dst_ptr = load ptr, ptr %local_4, align 8
+  %load_store_ref_dst_ptr = load ptr, ptr %local_4__id, align 8
   store i8 %load_store_ref_src, ptr %load_store_ref_dst_ptr, align 1
   ret void
 }


### PR DESCRIPTION
This PR supports the original source code for the struct fields. May help in debugging, testing, logging.

#### Many kudos to Jason for very instrumental criticism of #139, sharing the idea and helping with code. 

For original code
```Move
address 0x22 {
module mod1 {
    // struct definition
    struct Struct_A has drop {
        a1_8:     u8,
        a2_16:   u16,
    	a3_64:   u64,
	a4_b:   bool,
	a5_256: u256
    }
    struct Struct_B has drop {
        b1_8:     u8,
        b2_16:   u16,
    }
    
    fun foo1() : u64 {
      
	let _struct_a1 = Struct_A {
	    a1_8:  7,
	    a2_16: 15,
	    a3_64: 63,
	    a4_b:  true,
	    a5_256: 255
	};
	let _struct_b1 = Struct_B {
	    b1_8:  6,
	    b2_16: 14,
	};
	1177    // struct_a1.a3_64
}
}
```

This will build .ir as
```llvm
; ModuleID = '0x22__mod1'
source_filename = "<unknown>"

%struct.mod1__Struct_A = type { i8, i16, i64, i1, i256, i8 }
%struct.mod1__Struct_B = type { i8, i16, i8 }

declare i32 @memcmp(ptr, ptr, i64)

define i64 @mod1__foo1() {
entry:
  %local_0__a1_8 = alloca i8, align 1
  %local_1__a2_16 = alloca i16, align 2
  %local_2__a3_64 = alloca i64, align 8
  %local_3__a4_b = alloca i1, align 1
  %local_4__a5_256 = alloca i256, align 8
  %local_5 = alloca %struct.mod1__Struct_A, align 8
  %local_6__b1_8 = alloca i8, align 1
  %local_7__b2_16 = alloca i16, align 2
  %local_8 = alloca %struct.mod1__Struct_B, align 8
  %local_9 = alloca i64, align 8
  store i8 7, ptr %local_0__a1_8, align 1
  store i16 15, ptr %local_1__a2_16, align 2
  store i64 63, ptr %local_2__a3_64, align 4
  store i1 true, ptr %local_3__a4_b, align 1
  store i256 255, ptr %local_4__a5_256, align 4
  %fv.0 = load i8, ptr %local_0__a1_8, align 1
  %fv.1 = load i16, ptr %local_1__a2_16, align 2
  %fv.2 = load i64, ptr %local_2__a3_64, align 4
  %fv.3 = load i1, ptr %local_3__a4_b, align 1
  %fv.4 = load i256, ptr %local_4__a5_256, align 4
  %insert_0 = insertvalue %struct.mod1__Struct_A undef, i8 %fv.0, 0
  %insert_1 = insertvalue %struct.mod1__Struct_A %insert_0, i16 %fv.1, 1
  %insert_2 = insertvalue %struct.mod1__Struct_A %insert_1, i64 %fv.2, 2
  %insert_3 = insertvalue %struct.mod1__Struct_A %insert_2, i1 %fv.3, 3
  %insert_4 = insertvalue %struct.mod1__Struct_A %insert_3, i256 %fv.4, 4
  store %struct.mod1__Struct_A %insert_4, ptr %local_5, align 4
  store i8 6, ptr %local_6__b1_8, align 1
  store i16 14, ptr %local_7__b2_16, align 2
  %fv.01 = load i8, ptr %local_6__b1_8, align 1
  %fv.12 = load i16, ptr %local_7__b2_16, align 2
  %insert_03 = insertvalue %struct.mod1__Struct_B undef, i8 %fv.01, 0
  %insert_14 = insertvalue %struct.mod1__Struct_B %insert_03, i16 %fv.12, 1
  store %struct.mod1__Struct_B %insert_14, ptr %local_8, align 2
  store i64 1177, ptr %local_9, align 4
  %retval = load i64, ptr %local_9, align 4
  ret i64 %retval
}
```

Here the field name is build of two parts: 
- `local_NN` where `NN` is the index of the field in the buffer of locals, and
-  the rest, which is the original source code name. 

So it may help in auto testing to drop or modify a part of the name.



