### PR TITLE
NFC: Replace many uplevel references to enclosing ModuleContext reference.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -643,7 +643,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     curr_signer += 1;
                     let addr_val = BigUint::parse_bytes(signer.unwrap().as_bytes(), 16);
                     let c = self.constant(&sbc::Constant::Address(addr_val.unwrap()));
-                    self.parent_cx.llvm_builder.build_store(c.get0(), local.llval);
+                    self.parent_cx
+                        .llvm_builder
+                        .build_store(c.get0(), local.llval);
                 } else {
                     self.parent_cx
                         .llvm_builder
@@ -1618,7 +1620,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     .iter()
                     .map(|l| (l.llty, l.llval))
                     .collect::<Vec<_>>();
-                self.parent_cx.llvm_builder.load_call_store(ll_fn, &src, &dst);
+                self.parent_cx
+                    .llvm_builder
+                    .load_call_store(ll_fn, &src, &dst);
             }
         }
     }


### PR DESCRIPTION
The FunctionContext has grown organically over time and now contains
an unwieldly collection of seven uplevel references to the enclosing
ModuleContext-- including boxed function pointers needed during the
function translation.
    
This patch replaces all the uplevels with a single reference to the enclosing
ModuleContext and updates all users. This will also simplify the passing of
module-level structures (llvm::Context, llvm::Module) that are commonly needed
in bundles, such as in the rttydesc module. A future patch will make those
sorts of simplifications.