### PR TITLE
Fill in more of rttydesc.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,7 @@ dependencies = [
 name = "move-native"
 version = "0.1.1"
 dependencies = [
+ "ethnum",
  "serde 1.0.163",
  "sha2 0.9.3",
  "sha3 0.9.1",

--- a/language/move-native/Cargo.lock
+++ b/language/move-native/Cargo.lock
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethnum"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +77,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 name = "move-native"
 version = "0.1.1"
 dependencies = [
+ "ethnum",
  "serde",
  "sha2",
  "sha3",

--- a/language/move-native/Cargo.toml
+++ b/language/move-native/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["staticlib", "rlib"]
 solana = []
 
 [dependencies]
+ethnum = { version = "1.0.4", default-features = false }
 serde = { version = "1.0.124", default-features = false }
 sha2 = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -390,16 +390,17 @@ pub(crate) mod rt_types {
     pub enum TypeDesc {
         Bool = 1,
         U8 = 2,
-        U64 = 3,
-        U128 = 4,
-        Address = 5,
-        Signer = 6,
-        Vector = 7,
-        Struct = 8,
-        //StructInstantiation = 9,
-        Reference = 10,
-        //MutableReference = 11,
-        //TyParam = 12,
+        U16 = 3,
+        U32 = 4,
+        U64 = 5,
+        U128 = 6,
+        U256 = 7,
+        Address = 8,
+        Signer = 9,
+        Vector = 10,
+        Struct = 11,
+        Reference = 12,
+        //MutableReference = 13,
     }
 
     #[repr(C)]
@@ -757,6 +758,7 @@ mod std {
         use crate::rt_types::*;
         use alloc::vec::Vec;
         use core::{mem, ptr};
+        use ethnum::U256;
 
         // Safety: Even empty Rust vectors have non-null buffer pointers,
         // which must be correctly aligned. This function crates empty Rust vecs
@@ -766,8 +768,11 @@ mod std {
             let move_vec = match type_r.type_desc {
                 TypeDesc::Bool => rust_vec_to_move_vec::<bool>(Vec::new()),
                 TypeDesc::U8 => rust_vec_to_move_vec::<u8>(Vec::new()),
+                TypeDesc::U16 => rust_vec_to_move_vec::<u16>(Vec::new()),
+                TypeDesc::U32 => rust_vec_to_move_vec::<u32>(Vec::new()),
                 TypeDesc::U64 => rust_vec_to_move_vec::<u64>(Vec::new()),
                 TypeDesc::U128 => rust_vec_to_move_vec::<u128>(Vec::new()),
+                TypeDesc::U256 => rust_vec_to_move_vec::<U256>(Vec::new()),
                 TypeDesc::Address => rust_vec_to_move_vec::<MoveAddress>(Vec::new()),
                 TypeDesc::Signer => rust_vec_to_move_vec::<MoveSigner>(Vec::new()),
                 TypeDesc::Vector => {
@@ -834,8 +839,11 @@ mod std {
             let len = match rust_vec {
                 TypedMoveBorrowedRustVec::Bool(v) => v.len(),
                 TypedMoveBorrowedRustVec::U8(v) => v.len(),
+                TypedMoveBorrowedRustVec::U16(v) => v.len(),
+                TypedMoveBorrowedRustVec::U32(v) => v.len(),
                 TypedMoveBorrowedRustVec::U64(v) => v.len(),
                 TypedMoveBorrowedRustVec::U128(v) => v.len(),
+                TypedMoveBorrowedRustVec::U256(v) => v.len(),
                 TypedMoveBorrowedRustVec::Address(v) => v.len(),
                 TypedMoveBorrowedRustVec::Signer(v) => v.len(),
                 TypedMoveBorrowedRustVec::Vector(_t, v) => v.len(),
@@ -860,8 +868,11 @@ mod std {
             let value = match rust_vec {
                 TypedMoveBorrowedRustVec::Bool(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::U8(v) => mem::transmute(&v[i]),
+                TypedMoveBorrowedRustVec::U16(v) => mem::transmute(&v[i]),
+                TypedMoveBorrowedRustVec::U32(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::U64(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::U128(v) => mem::transmute(&v[i]),
+                TypedMoveBorrowedRustVec::U256(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::Address(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::Signer(v) => mem::transmute(&v[i]),
                 TypedMoveBorrowedRustVec::Vector(_t, v) => mem::transmute(&v[i]),
@@ -884,8 +895,11 @@ mod std {
             match rust_vec {
                 TypedMoveBorrowedRustVecMut::Bool(mut v) => v.push(ptr::read(e as *const bool)),
                 TypedMoveBorrowedRustVecMut::U8(mut v) => v.push(ptr::read(e as *const u8)),
+                TypedMoveBorrowedRustVecMut::U16(mut v) => v.push(ptr::read(e as *const u16)),
+                TypedMoveBorrowedRustVecMut::U32(mut v) => v.push(ptr::read(e as *const u32)),
                 TypedMoveBorrowedRustVecMut::U64(mut v) => v.push(ptr::read(e as *const u64)),
                 TypedMoveBorrowedRustVecMut::U128(mut v) => v.push(ptr::read(e as *const u128)),
+                TypedMoveBorrowedRustVecMut::U256(mut v) => v.push(ptr::read(e as *const U256)),
                 TypedMoveBorrowedRustVecMut::Address(mut v) => v.push(ptr::read(e as *const MoveAddress)),
                 TypedMoveBorrowedRustVecMut::Signer(mut v) => v.push(ptr::read(e as *const MoveSigner)),
                 TypedMoveBorrowedRustVecMut::Vector(_t, mut v) => v.push(ptr::read(e as *const MoveUntypedVector)),
@@ -907,8 +921,11 @@ mod std {
             let value = match rust_vec {
                 TypedMoveBorrowedRustVecMut::Bool(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::U8(mut v) => mem::transmute(&mut v[i]),
+                TypedMoveBorrowedRustVecMut::U16(mut v) => mem::transmute(&mut v[i]),
+                TypedMoveBorrowedRustVecMut::U32(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::U64(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::U128(mut v) => mem::transmute(&mut v[i]),
+                TypedMoveBorrowedRustVecMut::U256(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::Address(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::Signer(mut v) => mem::transmute(&mut v[i]),
                 TypedMoveBorrowedRustVecMut::Vector(_t, mut v) => mem::transmute(&mut v[i]),
@@ -935,11 +952,20 @@ mod std {
                 TypedMoveBorrowedRustVecMut::U8(mut v) => {
                     ptr::write(r as *mut u8, v.pop().expect(msg));
                 }
+                TypedMoveBorrowedRustVecMut::U16(mut v) => {
+                    ptr::write(r as *mut u16, v.pop().expect(msg));
+                }
+                TypedMoveBorrowedRustVecMut::U32(mut v) => {
+                    ptr::write(r as *mut u32, v.pop().expect(msg));
+                }
                 TypedMoveBorrowedRustVecMut::U64(mut v) => {
                     ptr::write(r as *mut u64, v.pop().expect(msg));
                 }
                 TypedMoveBorrowedRustVecMut::U128(mut v) => {
                     ptr::write(r as *mut u128, v.pop().expect(msg));
+                }
+                TypedMoveBorrowedRustVecMut::U256(mut v) => {
+                    ptr::write(r as *mut U256, v.pop().expect(msg));
                 }
                 TypedMoveBorrowedRustVecMut::Address(mut v) => {
                     ptr::write(r as *mut MoveAddress, v.pop().expect(msg));
@@ -963,8 +989,11 @@ mod std {
             match type_ve.type_desc {
                 TypeDesc::Bool => drop(move_vec_to_rust_vec::<bool>(v)),
                 TypeDesc::U8 => drop(move_vec_to_rust_vec::<u8>(v)),
+                TypeDesc::U16 => drop(move_vec_to_rust_vec::<u16>(v)),
+                TypeDesc::U32 => drop(move_vec_to_rust_vec::<u32>(v)),
                 TypeDesc::U64 => drop(move_vec_to_rust_vec::<u64>(v)),
                 TypeDesc::U128 => drop(move_vec_to_rust_vec::<u128>(v)),
+                TypeDesc::U256 => drop(move_vec_to_rust_vec::<U256>(v)),
                 TypeDesc::Address => drop(move_vec_to_rust_vec::<MoveAddress>(v)),
                 TypeDesc::Signer => drop(move_vec_to_rust_vec::<MoveSigner>(v)),
                 TypeDesc::Vector => {
@@ -1020,8 +1049,11 @@ mod std {
             match rust_vec {
                 TypedMoveBorrowedRustVecMut::Bool(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::U8(mut v) => v.swap(i, j),
+                TypedMoveBorrowedRustVecMut::U16(mut v) => v.swap(i, j),
+                TypedMoveBorrowedRustVecMut::U32(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::U64(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::U128(mut v) => v.swap(i, j),
+                TypedMoveBorrowedRustVecMut::U256(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::Address(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::Signer(mut v) => v.swap(i, j),
                 TypedMoveBorrowedRustVecMut::Vector(_t, mut v) => v.swap(i, j),
@@ -1041,6 +1073,7 @@ pub(crate) mod conv {
     use core::ops::{Deref, DerefMut};
     use core::ptr;
     use core::slice;
+    use ethnum::U256;
 
     /// This is a placeholder for the unstable `ptr::invalid_mut`.
     ///
@@ -1400,8 +1433,11 @@ pub(crate) mod conv {
     pub enum BorrowedTypedMoveValue<'mv> {
         Bool(&'mv bool),
         U8(&'mv u8),
+        U16(&'mv u16),
+        U32(&'mv u32),
         U64(&'mv u64),
         U128(&'mv u128),
+        U256(&'mv U256),
         Address(&'mv MoveAddress),
         Signer(&'mv MoveSigner),
         Vector(MoveType, &'mv MoveUntypedVector),
@@ -1418,8 +1454,11 @@ pub(crate) mod conv {
         match type_.type_desc {
             TypeDesc::Bool => BorrowedTypedMoveValue::Bool(mem::transmute(value)),
             TypeDesc::U8 => BorrowedTypedMoveValue::U8(mem::transmute(value)),
+            TypeDesc::U16 => BorrowedTypedMoveValue::U16(mem::transmute(value)),
+            TypeDesc::U32 => BorrowedTypedMoveValue::U32(mem::transmute(value)),
             TypeDesc::U64 => BorrowedTypedMoveValue::U64(mem::transmute(value)),
             TypeDesc::U128 => BorrowedTypedMoveValue::U128(mem::transmute(value)),
+            TypeDesc::U256 => BorrowedTypedMoveValue::U256(mem::transmute(value)),
             TypeDesc::Address => BorrowedTypedMoveValue::Address(mem::transmute(value)),
             TypeDesc::Signer => BorrowedTypedMoveValue::Signer(mem::transmute(value)),
             TypeDesc::Vector => {
@@ -1442,8 +1481,11 @@ pub(crate) mod conv {
     pub enum TypedMoveBorrowedRustVec<'mv> {
         Bool(MoveBorrowedRustVec<'mv, bool>),
         U8(MoveBorrowedRustVec<'mv, u8>),
+        U16(MoveBorrowedRustVec<'mv, u16>),
+        U32(MoveBorrowedRustVec<'mv, u32>),
         U64(MoveBorrowedRustVec<'mv, u64>),
         U128(MoveBorrowedRustVec<'mv, u128>),
+        U256(MoveBorrowedRustVec<'mv, U256>),
         Address(MoveBorrowedRustVec<'mv, MoveAddress>),
         Signer(MoveBorrowedRustVec<'mv, MoveSigner>),
         Vector(MoveType, MoveBorrowedRustVec<'mv, MoveUntypedVector>),
@@ -1456,8 +1498,11 @@ pub(crate) mod conv {
     pub enum TypedMoveBorrowedRustVecMut<'mv> {
         Bool(MoveBorrowedRustVecMut<'mv, bool>),
         U8(MoveBorrowedRustVecMut<'mv, u8>),
+        U16(MoveBorrowedRustVecMut<'mv, u16>),
+        U32(MoveBorrowedRustVecMut<'mv, u32>),
         U64(MoveBorrowedRustVecMut<'mv, u64>),
         U128(MoveBorrowedRustVecMut<'mv, u128>),
+        U256(MoveBorrowedRustVecMut<'mv, U256>),
         Address(MoveBorrowedRustVecMut<'mv, MoveAddress>),
         Signer(MoveBorrowedRustVecMut<'mv, MoveSigner>),
         Vector(MoveType, MoveBorrowedRustVecMut<'mv, MoveUntypedVector>),
@@ -1478,11 +1523,20 @@ pub(crate) mod conv {
             TypeDesc::U8 => {
                 TypedMoveBorrowedRustVec::U8(borrow_move_vec_as_rust_vec::<u8>(mv))
             }
+            TypeDesc::U16 => {
+                TypedMoveBorrowedRustVec::U16(borrow_move_vec_as_rust_vec::<u16>(mv))
+            }
+            TypeDesc::U32 => {
+                TypedMoveBorrowedRustVec::U32(borrow_move_vec_as_rust_vec::<u32>(mv))
+            }
             TypeDesc::U64 => {
                 TypedMoveBorrowedRustVec::U64(borrow_move_vec_as_rust_vec::<u64>(mv))
             }
             TypeDesc::U128 => {
                 TypedMoveBorrowedRustVec::U128(borrow_move_vec_as_rust_vec::<u128>(mv))
+            }
+            TypeDesc::U256 => {
+                TypedMoveBorrowedRustVec::U256(borrow_move_vec_as_rust_vec::<U256>(mv))
             }
             TypeDesc::Address => {
                 TypedMoveBorrowedRustVec::Address(borrow_move_vec_as_rust_vec::<MoveAddress>(mv))
@@ -1526,11 +1580,20 @@ pub(crate) mod conv {
             TypeDesc::U8 => {
                 TypedMoveBorrowedRustVecMut::U8(borrow_move_vec_as_rust_vec_mut::<u8>(mv))
             }
+            TypeDesc::U16 => {
+                TypedMoveBorrowedRustVecMut::U16(borrow_move_vec_as_rust_vec_mut::<u16>(mv))
+            }
+            TypeDesc::U32 => {
+                TypedMoveBorrowedRustVecMut::U32(borrow_move_vec_as_rust_vec_mut::<u32>(mv))
+            }
             TypeDesc::U64 => {
                 TypedMoveBorrowedRustVecMut::U64(borrow_move_vec_as_rust_vec_mut::<u64>(mv))
             }
             TypeDesc::U128 => {
                 TypedMoveBorrowedRustVecMut::U128(borrow_move_vec_as_rust_vec_mut::<u128>(mv))
+            }
+            TypeDesc::U256 => {
+                TypedMoveBorrowedRustVecMut::U256(borrow_move_vec_as_rust_vec_mut::<U256>(mv))
             }
             TypeDesc::Address => {
                 TypedMoveBorrowedRustVecMut::Address(borrow_move_vec_as_rust_vec_mut::<MoveAddress>(mv))
@@ -1589,8 +1652,11 @@ pub(crate) mod conv {
             match self {
                 BorrowedTypedMoveValue::Bool(v) => serializer.serialize_bool(**v),
                 BorrowedTypedMoveValue::U8(v) => serializer.serialize_u8(**v),
+                BorrowedTypedMoveValue::U16(v) => serializer.serialize_u16(**v),
+                BorrowedTypedMoveValue::U32(v) => serializer.serialize_u32(**v),
                 BorrowedTypedMoveValue::U64(v) => serializer.serialize_u64(**v),
                 BorrowedTypedMoveValue::U128(v) => serializer.serialize_u128(**v),
+                BorrowedTypedMoveValue::U256(v) => v.0.serialize(serializer),
                 BorrowedTypedMoveValue::Address(v) => v.0.serialize(serializer),
                 BorrowedTypedMoveValue::Signer(v) => v.0 .0.serialize(serializer),
                 BorrowedTypedMoveValue::Vector(mt, mv) => unsafe {
@@ -1635,6 +1701,20 @@ pub(crate) mod conv {
                     }
                     seq.end()
                 }
+                TypedMoveBorrowedRustVec::U16(v) => {
+                    let mut seq = serializer.serialize_seq(Some(v.len()))?;
+                    for e in v.iter() {
+                        seq.serialize_element(e)?;
+                    }
+                    seq.end()
+                }
+                TypedMoveBorrowedRustVec::U32(v) => {
+                    let mut seq = serializer.serialize_seq(Some(v.len()))?;
+                    for e in v.iter() {
+                        seq.serialize_element(e)?;
+                    }
+                    seq.end()
+                }
                 TypedMoveBorrowedRustVec::U64(v) => {
                     let mut seq = serializer.serialize_seq(Some(v.len()))?;
                     for e in v.iter() {
@@ -1646,6 +1726,13 @@ pub(crate) mod conv {
                     let mut seq = serializer.serialize_seq(Some(v.len()))?;
                     for e in v.iter() {
                         seq.serialize_element(e)?;
+                    }
+                    seq.end()
+                }
+                TypedMoveBorrowedRustVec::U256(v) => {
+                    let mut seq = serializer.serialize_seq(Some(v.len()))?;
+                    for e in v.iter() {
+                        seq.serialize_element(&e.0)?;
                     }
                     seq.end()
                 }
@@ -1708,8 +1795,11 @@ pub(crate) mod conv {
             match self {
                 BorrowedTypedMoveValue::Bool(v) => v.fmt(f),
                 BorrowedTypedMoveValue::U8(v) => v.fmt(f),
+                BorrowedTypedMoveValue::U16(v) => v.fmt(f),
+                BorrowedTypedMoveValue::U32(v) => v.fmt(f),
                 BorrowedTypedMoveValue::U64(v) => v.fmt(f),
                 BorrowedTypedMoveValue::U128(v) => v.fmt(f),
+                BorrowedTypedMoveValue::U256(v) => v.fmt(f),
                 BorrowedTypedMoveValue::Address(v) => v.fmt(f),
                 BorrowedTypedMoveValue::Signer(v) => v.fmt(f),
                 BorrowedTypedMoveValue::Vector(t, v) => unsafe {
@@ -1739,8 +1829,11 @@ pub(crate) mod conv {
             match self {
                 TypedMoveBorrowedRustVec::Bool(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::U8(v) => v.fmt(f),
+                TypedMoveBorrowedRustVec::U16(v) => v.fmt(f),
+                TypedMoveBorrowedRustVec::U32(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::U64(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::U128(v) => v.fmt(f),
+                TypedMoveBorrowedRustVec::U256(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::Address(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::Signer(v) => v.fmt(f),
                 TypedMoveBorrowedRustVec::Vector(t, v) => {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -135,7 +135,12 @@ fn type_name(mty: &mty::Type, type_display_ctx: &mty::TypeDisplayContext) -> Str
 fn type_descrim(mty: &mty::Type) -> u64 {
     use mty::{PrimitiveType, Type};
     match mty {
+        Type::Primitive(PrimitiveType::U8) => TypeDesc::U8 as u64,
+        Type::Primitive(PrimitiveType::U16) => TypeDesc::U16 as u64,
+        Type::Primitive(PrimitiveType::U32) => TypeDesc::U32 as u64,
         Type::Primitive(PrimitiveType::U64) => TypeDesc::U64 as u64,
+        Type::Primitive(PrimitiveType::U128) => TypeDesc::U128 as u64,
+        Type::Primitive(PrimitiveType::U256) => TypeDesc::U256 as u64,
         Type::Vector(_) => TypeDesc::Vector as u64,
         _ => todo!(),
     }
@@ -159,11 +164,16 @@ fn define_type_info_global(
         None => {
             use mty::{PrimitiveType, Type};
             match mty {
-                Type::Primitive(PrimitiveType::U64) => {
-                    define_type_info_global_nil(llcx, llmod, &symbol_name)
-                }
+                _ if !has_type_info(mty) => define_type_info_global_nil(llcx, llmod, &symbol_name),
                 Type::Vector(elt_ty) => match **elt_ty {
-                    Type::Primitive(PrimitiveType::U64) => define_type_info_global_vec(
+                    Type::Primitive(
+                        PrimitiveType::U8
+                        | PrimitiveType::U16
+                        | PrimitiveType::U32
+                        | PrimitiveType::U64
+                        | PrimitiveType::U128
+                        | PrimitiveType::U256,
+                    ) => define_type_info_global_vec(
                         llcx,
                         llmod,
                         &symbol_name,
@@ -230,10 +240,26 @@ fn global_tydesc_name_name(mty: &mty::Type, type_display_ctx: &mty::TypeDisplayC
     format!("__move_rttydesc_{name}_name")
 }
 
+fn has_type_info(mty: &mty::Type) -> bool {
+    use mty::{PrimitiveType, Type};
+    match mty {
+        Type::Primitive(
+            PrimitiveType::U8
+            | PrimitiveType::U16
+            | PrimitiveType::U32
+            | PrimitiveType::U64
+            | PrimitiveType::U128
+            | PrimitiveType::U256,
+        ) => false,
+        Type::Vector(_) => true,
+        _ => todo!(),
+    }
+}
+
 fn global_tydesc_info_name(mty: &mty::Type, type_display_ctx: &mty::TypeDisplayContext) -> String {
     use mty::{PrimitiveType, Type};
     let name = match mty {
-        Type::Primitive(_) => {
+        _ if !has_type_info(mty) => {
             // A special name for types that don't need type info.
             "NOTHING".to_string()
         }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/debug-print.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/debug-print.move
@@ -1,13 +1,67 @@
 // log 10
+// log 11
+// log 12
+// log 13
+// log 14
+// log 15
+
+// log [1]
+// log [2]
+// log [3]
+// log [4]
+// log [5]
+// log [6]
+
 
 module 0x10::debug {
   native public fun print<T>(x: &T);
 }
 
+module 0x10::vector {
+  native public fun empty<Element>(): vector<Element>;
+  native public fun length<Element>(v: &vector<Element>): u64;
+  native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+  native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+  native public fun destroy_empty<Element>(v: vector<Element>);
+  native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+  native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+  native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+}
+
 script {
   use 0x10::debug;
+  use 0x10::vector;
 
   fun main() {
-    debug::print(&10);
+    debug::print(&10_u8);
+    debug::print(&11_u16);
+    debug::print(&12_u32);
+    debug::print(&13_u64);
+    debug::print(&14_u128);
+    debug::print(&15_u256);
+
+    let v: vector<u8> = vector::empty();
+    vector::push_back(&mut v, 1);
+    debug::print(&v);
+
+    let v: vector<u16> = vector::empty();
+    vector::push_back(&mut v, 2);
+    debug::print(&v);
+
+    let v: vector<u32> = vector::empty();
+    vector::push_back(&mut v, 3);
+    debug::print(&v);
+
+    let v: vector<u64> = vector::empty();
+    vector::push_back(&mut v, 4);
+    debug::print(&v);
+
+    let v: vector<u128> = vector::empty();
+    vector::push_back(&mut v, 5);
+    debug::print(&v);
+
+    let v: vector<u256> = vector::empty();
+    vector::push_back(&mut v, 6);
+    debug::print(&v);
   }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/vec.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/vec.move
@@ -9,10 +9,65 @@ module 0x10::vector {
   native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
 }
 
-script {
+module 0x10::tests {
   use 0x10::vector;
 
-  fun main() {
+
+  public fun test_u8() {
+    let v: vector<u8> = vector::empty();
+
+    let len = vector::length(&v);
+    assert!(len == 0, 10);
+
+    vector::push_back(&mut v, 2);
+    vector::push_back(&mut v, 3);
+
+    let len = vector::length(&v);
+    assert!(len == 2, 10);
+
+    vector::swap(&mut v, 0, 1);
+
+    let elt = vector::borrow(&v, 0);
+    assert!(*elt == 3, 10);
+    let elt = vector::borrow_mut(&mut v, 0);
+    assert!(*elt == 3, 10);
+
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 2, 10);
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 3, 10);
+
+    vector::destroy_empty(v);
+  }
+
+  public fun test_u16() {
+    let v: vector<u16> = vector::empty();
+
+    let len = vector::length(&v);
+    assert!(len == 0, 10);
+
+    vector::push_back(&mut v, 2);
+    vector::push_back(&mut v, 3);
+
+    let len = vector::length(&v);
+    assert!(len == 2, 10);
+
+    vector::swap(&mut v, 0, 1);
+
+    let elt = vector::borrow(&v, 0);
+    assert!(*elt == 3, 10);
+    let elt = vector::borrow_mut(&mut v, 0);
+    assert!(*elt == 3, 10);
+
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 2, 10);
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 3, 10);
+
+    vector::destroy_empty(v);
+  }
+
+  public fun test_u64() {
     let v: vector<u64> = vector::empty();
 
     let len = vector::length(&v);
@@ -37,5 +92,71 @@ script {
     assert!(elt == 3, 10);
 
     vector::destroy_empty(v);
+  }
+
+  public fun test_u128() {
+    let v: vector<u128> = vector::empty();
+
+    let len = vector::length(&v);
+    assert!(len == 0, 10);
+
+    vector::push_back(&mut v, 2);
+    vector::push_back(&mut v, 3);
+
+    let len = vector::length(&v);
+    assert!(len == 2, 10);
+
+    vector::swap(&mut v, 0, 1);
+
+    let elt = vector::borrow(&v, 0);
+    assert!(*elt == 3, 10);
+    let elt = vector::borrow_mut(&mut v, 0);
+    assert!(*elt == 3, 10);
+
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 2, 10);
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 3, 10);
+
+    vector::destroy_empty(v);
+  }
+
+  public fun test_u256() {
+    let v: vector<u256> = vector::empty();
+
+    let len = vector::length(&v);
+    assert!(len == 0, 10);
+
+    vector::push_back(&mut v, 2);
+    vector::push_back(&mut v, 3);
+
+    let len = vector::length(&v);
+    assert!(len == 2, 10);
+
+    vector::swap(&mut v, 0, 1);
+
+    let elt = vector::borrow(&v, 0);
+    assert!(*elt == 3, 10);
+    let elt = vector::borrow_mut(&mut v, 0);
+    assert!(*elt == 3, 10);
+
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 2, 10);
+    let elt = vector::pop_back(&mut v);
+    assert!(elt == 3, 10);
+
+    vector::destroy_empty(v);
+  }
+}
+
+script {
+  use 0x10::tests;
+
+  fun main() {
+    tests::test_u8();
+    tests::test_u16();
+    tests::test_u64();
+    tests::test_u128();
+    tests::test_u256();
   }
 }


### PR DESCRIPTION
This makes native vector functions work for vectors of all the numeric types.

I'm still debugging some crashes when dealing with vectors of vectors, and will submit support for more types later.