### PR TITLE
Implement initial support for generic Move functions.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -816,6 +816,10 @@ impl FunctionType {
 pub struct Function(LLVMValueRef);
 
 impl Function {
+    pub fn as_gv(&self) -> Global {
+        Global(self.0)
+    }
+
     pub fn get_next_basic_block(&self, basic_block: BasicBlock) -> Option<BasicBlock> {
         let next_bb = unsafe { BasicBlock(LLVMGetNextBasicBlock(basic_block.0)) };
         if next_bb.0.is_null() {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define void @Test__test() {
+define private void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define void @Test__test() {
+define private void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test__test_and(i8 %0, i8 %1) {
+define private i8 @Test__test_and(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -24,7 +24,7 @@ entry:
   ret i8 %retval
 }
 
-define i8 @Test__test_or(i8 %0, i8 %1) {
+define private i8 @Test__test_or(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -45,7 +45,7 @@ entry:
   ret i8 %retval
 }
 
-define i128 @Test__test_shl128(i128 %0, i8 %1) {
+define private i128 @Test__test_shl128(i128 %0, i8 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i8, align 1
@@ -75,7 +75,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i32 @Test__test_shl32(i32 %0, i8 %1) {
+define private i32 @Test__test_shl32(i32 %0, i8 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i8, align 1
@@ -105,7 +105,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i64 @Test__test_shl64(i64 %0, i8 %1) {
+define private i64 @Test__test_shl64(i64 %0, i8 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1
@@ -135,7 +135,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i8 @Test__test_shl8(i8 %0, i8 %1) {
+define private i8 @Test__test_shl8(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -164,7 +164,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__test_shr128(i128 %0, i8 %1) {
+define private i128 @Test__test_shr128(i128 %0, i8 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i8, align 1
@@ -194,7 +194,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i32 @Test__test_shr32(i32 %0, i8 %1) {
+define private i32 @Test__test_shr32(i32 %0, i8 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i8, align 1
@@ -224,7 +224,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i64 @Test__test_shr64(i64 %0, i8 %1) {
+define private i64 @Test__test_shr64(i64 %0, i8 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1
@@ -254,7 +254,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i8 @Test__test_shr8(i8 %0, i8 %1) {
+define private i8 @Test__test_shr8(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -283,7 +283,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_xor(i8 %0, i8 %1) {
+define private i8 @Test__test_xor(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test__get_sub(i8 %0, i8 %1) {
+define private i8 @Test__get_sub(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -32,7 +32,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define void @Test__test() {
+define private void @Test__test() {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i32 @Test__cast_u32(i8 %0) {
+define private i32 @Test__cast_u32(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -18,7 +18,7 @@ entry:
   ret i32 %retval
 }
 
-define i64 @Test__cast_u64(i8 %0) {
+define private i64 @Test__cast_u64(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -33,7 +33,7 @@ entry:
   ret i64 %retval
 }
 
-define i8 @Test__cast_u8(i32 %0) {
+define private i8 @Test__cast_u8(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i128 @Test__cast_u128_as_u128(i128 %0) {
+define private i128 @Test__cast_u128_as_u128(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -17,7 +17,7 @@ entry:
   ret i128 %retval
 }
 
-define i16 @Test__cast_u128_as_u16(i128 %0) {
+define private i16 @Test__cast_u128_as_u16(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -40,7 +40,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define i256 @Test__cast_u128_as_u256(i128 %0) {
+define private i256 @Test__cast_u128_as_u256(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -55,7 +55,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u128_as_u32(i128 %0) {
+define private i32 @Test__cast_u128_as_u32(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -78,7 +78,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i64 @Test__cast_u128_as_u64(i128 %0) {
+define private i64 @Test__cast_u128_as_u64(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -101,7 +101,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i8 @Test__cast_u128_as_u8(i128 %0) {
+define private i8 @Test__cast_u128_as_u8(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -124,7 +124,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__cast_u16_as_u128(i16 %0) {
+define private i128 @Test__cast_u16_as_u128(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -139,7 +139,7 @@ entry:
   ret i128 %retval
 }
 
-define i16 @Test__cast_u16_as_u16(i16 %0) {
+define private i16 @Test__cast_u16_as_u16(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -153,7 +153,7 @@ entry:
   ret i16 %retval
 }
 
-define i256 @Test__cast_u16_as_u256(i16 %0) {
+define private i256 @Test__cast_u16_as_u256(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -168,7 +168,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u16_as_u32(i16 %0) {
+define private i32 @Test__cast_u16_as_u32(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -183,7 +183,7 @@ entry:
   ret i32 %retval
 }
 
-define i64 @Test__cast_u16_as_u64(i16 %0) {
+define private i64 @Test__cast_u16_as_u64(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -198,7 +198,7 @@ entry:
   ret i64 %retval
 }
 
-define i8 @Test__cast_u16_as_u8(i16 %0) {
+define private i8 @Test__cast_u16_as_u8(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -221,7 +221,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__cast_u256_as_u128(i256 %0) {
+define private i128 @Test__cast_u256_as_u128(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -244,7 +244,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i16 @Test__cast_u256_as_u16(i256 %0) {
+define private i16 @Test__cast_u256_as_u16(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -267,7 +267,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define i256 @Test__cast_u256_as_u256(i256 %0) {
+define private i256 @Test__cast_u256_as_u256(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -281,7 +281,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u256_as_u32(i256 %0) {
+define private i32 @Test__cast_u256_as_u32(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -304,7 +304,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i64 @Test__cast_u256_as_u64(i256 %0) {
+define private i64 @Test__cast_u256_as_u64(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -327,7 +327,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i8 @Test__cast_u256_as_u8(i256 %0) {
+define private i8 @Test__cast_u256_as_u8(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -350,7 +350,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__cast_u32_as_u128(i32 %0) {
+define private i128 @Test__cast_u32_as_u128(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -365,7 +365,7 @@ entry:
   ret i128 %retval
 }
 
-define i16 @Test__cast_u32_as_u16(i32 %0) {
+define private i16 @Test__cast_u32_as_u16(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -388,7 +388,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define i256 @Test__cast_u32_as_u256(i32 %0) {
+define private i256 @Test__cast_u32_as_u256(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -403,7 +403,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u32_as_u32(i32 %0) {
+define private i32 @Test__cast_u32_as_u32(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -417,7 +417,7 @@ entry:
   ret i32 %retval
 }
 
-define i64 @Test__cast_u32_as_u64(i32 %0) {
+define private i64 @Test__cast_u32_as_u64(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -432,7 +432,7 @@ entry:
   ret i64 %retval
 }
 
-define i8 @Test__cast_u32_as_u8(i32 %0) {
+define private i8 @Test__cast_u32_as_u8(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -455,7 +455,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__cast_u64_as_u128(i64 %0) {
+define private i128 @Test__cast_u64_as_u128(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -470,7 +470,7 @@ entry:
   ret i128 %retval
 }
 
-define i16 @Test__cast_u64_as_u16(i64 %0) {
+define private i16 @Test__cast_u64_as_u16(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -493,7 +493,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define i256 @Test__cast_u64_as_u256(i64 %0) {
+define private i256 @Test__cast_u64_as_u256(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -508,7 +508,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u64_as_u32(i64 %0) {
+define private i32 @Test__cast_u64_as_u32(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -531,7 +531,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i64 @Test__cast_u64_as_u64(i64 %0) {
+define private i64 @Test__cast_u64_as_u64(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -545,7 +545,7 @@ entry:
   ret i64 %retval
 }
 
-define i8 @Test__cast_u64_as_u8(i64 %0) {
+define private i8 @Test__cast_u64_as_u8(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -568,7 +568,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i128 @Test__cast_u8_as_u128(i8 %0) {
+define private i128 @Test__cast_u8_as_u128(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -583,7 +583,7 @@ entry:
   ret i128 %retval
 }
 
-define i16 @Test__cast_u8_as_u16(i8 %0) {
+define private i16 @Test__cast_u8_as_u16(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -598,7 +598,7 @@ entry:
   ret i16 %retval
 }
 
-define i256 @Test__cast_u8_as_u256(i8 %0) {
+define private i256 @Test__cast_u8_as_u256(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -613,7 +613,7 @@ entry:
   ret i256 %retval
 }
 
-define i32 @Test__cast_u8_as_u32(i8 %0) {
+define private i32 @Test__cast_u8_as_u32(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -628,7 +628,7 @@ entry:
   ret i32 %retval
 }
 
-define i64 @Test__cast_u8_as_u64(i8 %0) {
+define private i64 @Test__cast_u8_as_u64(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -643,7 +643,7 @@ entry:
   ret i64 %retval
 }
 
-define i8 @Test__cast_u8_as_u8(i8 %0) {
+define private i8 @Test__cast_u8_as_u8(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i128 @Test__takes_u128(i128 %0) {
+define private i128 @Test__takes_u128(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -14,7 +14,7 @@ entry:
   ret i128 %retval
 }
 
-define i128 @Test__test_const_u128() {
+define private i128 @Test__test_const_u128() {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i1 @Test__test(i8 %0, i8 %1) {
+define private i1 @Test__test(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
@@ -11,7 +11,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i1 @M6__boo() {
+define private i1 @M6__boo() {
 entry:
   %local_0__x = alloca i1, align 1
   %local_1 = alloca %struct.M6__Foo_bool_, align 8
@@ -27,7 +27,7 @@ entry:
   ret i1 %retval
 }
 
-define { i8, i64 } @M6__goo() {
+define private { i8, i64 } @M6__goo() {
 entry:
   %local_0__x = alloca i8, align 1
   %local_1__y = alloca i64, align 8
@@ -53,7 +53,7 @@ entry:
   ret { i8, i64 } %insert_12
 }
 
-define i32 @M6__rcv_and_idx(%struct.M6__Baz_address.u32_ %0) {
+define private i32 @M6__rcv_and_idx(%struct.M6__Baz_address.u32_ %0) {
 entry:
   %local_0 = alloca %struct.M6__Baz_address.u32_, align 8
   %local_1 = alloca ptr, align 8
@@ -75,7 +75,7 @@ entry:
   ret i32 %retval
 }
 
-define %struct.M6__Foo_u16_ @M6__snd_rcv(%struct.M6__Foo_u16_ %0) {
+define private %struct.M6__Foo_u16_ @M6__snd_rcv(%struct.M6__Foo_u16_ %0) {
 entry:
   %local_0 = alloca %struct.M6__Foo_u16_, align 8
   %local_1 = alloca %struct.M6__Foo_u16_, align 8
@@ -84,7 +84,7 @@ entry:
   ret %struct.M6__Foo_u16_ %retval
 }
 
-define { i8, i64 } @M6__zoo() {
+define private { i8, i64 } @M6__zoo() {
 entry:
   %local_0 = alloca %struct.M6__Foo_u64_, align 8
   %local_1__x = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
@@ -1,0 +1,49 @@
+; ModuleID = '0x100__M2'
+source_filename = "<unknown>"
+
+%struct.M2__Coin_M2__Bitcoin_ = type { i64, i8 }
+%struct.M2__Coin_M2__Sol_ = type { i64, i8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private %struct.M2__Coin_M2__Bitcoin_ @M2__call_mint_generic() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
+  store i64 4, ptr %local_0, align 4
+  %call_arg_0 = load i64, ptr %local_0, align 4
+  %retval = call %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %call_arg_0)
+  store %struct.M2__Coin_M2__Bitcoin_ %retval, ptr %local_1, align 4
+  %retval1 = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_1, align 4
+  ret %struct.M2__Coin_M2__Bitcoin_ %retval1
+}
+
+define %struct.M2__Coin_M2__Sol_ @M2__mint_concrete(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1__value = alloca i64, align 8
+  %local_2 = alloca %struct.M2__Coin_M2__Sol_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1__value, align 4
+  %fv.0 = load i64, ptr %local_1__value, align 4
+  %insert_0 = insertvalue %struct.M2__Coin_M2__Sol_ undef, i64 %fv.0, 0
+  store %struct.M2__Coin_M2__Sol_ %insert_0, ptr %local_2, align 4
+  %retval = load %struct.M2__Coin_M2__Sol_, ptr %local_2, align 4
+  ret %struct.M2__Coin_M2__Sol_ %retval
+}
+
+define %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1__value = alloca i64, align 8
+  %local_2 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1__value, align 4
+  %fv.0 = load i64, ptr %local_1__value, align 4
+  %insert_0 = insertvalue %struct.M2__Coin_M2__Bitcoin_ undef, i64 %fv.0, 0
+  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 4
+  %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 4
+  ret %struct.M2__Coin_M2__Bitcoin_ %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01.move
@@ -1,0 +1,27 @@
+
+module 0x100::M2 {
+    // Currency Specifiers
+    struct Sol {}
+    struct Bitcoin {}
+
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    struct Coin<phantom Currency> has store {
+        value: u64
+    }
+
+    // Write code generically about all currencies
+    public fun mint_generic<Currency>(value: u64): Coin<Currency> {
+        Coin { value }
+    }
+
+    // Write code concretely about one currency
+    public fun mint_concrete(value: u64): Coin<Sol> {
+        Coin { value }
+    }
+
+    fun call_mint_generic(): Coin<Bitcoin> {
+        mint_generic<Bitcoin>(4)
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/0_Coins.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/0_Coins.expected.ll
@@ -1,0 +1,4 @@
+; ModuleID = '0x100__Coins'
+source_filename = "<unknown>"
+
+declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
@@ -1,0 +1,118 @@
+; ModuleID = '0x200__M11'
+source_filename = "<unknown>"
+
+%struct.Coins__Coin_M11__USDC_ = type { i64, i8 }
+%struct.Coins__Coin_M11__Eth_ = type { i64, i8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private i64 @M11__get_value_usdc(%struct.Coins__Coin_M11__USDC_ %0) {
+entry:
+  %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_2 = alloca i64, align 8
+  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
+  %call_arg_0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
+  %retval = call i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %call_arg_0)
+  store i64 %retval, ptr %local_2, align 4
+  %retval1 = load i64, ptr %local_2, align 4
+  ret i64 %retval1
+}
+
+define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @M11__mint_2coins_usdc_and_eth(i64 %0, i64 %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_5 = alloca %struct.Coins__Coin_M11__Eth_, align 8
+  store i64 %0, ptr %local_0, align 4
+  store i64 %1, ptr %local_1, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp1 = load i64, ptr %local_1, align 4
+  store i64 %load_store_tmp1, ptr %local_3, align 4
+  %call_arg_0 = load i64, ptr %local_2, align 4
+  %call_arg_1 = load i64, ptr %local_3, align 4
+  %retval = call { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %call_arg_0, i64 %call_arg_1)
+  %extract_0 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 0
+  %extract_1 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 1
+  store %struct.Coins__Coin_M11__USDC_ %extract_0, ptr %local_4, align 4
+  store %struct.Coins__Coin_M11__Eth_ %extract_1, ptr %local_5, align 4
+  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_4, align 4
+  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 4
+  %insert_0 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
+  %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_0, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
+  ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
+}
+
+define private %struct.Coins__Coin_M11__USDC_ @M11__mint_usdc(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %call_arg_0 = load i64, ptr %local_1, align 4
+  %retval = call %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %call_arg_0)
+  store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 4
+  %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
+  ret %struct.Coins__Coin_M11__USDC_ %retval1
+}
+
+define private i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %0) {
+entry:
+  %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_2__value = alloca i64, align 8
+  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
+  %srcval = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
+  %ext_0 = extractvalue %struct.Coins__Coin_M11__USDC_ %srcval, 0
+  store i64 %ext_0, ptr %local_2__value, align 4
+  %retval = load i64, ptr %local_2__value, align 4
+  ret i64 %retval
+}
+
+define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %0, i64 %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2__value = alloca i64, align 8
+  %local_3 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_4__value = alloca i64, align 8
+  %local_5 = alloca %struct.Coins__Coin_M11__Eth_, align 8
+  store i64 %0, ptr %local_0, align 4
+  store i64 %1, ptr %local_1, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_2__value, align 4
+  %fv.0 = load i64, ptr %local_2__value, align 4
+  %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
+  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_3, align 4
+  %load_store_tmp1 = load i64, ptr %local_1, align 4
+  store i64 %load_store_tmp1, ptr %local_4__value, align 4
+  %fv.02 = load i64, ptr %local_4__value, align 4
+  %insert_03 = insertvalue %struct.Coins__Coin_M11__Eth_ undef, i64 %fv.02, 0
+  store %struct.Coins__Coin_M11__Eth_ %insert_03, ptr %local_5, align 4
+  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_3, align 4
+  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 4
+  %insert_04 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
+  %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_04, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
+  ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
+}
+
+define private %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1__value = alloca i64, align 8
+  %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1__value, align 4
+  %fv.0 = load i64, ptr %local_1__value, align 4
+  %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
+  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_2, align 4
+  %retval = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
+  ret %struct.Coins__Coin_M11__USDC_ %retval
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02.move
@@ -1,0 +1,47 @@
+
+module 0x100::Coins {
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    struct Coin<phantom Currency> has store {
+        value: u64
+    }
+
+    // Write code generically about all currencies
+    public fun mint_generic<Currency>(value: u64): Coin<Currency> {
+        Coin { value }
+    }
+
+    public fun get_value_generic<Currency>(c: Coin<Currency>): u64 {
+        let Coin<Currency> { value } = c;
+        value
+    }
+
+    public fun mint_2coins_generic<C1, C2>(n1: u64, n2: u64): (Coin<C1>, Coin<C2>) {
+        (Coin<C1> { value: n1 }, Coin<C2> { value: n2 })
+   }
+}
+
+// Instantiate generic function from a different module.
+//
+// Also exercises generic structs as arguments and return values
+// of generic functions (including returning multiple generic values).
+module 0x200::M11 {
+    use 0x100::Coins::Coin;
+
+    // Currency Specifiers.
+    struct Eth {}
+    struct USDC {}
+
+    fun mint_usdc(n: u64): Coin<USDC> {
+        0x100::Coins::mint_generic<USDC>(n)
+    }
+
+    fun mint_2coins_usdc_and_eth(nu: u64, ne: u64): (Coin<USDC>, Coin<Eth>) {
+        0x100::Coins::mint_2coins_generic<USDC, Eth>(nu, ne)
+    }
+
+    fun get_value_usdc(c: Coin<USDC>): u64 {
+        0x100::Coins::get_value_generic<USDC>(c)
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test__test(i1 %0) {
+define private i8 @Test__test(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i1 @Test__test_eq(i8 %0, i8 %1) {
+define private i1 @Test__test_eq(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -24,7 +24,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_ge(i8 %0, i8 %1) {
+define private i1 @Test__test_ge(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -45,7 +45,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_gt(i8 %0, i8 %1) {
+define private i1 @Test__test_gt(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -66,7 +66,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_le(i8 %0, i8 %1) {
+define private i1 @Test__test_le(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -87,7 +87,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_logical_and(i1 %0, i1 %1) {
+define private i1 @Test__test_logical_and(i1 %0, i1 %1) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -108,7 +108,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_logical_or(i1 %0, i1 %1) {
+define private i1 @Test__test_logical_or(i1 %0, i1 %1) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -129,7 +129,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_lt(i8 %0, i8 %1) {
+define private i1 @Test__test_lt(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -150,7 +150,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_ne(i8 %0, i8 %1) {
+define private i1 @Test__test_ne(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -171,7 +171,7 @@ entry:
   ret i1 %retval
 }
 
-define i1 @Test__test_not(i1 %0) {
+define private i1 @Test__test_not(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i128 @Test__test(i128 %0, i128 %1) {
+define private i128 @Test__test(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -32,7 +32,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i128 @Test__test_div(i128 %0, i128 %1) {
+define private i128 @Test__test_div(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -61,7 +61,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i128 @Test__test_mod(i128 %0, i128 %1) {
+define private i128 @Test__test_mod(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -90,7 +90,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i128 @Test__test_mul(i128 %0, i128 %1) {
+define private i128 @Test__test_mul(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -120,7 +120,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define i128 @Test__test_sub(i128 %0, i128 %1) {
+define private i128 @Test__test_sub(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i32 @Test__test(i32 %0, i32 %1) {
+define private i32 @Test__test(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -32,7 +32,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i32 @Test__test_div(i32 %0, i32 %1) {
+define private i32 @Test__test_div(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -61,7 +61,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i32 @Test__test_mul_trunc(i32 %0, i32 %1) {
+define private i32 @Test__test_mul_trunc(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -91,7 +91,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define i32 @Test__test_sub(i32 %0, i32 %1) {
+define private i32 @Test__test_sub(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i64 @Test__test(i64 %0, i64 %1) {
+define private i64 @Test__test(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -32,7 +32,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i64 @Test__test_div(i64 %0, i64 %1) {
+define private i64 @Test__test_div(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -61,7 +61,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i64 @Test__test_mul(i64 %0, i64 %1) {
+define private i64 @Test__test_mul(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -91,7 +91,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define i64 @Test__test_sub(i64 %0, i64 %1) {
+define private i64 @Test__test_sub(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test__test_add(i8 %0, i8 %1) {
+define private i8 @Test__test_add(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -32,7 +32,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_div(i8 %0, i8 %1) {
+define private i8 @Test__test_div(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -61,7 +61,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_mod(i8 %0, i8 %1) {
+define private i8 @Test__test_mod(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -90,7 +90,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_mul(i8 %0, i8 %1) {
+define private i8 @Test__test_mul(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -120,7 +120,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define i8 @Test__test_sub(i8 %0, i8 %1) {
+define private i8 @Test__test_sub(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define { i1, i1 } @Test__ret_2vals() {
+define private { i1, i1 } @Test__ret_2vals() {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -16,7 +16,7 @@ entry:
   ret { i1, i1 } %insert_1
 }
 
-define { ptr, i8, i128, i32 } @Test__ret_4vals(ptr %0) {
+define private { ptr, i8, i128, i32 } @Test__ret_4vals(ptr %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -40,7 +40,7 @@ entry:
   ret { ptr, i8, i128, i32 } %insert_3
 }
 
-define void @Test__use_2val_call_result() {
+define private void @Test__use_2val_call_result() {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -57,7 +57,7 @@ entry:
   ret void
 }
 
-define void @Test__use_4val_call_result() {
+define private void @Test__use_4val_call_result() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
@@ -3,7 +3,7 @@ source_filename = "<unknown>"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test__test() {
+define private i8 @Test__test() {
 entry:
   %local_0 = alloca i8, align 1
   store i8 100, ptr %local_0, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/check-dup-private-func.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/check-dup-private-func.move
@@ -1,0 +1,26 @@
+
+// Check that private functions with the same name from two different
+// modules (also with the same name) don't have name collision (proper
+// visibility).
+module 0x100::MX {
+    fun my_private() {
+    }
+    public fun doit1() {
+        my_private();
+    }
+}
+
+module 0x200::MX {
+    fun my_private() {
+    }
+    public fun doit2() {
+        my_private();
+    }
+}
+
+script {
+    fun main() {
+        0x100::MX::doit1();
+        0x200::MX::doit2();
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func01.move
@@ -1,0 +1,44 @@
+
+module 0x100::M2 {
+    // Currency Specifiers
+    struct Sol {}
+    struct Bitcoin {}
+
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    struct Coin<phantom Currency> has store {
+        value: u64
+    }
+
+    // Write code generically about all currencies
+    public fun mint_generic<Currency>(value: u64): Coin<Currency> {
+        Coin { value }
+    }
+
+    // Write code concretely about one currency
+    public fun mint_sol(value: u64): Coin<Sol> {
+        Coin { value }
+    }
+
+    public fun mint_bitcoin_via_generic(n: u64): Coin<Bitcoin> {
+        mint_generic<Bitcoin>(n)
+    }
+
+    public fun get_value_generic<Currency>(c: Coin<Currency>): u64 {
+        let Coin<Currency> { value } = c;
+        value
+    }
+}
+
+script {
+    fun main() {
+        let some_sol = 0x100::M2::mint_sol(860);
+        let t1 = 0x100::M2::get_value_generic<0x100::M2::Sol>(some_sol);
+        assert!(t1 == 860, 0xf00);
+
+        let some_btc = 0x100::M2::mint_bitcoin_via_generic(13);
+        let t2 = 0x100::M2::get_value_generic<0x100::M2::Bitcoin>(some_btc);
+        assert!(t2 == 13, 0xf01);
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func02.move
@@ -1,0 +1,66 @@
+
+module 0x100::Coins {
+    // A generic coin type that can be instantiated using a currency
+    // specifier type.
+    //   e.g. Coin<Currency1>, Coin<Currency2> etc.
+    struct Coin<phantom Currency> has store {
+        value: u64
+    }
+
+    // Write code generically about all currencies
+    public fun mint_generic<Currency>(value: u64): Coin<Currency> {
+        Coin { value }
+    }
+
+    public fun get_value_generic<Currency>(c: Coin<Currency>): u64 {
+        let Coin<Currency> { value } = c;
+        value
+    }
+
+    public fun mint_2coins_generic<C1, C2>(n1: u64, n2: u64): (Coin<C1>, Coin<C2>) {
+        (Coin<C1> { value: n1 }, Coin<C2> { value: n2 })
+   }
+}
+
+// Instantiate generic function from a different module.
+//
+// Also exercises generic structs as arguments and return values
+// of generic functions (including returning multiple generic values).
+module 0x200::M11 {
+    use 0x100::Coins::Coin;
+
+    // Currency Specifiers.
+    struct Eth {}
+    struct USDC {}
+
+    public fun mint_usdc(n: u64): Coin<USDC> {
+        0x100::Coins::mint_generic<USDC>(n)
+    }
+
+    public fun mint_usdc_and_eth(nu: u64, ne: u64): (Coin<USDC>, Coin<Eth>) {
+        0x100::Coins::mint_2coins_generic<USDC, Eth>(nu, ne)
+    }
+
+    public fun get_value_usdc(c: Coin<USDC>): u64 {
+        0x100::Coins::get_value_generic<USDC>(c)
+    }
+
+    public fun get_value_eth(c: Coin<Eth>): u64 {
+        0x100::Coins::get_value_generic<Eth>(c)
+    }
+}
+
+script {
+    fun main() {
+        let some_usdc = 0x200::M11::mint_usdc(123);
+        let t1 = 0x200::M11::get_value_usdc(some_usdc);
+        assert!(t1 == 123, 0xf00);
+
+        let (t_usdc, t_eth) = 0x200::M11::mint_usdc_and_eth(9000, 87);
+        let t2 = 0x200::M11::get_value_usdc(t_usdc);
+        let t3 = 0x200::M11::get_value_eth(t_eth);
+        assert!(t2 == 9000, 0xf01);
+        assert!(t3 == 87, 0xf02);
+
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func03.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rgeneric-func03.move
@@ -1,0 +1,36 @@
+
+// Check generics with primitive types.
+//
+// Also check that instantiations of the same generic from two different
+// modules don't have name collision.
+module 0x100::MX {
+    public fun generic_id<T>(v: T): T {
+        v
+    }
+}
+
+module 0x200::MX {
+    use 0x100::MX::generic_id;
+
+    public fun square32(n: u32): u32 {
+        generic_id<u32>(n) * generic_id<u32>(n)
+    }
+
+    public fun square8(n: u8): u8 {
+        generic_id<u8>(n) * generic_id<u8>(n)
+    }
+}
+
+script {
+    fun main() {
+        let x2 = 0x200::MX::square8(8);
+        assert!(x2 == 64, 0xf00);
+
+        let y2 = 0x200::MX::square32(32);
+        assert!(y2 == 1024, 0xf01);
+
+        // Second instantiation of generic_id<u8>.
+        let z = 0x100::MX::generic_id<u8>(33);
+        assert!(z == 33, 0xf02);
+    }
+}


### PR DESCRIPTION
This patch implements support for generic Move functions (functions parameterized by types).

Like generic structs, the idea is to locate and collect the generic functions and then materialize each concrete instance in turn.

Unlike generic structs, Move functions are not first-class types, so there is only one context these occur in. All can be found from the single FunctionInstantiation table.

This also fixes an existing defect where private functions with the same name from two different modules (also with the same name) had name collisions (improper visibility).

Both runnable rbpf test cases and static LLVM IR tests are included.