### PR TITLE
Add line number (after file name) to log

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -35,7 +35,9 @@ use crate::{
     stackless::{extensions::*, llvm, rttydesc},
 };
 use llvm_sys::prelude::LLVMValueRef;
-use log::debug;
+use log::{debug, Level};
+use env_logger::fmt::Color;
+use std::io::Write;
 use move_core_types::{account_address, u256::U256, vm_status::StatusCode::ARITHMETIC_ERROR};
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_stackless_bytecode::{
@@ -116,7 +118,28 @@ impl<'up> GlobalContext<'up> {
 
         target.initialize_llvm();
 
-        env_logger::init();
+        env_logger::Builder::from_default_env()
+        .format(|buf, record| {
+            let level = record.level();
+            let mut style = buf.style();
+            match record.level() {
+                Level::Error => style.set_color(Color::Red),
+                Level::Warn => style.set_color(Color::Yellow),
+                Level::Info => style.set_color(Color::Green),
+                Level::Debug => style.set_color(Color::Blue),
+                Level::Trace => style.set_color(Color::Cyan),
+            };
+
+            writeln!(
+                buf,
+                "{}:{} [{}] - {}",
+                record.file().unwrap_or("unknown"),
+                record.line().unwrap_or(0),
+                style.value(level),
+                record.args()
+            )
+        })
+        .init();
 
         debug!(target: "globalenv", "{:#?}", env);
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -34,10 +34,9 @@ use crate::{
     cli::Args,
     stackless::{extensions::*, llvm, rttydesc},
 };
+use env_logger::fmt::Color;
 use llvm_sys::prelude::LLVMValueRef;
 use log::{debug, Level};
-use env_logger::fmt::Color;
-use std::io::Write;
 use move_core_types::{account_address, u256::U256, vm_status::StatusCode::ARITHMETIC_ERROR};
 use move_model::{ast as mast, model as mm, ty as mty};
 use move_stackless_bytecode::{
@@ -48,6 +47,7 @@ use move_stackless_bytecode::{
 use num::BigUint;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
+    io::Write,
     iter,
 };
 
@@ -119,27 +119,27 @@ impl<'up> GlobalContext<'up> {
         target.initialize_llvm();
 
         env_logger::Builder::from_default_env()
-        .format(|buf, record| {
-            let level = record.level();
-            let mut style = buf.style();
-            match record.level() {
-                Level::Error => style.set_color(Color::Red),
-                Level::Warn => style.set_color(Color::Yellow),
-                Level::Info => style.set_color(Color::Green),
-                Level::Debug => style.set_color(Color::Blue),
-                Level::Trace => style.set_color(Color::Cyan),
-            };
+            .format(|buf, record| {
+                let level = record.level();
+                let mut style = buf.style();
+                match record.level() {
+                    Level::Error => style.set_color(Color::Red),
+                    Level::Warn => style.set_color(Color::Yellow),
+                    Level::Info => style.set_color(Color::Green),
+                    Level::Debug => style.set_color(Color::Blue),
+                    Level::Trace => style.set_color(Color::Cyan),
+                };
 
-            writeln!(
-                buf,
-                "{}:{} [{}] - {}",
-                record.file().unwrap_or("unknown"),
-                record.line().unwrap_or(0),
-                style.value(level),
-                record.args()
-            )
-        })
-        .init();
+                writeln!(
+                    buf,
+                    "{}:{} [{}] - {}",
+                    record.file().unwrap_or("unknown"),
+                    record.line().unwrap_or(0),
+                    style.value(level),
+                    record.args()
+                )
+            })
+            .init();
 
         debug!(target: "globalenv", "{:#?}", env);
 


### PR DESCRIPTION
As I started to read our logs (rather than using dbg!) I found that the line number was missing.
Bringing it back.
Also adding colors to messages.

###### Example of the log

![Screenshot 2023-05-31 at 5 33 06 PM](https://github.com/solana-labs/move/assets/30603832/5db1021f-72c2-4c28-8310-409b51c9c210)
