### PR TITLE
Implement initial support for generic Move structs.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -199,7 +199,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         worklist.push_back(m_env.get_id());
         while let Some(mid) = worklist.pop_front() {
             let module_data = &g_env.module_data[mid.to_usize()];
-            for shandle in module_data.module.struct_handles().iter() {
+            for shandle in module_data.module.struct_handles() {
                 let struct_view = StructHandleView::new(&module_data.module, shandle);
                 let declaring_module_env = g_env
                     .find_module(&g_env.to_module_name(&struct_view.module_id()))
@@ -224,7 +224,19 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             .collect();
         all_structs.append(&mut local_structs);
 
-        debug!(target: "structs", "{}", self.dump_all_structs(&all_structs, false));
+        let mut all: Vec<(mm::StructEnv, Vec<mty::Type>)> = Vec::new();
+        for s_env in &all_structs {
+            if !s_env.get_type_parameters().is_empty() {
+                // This is a generic structure handle (i.e., representing potentially many
+                // concrete structures). The expansions will occur when the struct definition
+                // instantiations are processed later.
+                continue;
+            }
+            let p = (s_env.clone(), vec![]);
+            all.push(p);
+        }
+
+        debug!(target: "structs", "{}", self.dump_all_structs(&all, false));
 
         // Visit each struct definition, creating corresponding LLVM IR struct types.
         //
@@ -237,13 +249,62 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         // That is, on the first traversal, we create opaque structs (i.e., partially formed,
         // deferring field translation). The second traversal will then fill in the struct bodies
         // where it will have all structure types previously defined.
-        for s_env in &all_structs {
+        for (s_env, _) in &all {
             if !s_env.get_type_parameters().is_empty() {
-                todo!("generic structs not yet implemented");
+                unreachable!("");
             }
-            let ll_name = self.ll_struct_name_from_raw_name(s_env);
+            let ll_name = self.ll_struct_name_from_raw_name(s_env, &[]);
             self.llvm_cx.create_opaque_named_struct(&ll_name);
         }
+
+        // Now that all the concrete structs are available, pull in the generic ones. Each such
+        // StructDefInstantation will induce a concrete expansion once fields are visited later.
+        let this_module_data = &g_env.module_data[m_env.get_id().to_usize()];
+        let cm = &this_module_data.module;
+        for s_def_inst in cm.struct_instantiations() {
+            let tys = m_env.get_type_actuals(Some(s_def_inst.type_parameters));
+            let s_env = m_env.get_struct_by_def_idx(s_def_inst.def);
+            let ll_name = self.ll_struct_name_from_raw_name(&s_env, &tys);
+            self.llvm_cx.create_opaque_named_struct(&ll_name);
+            all.push((s_env, tys));
+        }
+
+        // Similarly, pull in generics from field instantiations.
+        for f_inst in cm.field_instantiations() {
+            let fld_handle = cm.field_handle_at(f_inst.handle);
+            let tys = m_env.get_type_actuals(Some(f_inst.type_parameters));
+            let s_env = m_env.get_struct_by_def_idx(fld_handle.owner);
+            let ll_name = self.ll_struct_name_from_raw_name(&s_env, &tys);
+            if self.llvm_cx.named_struct_type(&ll_name).is_none() {
+                self.llvm_cx.create_opaque_named_struct(&ll_name);
+                all.push((s_env, tys));
+            }
+        }
+
+        // Finally, some generic instantiations still may not have been seen. That would be
+        // case where no explicit definition was already available, such as passing/returning
+        // a generic or constructing a generic. Visit the signature table for any remaining.
+        for sig in this_module_data.module.signatures() {
+            use move_binary_format::file_format::SignatureToken;
+            for st in &sig.0 {
+                if !matches!(st, SignatureToken::StructInstantiation(..)) {
+                    continue;
+                }
+                let gs = m_env.globalize_signature(st);
+                if let mty::Type::Struct(mid, sid, tys) = gs {
+                    let s_env = g_env.get_module(mid).into_struct(sid);
+                    let ll_name = self.ll_struct_name_from_raw_name(&s_env, &tys);
+                    if self.llvm_cx.named_struct_type(&ll_name).is_none() {
+                        self.llvm_cx.create_opaque_named_struct(&ll_name);
+                        all.push((s_env, tys));
+                    }
+                } else {
+                    unreachable!("");
+                }
+            }
+        }
+
+        debug!(target: "structs", "{}", self.dump_all_structs(&all, false));
 
         // Translate input IR representing Move struct MyMod::MyStruct:
         //   struct MyStruct has { copy, drop, key, store } {
@@ -267,11 +328,8 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         //
         // As the compiler evolves and the design comes into focus, additional fields may be added
         // or existing fields changed or removed.
-        for s_env in &all_structs {
-            if !s_env.get_type_parameters().is_empty() {
-                todo!("generic structs not yet implemented");
-            }
-            let ll_name = self.ll_struct_name_from_raw_name(s_env);
+        for (s_env, tyvec) in &all {
+            let ll_name = self.ll_struct_name_from_raw_name(s_env, tyvec);
             let ll_sty = self
                 .llvm_cx
                 .named_struct_type(&ll_name)
@@ -280,7 +338,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             // Visit each field in this struct, collecting field types.
             let mut ll_field_tys = Vec::with_capacity(s_env.get_field_count() + 1);
             for fld_env in s_env.get_fields() {
-                let ll_fld_type = self.llvm_type(&fld_env.get_type());
+                let ll_fld_type = self.llvm_type_with_ty_params(&fld_env.get_type(), tyvec);
                 ll_field_tys.push(ll_fld_type);
             }
 
@@ -289,22 +347,41 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             ll_sty.set_struct_body(&ll_field_tys);
         }
 
-        debug!(target: "structs", "{}", self.dump_all_structs(&all_structs, true));
+        debug!(target: "structs", "{}", self.dump_all_structs(&all, true));
     }
 
-    fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv) -> String {
-        let raw_name = s_env.get_full_name_str();
-        format!("struct.{}", raw_name.replace(':', "_"))
+    fn llvm_type_with_ty_params(&self, mty: &mty::Type, tyvec: &[mty::Type]) -> llvm::Type {
+        match mty {
+            mty::Type::Struct(_mid, _sid, _stys) => {
+                // Substitute any generic type parameters occuring in _stys.
+                let new_sty = mty.instantiate(tyvec);
+                self.llvm_type(&new_sty)
+            }
+            mty::Type::TypeParameter(tp_idx) => self.llvm_type(&tyvec[*tp_idx as usize]),
+            _ => self.llvm_type(mty),
+        }
+    }
+
+    fn struct_raw_type_name(&self, s_env: &mm::StructEnv, tys: &[mty::Type]) -> String {
+        let qid = s_env.get_qualified_id();
+        let s = mty::Type::Struct(qid.module_id, qid.id, tys.to_vec());
+        format!("{}", s.display(&self.env.env.get_type_display_ctx()))
+    }
+
+    fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv, tys: &[mty::Type]) -> String {
+        let raw_name = self.struct_raw_type_name(s_env, tys);
+        let xs = raw_name.replace([':', '<', '>'], "_").replace(", ", ".");
+        format!("struct.{}", xs)
     }
 
     fn dump_all_structs(
         &self,
-        all_structs: &Vec<mm::StructEnv>,
+        all_structs: &Vec<(mm::StructEnv, Vec<mty::Type>)>,
         is_post_translation: bool,
     ) -> String {
         let mut s = "\n".to_string();
-        for s_env in all_structs {
-            let ll_name = self.ll_struct_name_from_raw_name(s_env);
+        for (s_env, tyvec) in all_structs {
+            let ll_name = self.ll_struct_name_from_raw_name(s_env, tyvec);
             let prepost = if is_post_translation {
                 "Translated"
             } else {
@@ -313,7 +390,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             s += &format!(
                 "{} struct '{}' => '%{}'\n",
                 prepost,
-                s_env.get_full_name_str(),
+                self.struct_raw_type_name(s_env, tyvec),
                 ll_name
             )
             .to_string();
@@ -324,7 +401,8 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     fld_env.get_name().display(s_env.symbol_pool())
                 );
                 if is_post_translation {
-                    s += self.llvm_type(&fld_env.get_type()).print_to_str();
+                    let ll_fld_type = self.llvm_type_with_ty_params(&fld_env.get_type(), tyvec);
+                    s += ll_fld_type.print_to_str();
                 } else {
                     s += format!("{:?}", fld_env.get_type()).as_str();
                 };
@@ -512,12 +590,12 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                 // but might end up broken in the future.
                 self.llvm_cx.int_type(8)
             }
-            Type::Struct(declaring_module_id, struct_id, _) => {
+            Type::Struct(declaring_module_id, struct_id, tys) => {
                 let global_env = &self.env.env;
                 let struct_env = global_env
                     .get_module(*declaring_module_id)
                     .into_struct(*struct_id);
-                let struct_name = self.ll_struct_name_from_raw_name(&struct_env);
+                let struct_name = self.ll_struct_name_from_raw_name(&struct_env, tys);
                 if let Some(stype) = self.llvm_cx.named_struct_type(&struct_name) {
                     stype.as_any_type()
                 } else {
@@ -1212,7 +1290,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             return;
         }
 
-        assert!(src_mty.is_number());
+        assert!(src_mty.is_number() || src_mty.is_bool());
 
         let src0_reg = self.load_reg(src[0], &format!("{name}_src_0"));
         let src1_reg = self.load_reg(src[1], &format!("{name}_src_1"));
@@ -1362,8 +1440,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let dst_llval = self.locals[dst_idx].llval;
                 builder.ref_store(src_llval, dst_llval);
             }
-            Operation::BorrowField(mod_id, struct_id, _types, offset) => {
-                // We don't yet translate generic structs, so _types is unused.
+            Operation::BorrowField(mod_id, struct_id, types, offset) => {
                 assert_eq!(src.len(), 1);
                 assert_eq!(dst.len(), 1);
                 let src_llval = self.locals[src[0]].llval;
@@ -1372,7 +1449,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     .get_global_env()
                     .get_module(*mod_id)
                     .into_struct(*struct_id);
-                let struct_name = self.module_cx.ll_struct_name_from_raw_name(&struct_env);
+                let struct_name = self
+                    .module_cx
+                    .ll_struct_name_from_raw_name(&struct_env, types);
                 let stype = self
                     .module_cx
                     .llvm_cx
@@ -1380,15 +1459,16 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     .expect("no struct type");
                 builder.field_ref_store(src_llval, dst_llval, stype, *offset);
             }
-            Operation::Pack(mod_id, struct_id, _types) => {
-                // We don't yet translate generic structs, so _types is unused.
+            Operation::Pack(mod_id, struct_id, types) => {
                 let struct_env = self
                     .get_global_env()
                     .get_module(*mod_id)
                     .into_struct(*struct_id);
                 assert_eq!(dst.len(), 1);
                 assert_eq!(src.len(), struct_env.get_field_count());
-                let struct_name = self.module_cx.ll_struct_name_from_raw_name(&struct_env);
+                let struct_name = self
+                    .module_cx
+                    .ll_struct_name_from_raw_name(&struct_env, types);
                 let stype = self
                     .module_cx
                     .llvm_cx
@@ -1402,15 +1482,16 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let ldst = (self.locals[dst_idx].llty, self.locals[dst_idx].llval);
                 builder.insert_fields_and_store(&fvals, ldst, stype);
             }
-            Operation::Unpack(mod_id, struct_id, _types) => {
-                // We don't yet translate generic structs, so _types is unused.
+            Operation::Unpack(mod_id, struct_id, types) => {
                 let struct_env = self
                     .get_global_env()
                     .get_module(*mod_id)
                     .into_struct(*struct_id);
                 assert_eq!(src.len(), 1);
                 assert_eq!(dst.len(), struct_env.get_field_count());
-                let struct_name = self.module_cx.ll_struct_name_from_raw_name(&struct_env);
+                let struct_name = self
+                    .module_cx
+                    .ll_struct_name_from_raw_name(&struct_env, types);
                 let stype = self
                     .module_cx
                     .llvm_cx

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
@@ -1,0 +1,21 @@
+; ModuleID = '0x100__M2'
+source_filename = "<unknown>"
+
+%struct.M2__Coin_M2__Currency1_ = type { i64, i8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define %struct.M2__Coin_M2__Currency1_ @M2__mint_concrete(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1__value = alloca i64, align 8
+  %local_2 = alloca %struct.M2__Coin_M2__Currency1_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1__value, align 4
+  %fv.0 = load i64, ptr %local_1__value, align 4
+  %insert_0 = insertvalue %struct.M2__Coin_M2__Currency1_ undef, i64 %fv.0, 0
+  store %struct.M2__Coin_M2__Currency1_ %insert_0, ptr %local_2, align 4
+  %retval = load %struct.M2__Coin_M2__Currency1_, ptr %local_2, align 4
+  ret %struct.M2__Coin_M2__Currency1_ %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01.move
@@ -1,0 +1,25 @@
+
+module 0x100::M2 {
+    // Currency Specifiers
+    struct Currency1 {}
+    struct Currency2 {}
+
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    struct Coin<Currency> has store {
+        value: u64
+    }
+
+    // TODO: Enable this once generic functions are implemented.
+    //
+    // Write code generically about all currencies
+    //public fun mint_generic<Currency>(value: u64): Coin<Currency> {
+    //    Coin { value }
+    //}
+
+    // Write code concretely about one currency
+    public fun mint_concrete(value: u64): Coin<Currency1> {
+        Coin { value }
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
@@ -1,0 +1,128 @@
+; ModuleID = '0x100__M6'
+source_filename = "<unknown>"
+
+%struct.M6__Foo_bool_ = type { i1, i8 }
+%struct.M6__Bar_u8.u64_ = type { i8, i64, i8 }
+%struct.M6__Baz_address.u32_ = type { [32 x i8], %struct.M6__Foo_u32_, i8 }
+%struct.M6__Foo_u32_ = type { i32, i8 }
+%struct.M6__Foo_u16_ = type { i16, i8 }
+%struct.M6__Foo_u64_ = type { i64, i8 }
+%struct.M6__Baz_u8.u64_ = type { i8, %struct.M6__Foo_u64_, i8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define i1 @M6__boo() {
+entry:
+  %local_0__x = alloca i1, align 1
+  %local_1 = alloca %struct.M6__Foo_bool_, align 8
+  %local_2__x = alloca i1, align 1
+  store i1 true, ptr %local_0__x, align 1
+  %fv.0 = load i1, ptr %local_0__x, align 1
+  %insert_0 = insertvalue %struct.M6__Foo_bool_ undef, i1 %fv.0, 0
+  store %struct.M6__Foo_bool_ %insert_0, ptr %local_1, align 1
+  %srcval = load %struct.M6__Foo_bool_, ptr %local_1, align 1
+  %ext_0 = extractvalue %struct.M6__Foo_bool_ %srcval, 0
+  store i1 %ext_0, ptr %local_2__x, align 1
+  %retval = load i1, ptr %local_2__x, align 1
+  ret i1 %retval
+}
+
+define { i8, i64 } @M6__goo() {
+entry:
+  %local_0__x = alloca i8, align 1
+  %local_1__y = alloca i64, align 8
+  %local_2 = alloca %struct.M6__Bar_u8.u64_, align 8
+  %local_3__x = alloca i8, align 1
+  %local_4__y = alloca i64, align 8
+  store i8 123, ptr %local_0__x, align 1
+  store i64 456, ptr %local_1__y, align 4
+  %fv.0 = load i8, ptr %local_0__x, align 1
+  %fv.1 = load i64, ptr %local_1__y, align 4
+  %insert_0 = insertvalue %struct.M6__Bar_u8.u64_ undef, i8 %fv.0, 0
+  %insert_1 = insertvalue %struct.M6__Bar_u8.u64_ %insert_0, i64 %fv.1, 1
+  store %struct.M6__Bar_u8.u64_ %insert_1, ptr %local_2, align 4
+  %srcval = load %struct.M6__Bar_u8.u64_, ptr %local_2, align 4
+  %ext_0 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 0
+  %ext_1 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 1
+  store i8 %ext_0, ptr %local_3__x, align 1
+  store i64 %ext_1, ptr %local_4__y, align 4
+  %rv.0 = load i8, ptr %local_3__x, align 1
+  %rv.1 = load i64, ptr %local_4__y, align 4
+  %insert_01 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
+  %insert_12 = insertvalue { i8, i64 } %insert_01, i64 %rv.1, 1
+  ret { i8, i64 } %insert_12
+}
+
+define i32 @M6__rcv_and_idx(%struct.M6__Baz_address.u32_ %0) {
+entry:
+  %local_0 = alloca %struct.M6__Baz_address.u32_, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__y = alloca ptr, align 8
+  %local_3__x = alloca ptr, align 8
+  %local_4 = alloca i32, align 4
+  store %struct.M6__Baz_address.u32_ %0, ptr %local_0, align 4
+  store ptr %local_0, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.M6__Baz_address.u32_, ptr %tmp, i32 0, i32 1
+  store ptr %fld_ref, ptr %local_2__y, align 8
+  %tmp1 = load ptr, ptr %local_2__y, align 8
+  %fld_ref2 = getelementptr inbounds %struct.M6__Foo_u32_, ptr %tmp1, i32 0, i32 0
+  store ptr %fld_ref2, ptr %local_3__x, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_3__x, align 8
+  %load_deref_store_tmp2 = load i32, ptr %load_deref_store_tmp1, align 4
+  store i32 %load_deref_store_tmp2, ptr %local_4, align 4
+  %retval = load i32, ptr %local_4, align 4
+  ret i32 %retval
+}
+
+define %struct.M6__Foo_u16_ @M6__snd_rcv(%struct.M6__Foo_u16_ %0) {
+entry:
+  %local_0 = alloca %struct.M6__Foo_u16_, align 8
+  %local_1 = alloca %struct.M6__Foo_u16_, align 8
+  store %struct.M6__Foo_u16_ %0, ptr %local_0, align 2
+  %retval = load %struct.M6__Foo_u16_, ptr %local_0, align 2
+  ret %struct.M6__Foo_u16_ %retval
+}
+
+define { i8, i64 } @M6__zoo() {
+entry:
+  %local_0 = alloca %struct.M6__Foo_u64_, align 8
+  %local_1__x = alloca i8, align 1
+  %local_2__x = alloca i64, align 8
+  %local_3__y = alloca %struct.M6__Foo_u64_, align 8
+  %local_4 = alloca %struct.M6__Baz_u8.u64_, align 8
+  %local_5__x = alloca i8, align 1
+  %local_6__y = alloca %struct.M6__Foo_u64_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8__x = alloca ptr, align 8
+  %local_9 = alloca i64, align 8
+  store i8 123, ptr %local_1__x, align 1
+  store i64 1992, ptr %local_2__x, align 4
+  %fv.0 = load i64, ptr %local_2__x, align 4
+  %insert_0 = insertvalue %struct.M6__Foo_u64_ undef, i64 %fv.0, 0
+  store %struct.M6__Foo_u64_ %insert_0, ptr %local_3__y, align 4
+  %fv.01 = load i8, ptr %local_1__x, align 1
+  %fv.1 = load %struct.M6__Foo_u64_, ptr %local_3__y, align 4
+  %insert_02 = insertvalue %struct.M6__Baz_u8.u64_ undef, i8 %fv.01, 0
+  %insert_1 = insertvalue %struct.M6__Baz_u8.u64_ %insert_02, %struct.M6__Foo_u64_ %fv.1, 1
+  store %struct.M6__Baz_u8.u64_ %insert_1, ptr %local_4, align 4
+  %srcval = load %struct.M6__Baz_u8.u64_, ptr %local_4, align 4
+  %ext_0 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 0
+  %ext_1 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 1
+  store i8 %ext_0, ptr %local_5__x, align 1
+  store %struct.M6__Foo_u64_ %ext_1, ptr %local_6__y, align 4
+  %load_store_tmp = load %struct.M6__Foo_u64_, ptr %local_6__y, align 4
+  store %struct.M6__Foo_u64_ %load_store_tmp, ptr %local_0, align 4
+  store ptr %local_0, ptr %local_7, align 8
+  %tmp = load ptr, ptr %local_7, align 8
+  %fld_ref = getelementptr inbounds %struct.M6__Foo_u64_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_8__x, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_8__x, align 8
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
+  store i64 %load_deref_store_tmp2, ptr %local_9, align 4
+  %rv.0 = load i8, ptr %local_5__x, align 1
+  %rv.1 = load i64, ptr %local_9, align 4
+  %insert_03 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
+  %insert_14 = insertvalue { i8, i64 } %insert_03, i64 %rv.1, 1
+  ret { i8, i64 } %insert_14
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02.move
@@ -1,0 +1,42 @@
+
+
+module 0x100::M6 {
+    struct Foo<T> has copy, drop { x: T }
+
+    struct Bar<T1, T2> has copy, drop {
+        x: T1,
+        y: T2,
+    }
+
+    struct Baz<T1, T2> has copy, drop {
+        x: T1,
+        y: Foo<T2>,
+    }
+
+    fun boo(): bool {
+        let t1 = Foo<bool> { x: true };
+        let Foo<bool> { x } = t1;
+        x
+    }
+
+    fun goo(): (u8, u64) {
+        let t1 = Bar<u8, u64> { x: 123, y: 456 };
+        let Bar<u8, u64> { x, y } = t1;
+        (x, y)
+    }
+
+    fun zoo(): (u8, u64) {
+        let ffs = Foo<u64> { x: 1992 };
+        let t1 = Baz<u8, u64> { x: 123, y: ffs };
+        let Baz<u8, u64> { x, y } = t1;
+        (x, y.x)
+    }
+
+    fun snd_rcv(a: Foo<u16>): Foo<u16> {
+        a
+    }
+
+    fun rcv_and_idx(a: Baz<address, u32>): u32 {
+        a.y.x
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct01.move
@@ -1,0 +1,54 @@
+
+module 0x100::M10 {
+    struct Foo<T> has copy, drop { x: T }
+
+    struct Bar<T1, T2> has copy, drop {
+        x: T1,
+        y: T2,
+    }
+
+    public fun f1_pack_unpack_1type(in: bool): bool {
+        let t1 = Foo<bool> { x: in };
+        let Foo<bool> { x } = t1;
+        x
+    }
+
+    public fun f1_pack_unpack_2types(in1: u8, in2: u64): (u8, u64) {
+        let t1 = Bar<u8, u64> { x: in1, y: in2 };
+        let Bar<u8, u64> { x, y } = t1;
+        (x + 1, y + 1)
+    }
+
+    public fun new_foo_u16(val: u16): Foo<u16> {
+        Foo<u16> { x: val }
+    }
+
+    public fun get_from_foo_u16(s: Foo<u16>): u16 {
+        s.x
+    }
+
+    public fun get_from_foo_u16_byref(s: &Foo<u16>): u16 {
+        s.x
+    }
+}
+
+script {
+    use 0x100::M10;
+
+    fun main() {
+        let t1 = M10::f1_pack_unpack_1type(true);
+        assert!(t1 == true, 0xf00);
+        let t2 = M10::f1_pack_unpack_1type(false);
+        assert!(t2 == false, 0xf01);
+
+        let (t3, t4) = M10::f1_pack_unpack_2types(123, 456);
+        assert!(t3 == 124, 0xf02);
+        assert!(t4 == 457, 0xf03);
+
+        let t5 = M10::new_foo_u16(65000);
+        assert!(M10::get_from_foo_u16(t5) == 65000, 0xf04);
+
+        let t6 = M10::new_foo_u16(0xf00d);
+        assert!(M10::get_from_foo_u16_byref(&t6) == 0xf00d, 0xf05);
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct02.move
@@ -1,0 +1,71 @@
+
+
+module 0x100::M10 {
+    struct Many<T1, T2, T3, T4, T5, T6> has copy, drop {
+        a: T1,
+        b: T2,
+        c: T3,
+        d: T4,
+        e: T5,
+        f: T6,
+        x: bool,
+    }
+
+    public fun new(in1: u8, in2: u16, in3: u32, in4: u64, in5: u128, in6: u256): Many<u8, u16, u32, u64, u128, u256> {
+        let t1 = Many<u8, u16, u32, u64, u128, u256> {
+            a: in1, b: in2, c: in3, d: in4, e: in5, f: in6, x: true
+        };
+        t1
+    }
+
+    public fun get_a(s: Many<u8, u16, u32, u64, u128, u256>): u8 {
+        s.a
+    }
+    public fun get_b(s: Many<u8, u16, u32, u64, u128, u256>): u16 {
+        s.b
+    }
+    public fun get_c(s: Many<u8, u16, u32, u64, u128, u256>): u32 {
+        s.c
+    }
+    public fun get_d(s: Many<u8, u16, u32, u64, u128, u256>): u64 {
+        s.d
+    }
+    public fun get_e(s: Many<u8, u16, u32, u64, u128, u256>): u128 {
+        s.e
+    }
+    public fun get_f(s: Many<u8, u16, u32, u64, u128, u256>): u256 {
+        s.f
+    }
+    public fun get_x(s: Many<u8, u16, u32, u64, u128, u256>): bool {
+        s.x
+    }
+}
+
+script {
+    use 0x100::M10;
+
+    fun main() {
+        let t1 = M10::new(1, 2, 3, 4, 5, 6);
+
+        let ta = M10::get_a(t1);
+        assert!(ta == 1, 0xf00);
+
+        let tb = M10::get_b(t1);
+        assert!(tb == 2, 0xf01);
+
+        let tc = M10::get_c(t1);
+        assert!(tc == 3, 0xf02);
+
+        let td = M10::get_d(t1);
+        assert!(td == 4, 0xf03);
+
+        let te = M10::get_e(t1);
+        assert!(te == 5, 0xf04);
+
+        let tf = M10::get_f(t1);
+        assert!(tf == 6, 0xf05);
+
+        let tx = M10::get_x(t1);
+        assert!(tx == true , 0xf07);
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct03.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/generic-struct03.move
@@ -1,0 +1,47 @@
+
+
+module 0x100::M10 {
+    struct Foo<T> has copy, drop { x: T }
+
+    // Generic struct with generic struct member.
+    struct Bar<T1, T2> has copy, drop {
+        a: T1,
+        b: Foo<T2>,
+    }
+
+    public fun f1_pack_unpack_2types(in1: u8, in2: u64): (u8, u64) {
+        let t0 = Foo<u64> { x: in2 };
+        let t1 = Bar<u8, u64> { a: in1, b: t0 };
+        let Bar<u8, u64> { a, b } = t1;
+        (a + 1, b.x + 1)
+    }
+
+    public fun new_bar(in1: u8, in2: u64): Bar<u8, u64> {
+        let t0 = Foo<u64> { x: in2 };
+        let t1 = Bar<u8, u64> { a: in1, b: t0 };
+        t1
+    }
+
+    public fun get_inner(s: Bar<u8, u64>): Foo<u64> {
+        s.b
+    }
+
+    public fun get_from_foo(s: Foo<u64>): u64 {
+        s.x
+    }
+}
+
+script {
+    use 0x100::M10;
+
+    fun main() {
+        let (t1, t2) = M10::f1_pack_unpack_2types(123, 456);
+        assert!(t1 == 124, 0xf00);
+        assert!(t2 == 457, 0xf01);
+
+        let t3 = M10::new_bar(255, 65539);
+        let t4 = M10::get_inner(t3);
+        let t5 = M10::get_from_foo(t4);
+        assert!(t5 == 65539, 0xf03);
+    }
+}


### PR DESCRIPTION
This patch implements support for generic structs (structs parameterized by types). This builds on the previous patch that implements concrete struct support. That code eagerly detects and declares structs before the rest of the translation. We currently continue the same approach for generics.

The idea is to first visit the various "instantiation" tables (e.g., StructDefInstantiations, FieldInstantiations) to locate and collect the generic types.

Each generic type is then expanded into multiple concrete LLVM struct types depending on usage in the module.

In some cases, Not all generic types are evident from the tables mentioned above. These can arise implicitly from usage as function arguments or return values, or when constructing a generic. These remaining uses are gleaned from the signature table and added to the list to be expanded.

Note that llvm_type is currently not general enough to handle generics and does not properly deal with TypeParameter. I've written a wrapper type getter that is general enough to handle many cases. This avoids needing to update all the users of llvm_type in this patch (i.e., additional unnecessary churn). An orthogonal clean-up task is to generalize the existing llvm_type and is left for a later patch.

A few runnable rbpf test cases are included as well as a couple of static LLVM IR tests. As time goes on, we'll feed more substantial code through and add additional tests.

Finally, it is worth mentioning that in the original concrete struct patch, I considered lazily declaring structs during the translation proper. At the time, that was more complex than the eager approach (i.e., doing it ahead of time). With generics, however, the lazy approach might be simpler (i.e., see the passage above about cases not directly seen in the instantiation tables). I May re-examine this later as time permits.