### PR TITLE
Remove native `address_of`.

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -468,7 +468,7 @@ pub(crate) mod rt_types {
     /// This is mapped to the address size of the target platform, and may
     /// differ from Move VM.
     #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub struct MoveAddress(pub [u8; target_defs::ACCOUNT_ADDRESS_LENGTH]);
 
     // Defined in std::type_name; not a primitive.
@@ -645,11 +645,6 @@ mod std {
         #[export_name = "move_native_signer_borrow_address"]
         extern "C" fn borrow_address(s: &MoveSigner) -> &MoveAddress {
             &s.0
-        }
-
-        #[export_name = "move_native_signer_address_of"]
-        extern "C" fn address_of(s: &MoveSigner) -> MoveAddress {
-            s.0
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
@@ -1,8 +1,13 @@
 // signers 0xcafe,0xf00d,0xc0ffee,0xb00
 
+// A phony `signer` module until we build `move-stdlib`.
 module 0x500::signer {
-    native public fun address_of(acct: &signer): address;
     native public fun borrow_address(acct: &signer): &address;
+
+    // Copies the address of the signer
+    public fun address_of(s: &signer): address {
+        *borrow_address(s)
+    }
 }
 
 module 0x100::M5 {


### PR DESCRIPTION
This is essentially an NFC patch. I added native `address_of` originally not realizing that `move-stdlib` implements this as Move, not as a native. So we'll do the same.

Since we do not yet build `move-stdlib` (compiler features still maturing), signer test cases that want to use `address_of` will need to provide a mock implementation.