### PR TITLE
Enable env_logger and use it for sbc and struct dumps.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -10,7 +10,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 colored = "2.0.0"
+env_logger = "0.8.3"
 libc = "0.2"
+log = "0.4.14"
 once_cell = "1.10"
 parking_lot = "0.11"
 
@@ -37,8 +39,6 @@ num-traits = "0.2"
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
-env_logger = "0.8.3"
-log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 similar = "2.1.0"

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -750,6 +750,14 @@ impl Type {
             eprintln!();
         }
     }
+
+    pub fn print_to_str(&self) -> &str {
+        unsafe {
+            CStr::from_ptr(LLVMPrintTypeToString(self.0))
+                .to_str()
+                .unwrap()
+        }
+    }
 }
 
 pub struct StructType(LLVMTypeRef);


### PR DESCRIPTION
Initialize the env_logger so that logging can be started with RUST_LOG.

Adjust dump_all_structs to return a string rather than use eprintln!, and use 
debug! macro to log it.

Also log the stackless bytecode for each function.

RUST_LOG=debug will enable all debug information, while structs=debug or 
sbc=debug will selectively enable one or the other. 

This gives us something approximating LLVM's --debug-only=foo facility.