### PR TITLE
Pull in the transitive closure of called functions.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -456,6 +456,10 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     continue;
                 }
                 for fi in &fn_instantiations[&fn_qid] {
+                    let inst_is_generic = fi.into_iter().any(|t| t.is_open());
+                    if inst_is_generic {
+                        continue;
+                    }
                     self.declare_function(&fn_env, fi, linkage);
                     let fn_qiid = fn_qid.module_id.qualified_inst(fn_qid.id, fi.to_vec());
                     self.expanded_functions.push(fn_qiid);
@@ -468,9 +472,9 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                 }
             }
 
-            for called_fn in fn_env.get_called_functions() {
+            for called_fn in fn_env.get_transitive_closure_of_called_functions() {
                 let is_foreign_mod = called_fn.module_id != mod_env.get_id();
-                if is_foreign_mod {
+                if is_foreign_mod && g_env.get_function(called_fn).is_exposed() {
                     foreign_fns.insert(called_fn);
                 }
             }
@@ -479,7 +483,9 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         for fn_qid in foreign_fns {
             let called_fn_env = g_env.get_function(fn_qid);
             if !called_fn_env.is_native() && called_fn_env.get_type_parameter_count() > 0 {
-                assert!(fn_instantiations.contains_key(&fn_qid));
+                if !fn_instantiations.contains_key(&fn_qid) {
+                    continue;
+                }
                 for fi in &fn_instantiations[&fn_qid] {
                     self.declare_function(
                         &called_fn_env,
@@ -1851,7 +1857,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         dst: &[mast::TempIndex],
         src: &[mast::TempIndex],
     ) {
-        let typarams = self.get_rttydesc_ptrs(types);
+        let types = mty::Type::instantiate_vec(types.to_vec(), self.type_params);
+        let typarams = self.get_rttydesc_ptrs(&types);
 
         let dst_locals = dst.iter().map(|i| &self.locals[*i]).collect::<Vec<_>>();
         let src_locals = src.iter().map(|i| &self.locals[*i]).collect::<Vec<_>>();

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -456,7 +456,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     continue;
                 }
                 for fi in &fn_instantiations[&fn_qid] {
-                    let inst_is_generic = fi.into_iter().any(|t| t.is_open());
+                    let inst_is_generic = fi.iter().any(|t| t.is_open());
                     if inst_is_generic {
                         continue;
                     }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -17,4 +17,6 @@ entry:
   ret void
 }
 
+declare i8 @Test2__test2(i8, i8)
+
 declare i8 @Test1__test1(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector01.move
@@ -1,0 +1,160 @@
+
+// This is move-stdlib/sources/vector.move minus all the spec stuff to make
+// more concise.
+//
+//module std::vector {
+module 0x10::vector {
+    /// The index into the vector is out of bounds
+    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+
+    //#[bytecode_instruction]
+    /// Create an empty vector.
+    native public fun empty<Element>(): vector<Element>;
+
+    //#[bytecode_instruction]
+    /// Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    //#[bytecode_instruction]
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    //#[bytecode_instruction]
+    /// Add element `e` to the end of the vector `v`.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    //#[bytecode_instruction]
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+
+    //#[bytecode_instruction]
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    //#[bytecode_instruction]
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    //#[bytecode_instruction]
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i` or `j` is out of bounds.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    /// Return an vector of size one containing element `e`.
+    public fun singleton<Element>(e: Element): vector<Element> {
+        let v = empty();
+        push_back(&mut v, e);
+        v
+    }
+
+    /// Reverses the order of the elements in the vector `v` in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+
+    /// Pushes all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    /// Return true if `e` is in the vector `v`.
+    /// Otherwise, returns false.
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return (true, i);
+            i = i + 1;
+        };
+        (false, 0)
+    }
+
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+
+    /// Insert `e` at position `i` in the vector `v`.
+    /// If `i` is in bounds, this shifts the old `v[i]` and all subsequent elements to the right.
+    /// If `i == length(v)`, this adds `e` to the end of the vector.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i > length(v)`
+    public fun insert<Element>(v: &mut vector<Element>, e: Element, i: u64) {
+        let len = length(v);
+        // i too big abort
+        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+
+        push_back(v, e);
+        while (i < len) {
+            swap(v, i, len);
+            i = i + 1
+        }
+    }
+
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        assert!(!is_empty(v), EINDEX_OUT_OF_BOUNDS);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+}
+
+script {
+    fun main() {
+        use 0x10::vector;
+
+        // Very simple tests for some non-native vector functions with
+        // element type u64.
+        // This exercises generic function support combined with vectors.
+
+        // Test non-native `singleton` and `is_empty`.
+        let v = vector::singleton<u64>(123);
+        assert!(vector::length(&v) == 1, 0xf00);
+        assert!(!vector::is_empty<u64>(&v), 0xf01);
+        assert!(vector::pop_back<u64>(&mut v) == 123, 0xf02);
+        assert!(vector::is_empty<u64>(&v), 0xf03);
+    }
+}


### PR DESCRIPTION
When declaring all functions, pull in not just the directly called
functions, but the transitive closure of called functions.
    
Also do not attempt to instantiate generics whose type parameters
themselves are generic (those cannot  be expanded until a function
containing them is instantiated, resolving the type parameters).
    
This allows to compile std::vector (move-stdlib/sources/vector.move)
for the first time.
    
Added a runnable test case that includes vector.move and calls a
couple of the non-native methods (singleton and is_empty). This shows
the combination of vector, natives, and generic move functions all
functioning together for this first time!