### PR TITLE
Add Input test directive to specifying input data for runnable tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,6 +3474,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.1",
  "semver 1.0.14",
+ "serde 1.0.145",
+ "serde_json",
  "similar",
  "solana_rbpf",
  "thiserror",

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -38,6 +38,8 @@ num-traits = "0.2"
 datatest-stable = "0.1.1"
 env_logger = "0.8.3"
 log = "0.4.14"
+serde = { version = "1.0.124", features = ["derive"] }
+serde_json = "1.0.64"
 similar = "2.1.0"
 thiserror = "1.0.37"
 

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/input.json
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/input.json
@@ -1,0 +1,14 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [31, 32, 23, 24]
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/input.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/input.move
@@ -1,0 +1,7 @@
+// input input.json
+
+script {
+  fun main() {
+    assert!(true, 10);
+  }
+}


### PR DESCRIPTION
This change allows test program to specify account information of a transaction invoking the test program.
The account information is loaded from an input file. The location of the input file is specified as testcase directive.

The account information should be added in invoke context in follow up changes.