### PR TITLE
Add missing vector reference support for compare, move, and copy.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -661,6 +661,15 @@ impl Builder {
         unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr()) }
     }
 
+    pub fn build_load_from_valref(
+        &self,
+        ty: Type,
+        src0_reg: LLVMValueRef,
+        name: &str,
+    ) -> LLVMValueRef {
+        unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg, name.cstr()) }
+    }
+
     pub fn build_load_global_const(&self, gval: Global) -> Constant {
         unsafe {
             let ty = LLVMGlobalGetValueType(gval.0);

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector02.move
@@ -1,0 +1,198 @@
+
+// This is move-stdlib/sources/vector.move minus all the spec stuff to make
+// more concise.
+//
+// Also commented out the #[bytecode_instruction] lines, in which the Move
+// compiler converts native functions to bytecode instructions. That won't
+// work with our current scheme of translating natives, which expects to
+// see calls and produce declarations for them.
+//
+//module std::vector {
+module 0x10::vector {
+    /// The index into the vector is out of bounds
+    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+
+    //#[bytecode_instruction]
+    /// Create an empty vector.
+    native public fun empty<Element>(): vector<Element>;
+
+    //#[bytecode_instruction]
+    /// Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    //#[bytecode_instruction]
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    //#[bytecode_instruction]
+    /// Add element `e` to the end of the vector `v`.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    //#[bytecode_instruction]
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+
+    //#[bytecode_instruction]
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    //#[bytecode_instruction]
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    //#[bytecode_instruction]
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i` or `j` is out of bounds.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    /// Return an vector of size one containing element `e`.
+    public fun singleton<Element>(e: Element): vector<Element> {
+        let v = empty();
+        push_back(&mut v, e);
+        v
+    }
+
+    /// Reverses the order of the elements in the vector `v` in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+
+    /// Pushes all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    /// Return true if `e` is in the vector `v`.
+    /// Otherwise, returns false.
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return (true, i);
+            i = i + 1;
+        };
+        (false, 0)
+    }
+
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+
+    /// Insert `e` at position `i` in the vector `v`.
+    /// If `i` is in bounds, this shifts the old `v[i]` and all subsequent elements to the right.
+    /// If `i == length(v)`, this adds `e` to the end of the vector.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i > length(v)`
+    public fun insert<Element>(v: &mut vector<Element>, e: Element, i: u64) {
+        let len = length(v);
+        // i too big abort
+        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+
+        push_back(v, e);
+        while (i < len) {
+            swap(v, i, len);
+            i = i + 1
+        }
+    }
+
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        assert!(!is_empty(v), EINDEX_OUT_OF_BOUNDS);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+}
+
+script {
+    fun main() {
+        use 0x10::vector;
+
+        // More simple tests for all non-native vector functions with
+        // element type u64.
+        // This exercises generic function support combined with vectors.
+
+        // Test: singleton, is_empty, contains, index_of, reverse, swap_remove,
+        // remove, append.
+
+        let v = vector::singleton<u64>(123);
+        assert!(vector::length(&v) == 1, 0xf00);
+        assert!(!vector::is_empty<u64>(&v), 0xf01);
+        assert!(*vector::borrow<u64>(&mut v, 0) == 123, 0xf02);
+        assert!(vector::contains<u64>(&mut v, &123), 0xf03);
+        assert!(vector::pop_back<u64>(&mut v) == 123, 0xf04);
+        assert!(vector::is_empty<u64>(&v), 0xf05);
+
+        vector::push_back<u64>(&mut v, 386);
+        vector::push_back<u64>(&mut v, 486);
+        vector::push_back<u64>(&mut v, 860);
+        vector::push_back<u64>(&mut v, 960);
+        vector::push_back<u64>(&mut v, 970);
+        let (found, idx) = vector::index_of<u64>(&mut v, &970);
+        assert!(found == true, 0xf06);
+        assert!(idx == 4, 0xf07);
+
+        vector::reverse<u64>(&mut v);
+        let (found, idx) = vector::index_of<u64>(&mut v, &386);
+        assert!(found == true, 0xf08);
+        assert!(idx == 4, 0xf09);
+
+        let e = vector::swap_remove<u64>(&mut v, 2);
+        assert!(e == 860, 0xf0a);
+        assert!(vector::length(&v) == 4, 0xf0b);
+
+        let v2 = vector::singleton<u64>(686);
+        vector::append<u64>(&mut v, v2);
+        assert!(vector::length(&v) == 5, 0xf0c);
+        assert!(*vector::borrow<u64>(&mut v, 4) == 686, 0xf0d);
+
+        vector::remove<u64>(&mut v, 0);
+        assert!(*vector::borrow<u64>(&mut v, 0) == 960, 0xf0e);
+        assert!(*vector::borrow<u64>(&mut v, 1) == 386, 0xf0f);
+        assert!(*vector::borrow<u64>(&mut v, 2) == 486, 0xf10);
+        assert!(*vector::borrow<u64>(&mut v, 3) == 686, 0xf11);
+    }
+}


### PR DESCRIPTION
Pushing more vector + generic code through exposed missed handling
of references to vectors in various places.

Added another runnable rbf test which invokes every generic vector
function in std::vector.

Also added more explanatory comments in generic functions declaration
code (transitive closure, etc).