### PR TITLE
Add day-time to log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,6 +4259,7 @@ name = "move-mv-llvm-compiler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap 3.1.8",
  "colored",
  "datatest-stable",

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -13,6 +13,7 @@ colored = "2.0.0"
 env_logger = "0.8.3"
 libc = "0.2"
 log = "0.4.14"
+chrono = "0.4"
 once_cell = "1.10"
 parking_lot = "0.11"
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -34,6 +34,7 @@ use crate::{
     cli::Args,
     stackless::{extensions::*, llvm, rttydesc},
 };
+use chrono::Local as ChronoLocal;
 use env_logger::fmt::Color;
 use llvm_sys::prelude::LLVMValueRef;
 use log::{debug, Level};
@@ -119,9 +120,9 @@ impl<'up> GlobalContext<'up> {
         target.initialize_llvm();
 
         env_logger::Builder::from_default_env()
-            .format(|buf, record| {
+            .format(|formatter, record| {
                 let level = record.level();
-                let mut style = buf.style();
+                let mut style = formatter.style();
                 match record.level() {
                     Level::Error => style.set_color(Color::Red),
                     Level::Warn => style.set_color(Color::Yellow),
@@ -130,9 +131,12 @@ impl<'up> GlobalContext<'up> {
                     Level::Trace => style.set_color(Color::Cyan),
                 };
 
+                let now = ChronoLocal::now();
                 writeln!(
-                    buf,
-                    "{}:{} [{}] - {}",
+                    formatter,
+                    "[{}] {} - {}:{} [{}] {}",
+                    now.naive_utc(),
+                    module_path!(),
                     record.file().unwrap_or("unknown"),
                     record.line().unwrap_or(0),
                     style.value(level),


### PR DESCRIPTION
Added printing of day and time (might become useful in analyzing where the compiler spends cycles) and the module.

Example of log:
![Screenshot 2023-06-01 at 2 26 55 AM](https://github.com/solana-labs/move/assets/30603832/fa70381e-7a67-40fa-b65e-07d41b032aab)
