### PR TITLE
Implement support for Move `signer`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "move-model",
  "move-native",
  "move-stackless-bytecode",
+ "num 0.4.0",
  "num-traits 0.2.14",
  "once_cell",
  "parking_lot 0.11.1",

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -468,7 +468,7 @@ pub(crate) mod rt_types {
     /// This is mapped to the address size of the target platform, and may
     /// differ from Move VM.
     #[repr(transparent)]
-    #[derive(Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq)]
     pub struct MoveAddress(pub [u8; target_defs::ACCOUNT_ADDRESS_LENGTH]);
 
     // Defined in std::type_name; not a primitive.
@@ -645,6 +645,11 @@ mod std {
         #[export_name = "move_native_signer_borrow_address"]
         extern "C" fn borrow_address(s: &MoveSigner) -> &MoveAddress {
             &s.0
+        }
+
+        #[export_name = "move_native_signer_address_of"]
+        extern "C" fn address_of(s: &MoveSigner) -> MoveAddress {
+            s.0
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -32,6 +32,7 @@ semver = "1.0.13"
 llvm-sys = "150.0.3"
 llvm-extra-sys = { path = "./llvm-extra-sys" }
 extension-trait = "1.0.1"
+num = "0.4.0"
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -64,6 +64,10 @@ struct Args {
     #[clap(short = 'O')]
     pub obj: bool,
 
+    /// Provide signers to a script (only for testing/debugging purposes).
+    #[clap(long = "signers", use_value_delimiter = true, value_delimiter = ',')]
+    pub test_signers: Vec<String>,
+
     /// Write or view GraphViz dot graph files for each CFG.
     /// ("write": gen dot files, "view": gen dot files and invoke xdot viewer)"
     #[clap(long = "gen-dot-cfg", default_value = "")]
@@ -194,7 +198,7 @@ fn main() -> anyhow::Result<()> {
             .map(|m| m.get_id())
             .expect(".");
         let global_cx = GlobalContext::new(&model_env, Target::Solana);
-        let mod_cx = global_cx.create_module_context(mod_id, &dot_info);
+        let mod_cx = global_cx.create_module_context(mod_id, &dot_info, &args.test_signers);
         let mut llmod = mod_cx.translate();
         if !args.obj {
             llvm_write_to_file(llmod.as_mut(), args.llvm_ir, &args.output_file_path)?;

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -718,7 +718,7 @@ impl Builder {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Type(pub LLVMTypeRef);
 
 impl Type {
@@ -858,7 +858,7 @@ impl BasicBlock {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Alloca(LLVMValueRef);
 
 impl Alloca {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
@@ -117,7 +117,7 @@ fn compile_all_bytecode_to_llvm_ir(
     harness_paths: &tc::HarnessPaths,
     compilation_units: &[tc::CompilationUnit],
 ) -> anyhow::Result<()> {
-    tc::compile_all_bytecode(harness_paths, compilation_units, "-S", &|cu| {
+    tc::compile_all_bytecode(harness_paths, compilation_units, None, "-S", &|cu| {
         cu.llvm_ir_actual()
     })
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -37,7 +37,8 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
 
     let compilation_units = tc::find_compilation_units(&test_plan)?;
 
-    compile_all_bytecode_to_object_files(&harness_paths, &compilation_units)?;
+    let signers = test_plan.signer_list();
+    compile_all_bytecode_to_object_files(&harness_paths, &compilation_units, signers)?;
 
     let exe = link_object_files(&test_plan, &sbf_tools, &compilation_units, &runtime)?;
 
@@ -56,8 +57,9 @@ impl CompilationUnitExt for tc::CompilationUnit {
 fn compile_all_bytecode_to_object_files(
     harness_paths: &tc::HarnessPaths,
     compilation_units: &[tc::CompilationUnit],
+    signers: Option<String>,
 ) -> anyhow::Result<()> {
-    tc::compile_all_bytecode(harness_paths, compilation_units, "-O", &|cu| {
+    tc::compile_all_bytecode(harness_paths, compilation_units, signers, "-O", &|cu| {
         cu.object_file()
     })
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
@@ -1,0 +1,34 @@
+// signers 0xcafe,0xf00d,0xc0ffee,0xb00
+
+module 0x500::signer {
+    native public fun address_of(acct: &signer): address;
+    native public fun borrow_address(acct: &signer): &address;
+}
+
+module 0x100::M5 {
+    use 0x500::signer;
+
+    public fun signer_by_val(a: signer) {
+        assert!(signer::address_of(&a) == @0xcafe, 0xf00);
+        assert!(*signer::borrow_address(&a) == @0xcafe, 0xf01);
+    }
+
+    public fun signer_by_ref(a: &signer) {
+        assert!(signer::address_of(a) == @0xf00d, 0xf02);
+    }
+
+    public fun signers_by_ref(a: &signer, b: &signer) {
+        assert!(*signer::borrow_address(a) == @0xc0ffee, 0xf03);
+        assert!(*signer::borrow_address(b) == @0xb00, 0xf04);
+    }
+}
+
+script {
+    use 0x100::M5;
+
+    fun main(s1: signer, s2: signer, s3: signer, s4: signer) {
+        M5::signer_by_val(s1);
+        M5::signer_by_ref(&s2);
+        M5::signers_by_ref(&s3, &s4);
+    }
+}


### PR DESCRIPTION
This patch adds support for the Move `signer` type. This is essentially
an opaque address (LLVM type `{ [N x i8] }' that can only be created or
accessed by the runtime.

Add missing native function `signer::address_of(&signer): address` to
the move-native library.

Add a new `--signers` command line option to move-mv-llvm-compiler which
allows the user or test harness to inject signer values to arguments of
type `signer` of the script function. This is for testing purposes only.
This is needed as there is no way for a user program to create a signer.

Implement support in the test harness for a new directive `signers`. This
allows rbpf tests to inject signer values for their unit tests. It parses
and feeds them to the `--signers` command line option.

Add a runnable test `signer01` which shows all the pieces working together.