### PR TITLE
NFC: Fail for unhandled PrimitiveType

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -496,6 +496,13 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             }
             Type::Primitive(PrimitiveType::Address) => self.get_llvm_type_for_address(),
             Type::Primitive(PrimitiveType::Signer) => self.get_llvm_type_for_signer(),
+
+            Type::Primitive(PrimitiveType::Num)
+            | Type::Primitive(PrimitiveType::Range)
+            | Type::Primitive(PrimitiveType::EventStore) => {
+                panic!("{mty:?} only appears in specifications.")
+            }
+
             Type::Reference(_, referent_mty) => {
                 let referent_llty = self.llvm_type(referent_mty);
                 referent_llty.ptr_type()

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests.rs
@@ -169,6 +169,12 @@ fn compare_actual_llvm_ir_to_expected(
             compilation_unit.llvm_ir_actual(),
             diff_msg
         ));
+    } else {
+        // If the test was expected to fail but it passed, then issue an error.
+        let xfail = test_plan.xfail_message();
+        if let Some(x) = xfail {
+            anyhow::bail!(format!("Test expected to fail with: {}", x));
+        }
     }
 
     Ok(())

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num-build/modules/0_M.expected.ll
@@ -1,0 +1,4 @@
+; ModuleID = '0x42__M'
+source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num.move
@@ -1,0 +1,7 @@
+module 0x42::M {
+  spec module {
+    fun add_any_unsigned(x: u64, y: u64): num {
+      x + y
+    }
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range-build/modules/0_M.expected.ll
@@ -1,0 +1,4 @@
+; ModuleID = '0x42__M'
+source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range.move
@@ -1,0 +1,7 @@
+module 0x42::M {
+    spec module {
+    fun some_range(upper: u64): range {
+        0..upper
+    }
+    }
+}


### PR DESCRIPTION
These are only used in specifications