### PR TITLE
Implement vector compare, vector copy, vector literals, and runtime support.

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -462,6 +462,12 @@ pub(crate) mod rt_types {
     #[repr(transparent)]
     pub struct AnyValue(u8);
 
+    impl AnyValue {
+        pub fn new(v: u8) -> AnyValue {
+            AnyValue(v)
+        }
+    }
+
     #[repr(transparent)]
     #[derive(Debug, PartialEq)]
     pub struct MoveSigner(pub MoveAddress);
@@ -550,7 +556,7 @@ pub(crate) mod rt_types {
 /// Runtime calls emitted by the compiler.
 /// Reference: move/language/documentation/book/src/abort-and-assert.md
 mod rt {
-    use crate::rt_types::{MoveType, MoveUntypedVector};
+    use crate::rt_types::{AnyValue, MoveType, MoveUntypedVector, MoveAddress};
 
     #[export_name = "move_rt_abort"]
     fn abort(code: u64) -> ! {
@@ -561,6 +567,86 @@ mod rt {
     unsafe fn vec_destroy(type_ve: &MoveType, v: MoveUntypedVector) {
         assert_eq!(0, v.length, "can't destroy vectors with elements yet");
         crate::std::vector::destroy_empty(type_ve, v);
+    }
+
+    #[export_name = "move_rt_vec_empty"]
+    unsafe fn vec_empty(type_ve: &MoveType) -> MoveUntypedVector {
+        crate::std::vector::empty(type_ve)
+    }
+
+    #[export_name = "move_rt_vec_copy"]
+    unsafe fn vec_copy(type_ve: &MoveType, dstv: &mut MoveUntypedVector, srcv: &MoveUntypedVector) {
+        use crate::std::vector as V;
+        let src_len = V::length(type_ve, srcv);
+        let dst_len = V::length(type_ve, dstv);
+
+        // Drain the destination first.
+        for i in 0..dst_len {
+            let mut tmp = AnyValue::new(0);
+            V::pop_back(type_ve, dstv, &mut tmp);
+        }
+
+        // Now copy.
+        for i in 0..src_len {
+            let se = V::borrow(type_ve, srcv, i);
+            let septr = se as *const AnyValue as *mut AnyValue;
+            V::push_back(type_ve, dstv, septr);
+        }
+    }
+
+    #[export_name = "move_rt_vec_cmp_eq"]
+    unsafe fn vec_cmp_eq(type_ve: &MoveType, v1: &MoveUntypedVector, v2: &MoveUntypedVector) -> bool {
+        use crate::conv::{TypedMoveBorrowedRustVec, borrow_move_vec_as_rust_vec};
+        use crate::rt_types::TypeDesc;
+        use crate::std::vector as V;
+        use core::ops::Deref;
+
+        let v1_len = V::length(type_ve, v1);
+        let v2_len = V::length(type_ve, v2);
+
+        if v1_len != v2_len {
+            return false;
+        }
+
+        let is_eq = match type_ve.type_desc {
+            TypeDesc::Bool => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<bool>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<bool>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::U8 => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<u8>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<u8>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::U16 => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<u16>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<u16>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::U32 => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<u32>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<u32>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::U64 => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<u64>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<u64>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::U128 => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<u128>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<u128>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            TypeDesc::Address => {
+                let mut rv1 = borrow_move_vec_as_rust_vec::<MoveAddress>(v1);
+                let mut rv2 = borrow_move_vec_as_rust_vec::<MoveAddress>(v2);
+                rv1.deref().eq(rv2.deref())
+            }
+            _ => todo!()
+        };
+        is_eq
     }
 }
 
@@ -856,7 +942,7 @@ mod std {
         }
 
         #[export_name = "move_native_vector_borrow"]
-        unsafe extern "C" fn borrow<'v>(
+        pub unsafe extern "C" fn borrow<'v>(
             type_ve: &'v MoveType,
             v: &'v MoveUntypedVector,
             i: u64,

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -69,4 +69,13 @@ pub impl TypeExt for mty::Type {
         let name = format!("{}", self.display(type_display_ctx));
         name.replace(['<', '>'], "_")
     }
+
+    fn is_number_u8(&self) -> bool {
+        if let mty::Type::Primitive(p) = self {
+            if let mty::PrimitiveType::U8 = p {
+                return true;
+            }
+        }
+        false
+    }
 }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -71,10 +71,8 @@ pub impl TypeExt for mty::Type {
     }
 
     fn is_number_u8(&self) -> bool {
-        if let mty::Type::Primitive(p) = self {
-            if let mty::PrimitiveType::U8 = p {
-                return true;
-            }
+        if let mty::Type::Primitive(mty::PrimitiveType::U8) = self {
+            return true;
         }
         false
     }

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -149,6 +149,13 @@ impl Context {
         }
     }
 
+    pub fn const_array(&self, vals: &Vec<Constant>, llty: Type) -> ArrayValue {
+        let mut llvals: Vec<_> = vals.iter().map(|v| v.get0()).collect();
+        unsafe {
+            ArrayValue(LLVMConstArray(llty.0, llvals.as_mut_ptr(), vals.len() as u32))
+        }
+    }
+
     pub fn const_struct(&self, fields: &[Constant]) -> Constant {
         unsafe {
             let mut fields: Vec<_> = fields.iter().map(|f| f.0).collect();
@@ -312,6 +319,17 @@ impl Drop for Builder {
 }
 
 impl Builder {
+    pub fn get_entry_basic_block(&self, f: Function) -> BasicBlock {
+        unsafe { BasicBlock(LLVMGetEntryBasicBlock(f.0)) }
+    }
+
+    pub fn position_at_beginning(&self, bb: BasicBlock) {
+        unsafe {
+            let inst = LLVMGetFirstInstruction(bb.0);
+            LLVMPositionBuilderBefore(self.0, inst);
+        }
+    }
+
     pub fn get_insert_block(&self) -> BasicBlock {
         unsafe { BasicBlock(LLVMGetInsertBlock(self.0)) }
     }
@@ -657,8 +675,8 @@ impl Builder {
         }
     }
 
-    pub fn build_load(&self, ty: Type, src0_reg: Alloca, name: &str) -> LLVMValueRef {
-        unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr()) }
+    pub fn build_load(&self, ty: Type, src0_reg: Alloca, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr())) }
     }
 
     pub fn build_load_from_valref(
@@ -726,6 +744,10 @@ impl Builder {
     }
     pub fn build_trunc(&self, val: LLVMValueRef, dest_ty: LLVMTypeRef, name: &str) -> LLVMValueRef {
         unsafe { LLVMBuildTrunc(self.0, val, dest_ty, name.cstr()) }
+    }
+
+    pub fn wrap_as_any_value(&self, val: LLVMValueRef) -> AnyValue {
+        AnyValue(val)
     }
 }
 
@@ -889,6 +911,10 @@ impl Alloca {
         AnyValue(self.0)
     }
 
+    pub fn as_constant(&self) -> Constant {
+        Constant(self.0)
+    }
+
     pub fn llvm_type(&self) -> Type {
         unsafe { Type(LLVMTypeOf(self.0)) }
     }
@@ -903,6 +929,14 @@ pub struct AnyValue(LLVMValueRef);
 impl AnyValue {
     pub fn get0(&self) -> LLVMValueRef {
         self.0
+    }
+
+    pub fn llvm_type(&self) -> Type {
+        unsafe { Type(LLVMTypeOf(self.0)) }
+    }
+
+    pub fn as_constant(&self) -> Constant {
+        Constant(self.0)
     }
 }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -152,7 +152,11 @@ impl Context {
     pub fn const_array(&self, vals: &Vec<Constant>, llty: Type) -> ArrayValue {
         let mut llvals: Vec<_> = vals.iter().map(|v| v.get0()).collect();
         unsafe {
-            ArrayValue(LLVMConstArray(llty.0, llvals.as_mut_ptr(), vals.len() as u32))
+            ArrayValue(LLVMConstArray(
+                llty.0,
+                llvals.as_mut_ptr(),
+                vals.len() as u32,
+            ))
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -710,16 +710,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                     unreachable!("struct type for '{}' not found", &struct_name);
                 }
             }
-            Type::Vector(_) => {
-                // The type of vectors is shared with move-native,
-                // where it is declared as `MoveUntypedVector`.
-                // All vectors are a C struct of ( ptr, u64, u64 ).
-                self.llvm_cx.get_anonymous_struct_type(&[
-                    self.llvm_cx.int_type(8).ptr_type(),
-                    self.llvm_cx.int_type(64),
-                    self.llvm_cx.int_type(64),
-                ])
-            }
+            Type::Vector(_) => self.get_llvm_type_for_move_native_vector(),
             Type::Tuple(_) => {
                 todo!("{mty:?}")
             }
@@ -731,6 +722,17 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
                 panic!("unexpected field type {mty:?}")
             }
         }
+    }
+
+    fn get_llvm_type_for_move_native_vector(&self) -> llvm::Type {
+        // The type of vectors is shared with move-native,
+        // where it is declared as `MoveUntypedVector`.
+        // All vectors are a C struct of ( ptr, u64, u64 ).
+        self.llvm_cx.get_anonymous_struct_type(&[
+            self.llvm_cx.int_type(8).ptr_type(),
+            self.llvm_cx.int_type(64),
+            self.llvm_cx.int_type(64),
+        ])
     }
 
     fn get_llvm_type_for_address(&self) -> llvm::Type {
@@ -819,7 +821,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             .get_global_env()
             .get_module(qiid.module_id)
             .into_function(qiid.id);
-        self.module_cx.fn_decls[&fn_env.llvm_symbol_name(&qiid.inst)]
+        let sname = fn_env.llvm_symbol_name(&qiid.inst);
+        let decl = self.module_cx.fn_decls.get(&sname);
+        assert!(!decl.is_none(), "move fn decl not found: {}", sname);
+        *decl.unwrap()
     }
 
     fn lookup_native_fn_decl(&self, qid: mm::QualifiedId<mm::FunId>) -> llvm::Function {
@@ -827,7 +832,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             .get_global_env()
             .get_module(qid.module_id)
             .into_function(qid.id);
-        self.module_cx.fn_decls[&fn_env.llvm_native_fn_symbol_name()]
+        let sname = fn_env.llvm_native_fn_symbol_name();
+        let decl = self.module_cx.fn_decls.get(&sname);
+        assert!(!decl.is_none(), "native fn decl not found: {}", sname);
+        *decl.unwrap()
     }
 
     fn translate(mut self) {
@@ -918,7 +926,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     let signer = self.module_cx.args.test_signers[curr_signer].strip_prefix("0x");
                     curr_signer += 1;
                     let addr_val = BigUint::parse_bytes(signer.unwrap().as_bytes(), 16);
-                    let c = self.constant(&sbc::Constant::Address(addr_val.unwrap()));
+                    let c = self.constant(&sbc::Constant::Address(addr_val.unwrap()), None);
                     self.module_cx
                         .llvm_builder
                         .build_store(c.get0(), local.llval);
@@ -1014,6 +1022,13 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     mty::Type::Primitive(mty::PrimitiveType::Address) => {
                         builder.load_store(llty, src_llval, dst_llval);
                     }
+                    mty::Type::Vector(elt_mty) => {
+                        self.emit_rtcall_with_retval(RtCall::VecCopy(
+                            dst_llval.as_any_value(),
+                            src_llval.as_any_value(),
+                            (**elt_mty).clone()
+                        ));
+                    }
                     mty::Type::Reference(_, referent) => match **referent {
                         mty::Type::Struct(_, _, _) => {
                             builder.load_store(llty, src_llval, dst_llval);
@@ -1086,7 +1101,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             },
             sbc::Bytecode::Load(_, idx, val) => {
                 let local_llval = self.locals[*idx].llval;
-                let const_llval = self.constant(val);
+                let const_llval = self.constant(val, Some(&self.locals[*idx].mty));
                 builder.store_const(const_llval, local_llval);
             }
             sbc::Bytecode::Branch(_, label0, label1, cnd_idx) => {
@@ -1189,7 +1204,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let src_ty = self.locals[src_idx].llty;
         self.module_cx
             .llvm_builder
-            .build_load(src_ty, src_llval, name)
+            .build_load(src_ty, src_llval, name).get0()
     }
 
     fn store_reg(&self, dst_idx: mast::TempIndex, dst_reg: LLVMValueRef) {
@@ -1411,6 +1426,37 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         self.store_reg(dst[0], dst_reg);
     }
 
+    fn translate_vector_comparison_impl(
+        &self,
+        dst: &[mast::TempIndex],
+        src: &[mast::TempIndex],
+        _name: &str,
+        pred: llvm::LLVMIntPredicate,
+    ) {
+        // Generate the following LLVM IR to compare vector types.
+        // Note that only eq/ne apply to these.
+        //
+        // The incoming sources are allocas of vector type.
+        //    ...
+        //    %t = call void @move_rt_vec_cmp_eq(ptr @__move_rttydesc_{T}, ptr %vsrc0, ptr %vsrc1)
+        //    ...
+        let src_mty = &self.locals[src[0]].mty;
+        let vec_elt_cmp_mty = match src_mty {
+            mty::Type::Vector(ety) => &**ety,
+            _ => unreachable!(),
+        };
+        assert!(vec_elt_cmp_mty.is_number() || vec_elt_cmp_mty.is_bool());
+        assert!(pred == llvm::LLVMIntPredicate::LLVMIntEQ
+             || pred == llvm::LLVMIntPredicate::LLVMIntNE);
+
+        let dst_reg = self.emit_rtcall_with_retval(RtCall::VecCmpEq(
+            self.locals[src[0]].llval.as_any_value(),
+            self.locals[src[1]].llval.as_any_value(),
+            vec_elt_cmp_mty.clone()
+        ));
+        self.store_reg(dst[0], dst_reg.get0());
+    }
+
     fn translate_comparison_impl(
         &self,
         dst: &[mast::TempIndex],
@@ -1424,6 +1470,11 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let src_mty = &self.locals[src[0]].mty;
         if src_mty.is_address() {
             self.translate_address_comparison_impl(dst, src, name, pred);
+            return;
+        }
+
+        if src_mty.is_vector() {
+            self.translate_vector_comparison_impl(dst, src, name, pred);
             return;
         }
 
@@ -2032,9 +2083,13 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             .load_call_store(ll_fn, &src, &dst);
     }
 
-    fn constant(&self, mc: &sbc::Constant) -> llvm::Constant {
+    // Optional vec_mty is only used for a vector literal (i.e., Constant<Vector(Vec<Constant>))
+    // to help determine element type when vector constant data array is empty.
+    fn constant(&self, mc: &sbc::Constant, vec_mty: Option<&mty::Type>) -> llvm::Constant {
+        use mty::{PrimitiveType, Type};
         use sbc::Constant;
         let llcx = self.module_cx.llvm_cx;
+        let builder = &self.module_cx.llvm_builder;
         let ll_int = |n, val| llvm::Constant::int(llcx.int_type(n), U256::from(val));
         match mc {
             Constant::Bool(val) => ll_int(1, *val as u128),
@@ -2066,10 +2121,141 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 gval.set_constant();
                 gval.set_internal_linkage();
                 gval.set_initializer(aval);
-                self.module_cx.llvm_builder.build_load_global_const(gval)
+                builder.build_load_global_const(gval)
+            }
+            Constant::Vector(val_vec) => {
+                // What we'd like to do below is simply match Constant::* on an element of
+                // val_vec. But Move allows an empty vector literal (e.g., let v = vector[]),
+                // so that we may not be able to index an element of the vector. Instead, we
+                // have callers pass in an mty from their context and match on that to indirectly
+                // determine the Constant element type.
+                //
+                // Unpack the Constant vector literal data and repack as LLVM constants in a global
+                // array value containing vector literal data.
+                let vmty = vec_mty.unwrap();
+                let elt_mty = if let Type::Vector(et) = vmty { &**et } else { unreachable!() };
+                let aval = match elt_mty {
+                    Type::Primitive(PrimitiveType::Bool)
+                    | Type::Primitive(PrimitiveType::U8)
+                    | Type::Primitive(PrimitiveType::U16)
+                    | Type::Primitive(PrimitiveType::U32)
+                    | Type::Primitive(PrimitiveType::U64)
+                    | Type::Primitive(PrimitiveType::U128)
+                    | Type::Primitive(PrimitiveType::U256) => {
+                        eprintln!("here primitive case {}", format!("{:?}", vmty));
+                        let vals = self.rewrap_vec_constant(&val_vec);
+                        llcx.const_array(&vals, self.llvm_type(elt_mty)).as_const()
+                    }
+                    Type::Vector(bt) if bt.is_number_u8() => {
+                        // This is a Constant::ByteArray element type.
+                        assert!(matches!(val_vec[0], Constant::ByteArray(_)));
+                        eprintln!("here bytearray case {}", format!("{:?}", vmty));
+                        todo!();
+                    }
+                    _ => {
+                       eprintln!("unexpected vec constant: {}: {:#?}", val_vec.len(), val_vec);
+                       todo!("{:?}", vmty);
+                    }
+                };
+
+                let raw_vec_data = self
+                    .module_cx
+                    .llvm_module
+                    .add_global2(aval.llvm_type(), "vec_literal");
+                raw_vec_data.set_constant();
+                raw_vec_data.set_internal_linkage();
+                raw_vec_data.set_initializer(aval);
+
+                // Create an LLVM global containing the vector descriptor (to be passed to the
+                // runtime) and initialize it with the array created above. The format of the
+                // descriptor corresponds to 'move_native::rt_types::MoveUntypedVector'
+                let vec_descriptor_init = llcx.const_struct(
+                    &[
+                        raw_vec_data.ptr(),
+                        ll_int(64, val_vec.len() as u128),
+                        ll_int(64, val_vec.len() as u128),
+                    ],
+                );
+                let vec_descriptor = self
+                    .module_cx
+                    .llvm_module
+                    .add_global2(vec_descriptor_init.llvm_type(), "vdesc");
+                vec_descriptor.set_constant();
+                vec_descriptor.set_internal_linkage();
+                vec_descriptor.set_initializer(vec_descriptor_init);
+
+                // Generate LLVM IR to construct a new empty vector and then copy the global
+                // data into the new vector.
+                //   ...
+                //   %newv = call { ptr, i64, i64} move_rt_vec_empty(ptr @__move_rttydesc_{T})
+                //   %pv = alloca { ptr, i64, i64 }
+                //   store { ptr, i64, i64 } %newv, ptr %pv
+                //   call move_rt_vec_copy(ptr @__move_rttydesc_{T}, %pv, @vec_data_descriptor)
+                //   ...
+
+                let res_val = self.emit_rtcall_with_retval(RtCall::VecEmpty(elt_mty.clone()));
+
+                // Be sure to emit allocas only in the entry block. They may otherwise be
+                // interpreted as dynamic stack allocations by some parts of the LLVM code. These
+                // are not supported by the SBF/BPF back-ends.
+                //
+                // Temporarily reposition the builder at the entry basic block and insert there.
+                let curr_bb = builder.get_insert_block();
+                let parent_func = curr_bb.get_basic_block_parent();
+                builder.position_at_beginning(builder.get_entry_basic_block(parent_func));
+
+                let res_ptr = self
+                    .module_cx
+                    .llvm_builder
+                    .build_alloca(res_val.llvm_type(), "newv");
+
+                // Resume insertionn at the current block.
+                builder.position_at_end(curr_bb);
+
+                self.module_cx.llvm_builder.build_store(res_val.get0(), res_ptr);
+
+                self.emit_rtcall_with_retval(RtCall::VecCopy(
+                    res_ptr.as_any_value(),
+                    vec_descriptor.as_any_value(),
+                    elt_mty.clone(),
+                ))
+                .as_constant();
+
+                self.module_cx
+                    .llvm_builder
+                    .build_load(res_val.llvm_type(), res_ptr, "reload")
+                    .as_constant()
+
+            }
+            Constant::AddressArray(val_vec) => {
+                // This is just like Constant(Vector(_)) above, but the stackless bytecode
+                // currently treats it inconsistently as a special case.
+                eprintln!("vec constant: {}: {:#?}", val_vec.len(), val_vec);
+                let vmty = vec_mty.unwrap();
+                todo!("{:?}", vmty);
             }
             _ => todo!("{:?}", mc),
         }
+    }
+
+    // Transform `Vec<sbc::Constant>` to `Vec<llvm::Constant>`.
+    fn rewrap_vec_constant(&self, vc: &[sbc::Constant]) -> Vec<llvm::Constant> {
+        use sbc::Constant;
+        let retvec = vc.iter()
+            .map(|v| {
+                match v {
+                    Constant::Bool(_) => self.constant(v, None),
+                    Constant::U8(_) => self.constant(v, None),
+                    Constant::U16(_) => self.constant(v, None),
+                    Constant::U32(_) => self.constant(v, None),
+                    Constant::U64(_) => self.constant(v, None),
+                    Constant::U128(_) => self.constant(v, None),
+                    Constant::U256(_) => self.constant(v, None),
+                    _ => unreachable!("{:?}", v)
+                }
+            })
+            .collect();
+        retvec
     }
 
     fn emit_rtcall(&self, rtcall: RtCall) {
@@ -2095,6 +2281,44 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let args = typarams.chain(Some(local)).collect::<Vec<_>>();
                 self.module_cx.llvm_builder.call_store(llfn, &args, &[]);
             }
+            _ => unreachable!(),
+        }
+    }
+
+    // This version is used in contexts where TempIndexes are not used and/or where the caller
+    // expects a return value that it will decide how to use or store.
+    fn emit_rtcall_with_retval(&self, rtcall: RtCall) -> llvm::AnyValue {
+        match &rtcall {
+            RtCall::VecCopy(ll_dst_value, ll_src_value, elt_mty) => {
+                // Note, no retval from vec_copy.
+                let llfn = self.get_runtime_function(&rtcall);
+                let mut typarams: Vec<_> = self
+                    .get_rttydesc_ptrs(&[elt_mty.clone()])
+                    .iter()
+                    .map(|llval| llval.as_any_value()).collect();
+                typarams.push(*ll_dst_value);
+                typarams.push(*ll_src_value);
+                self.module_cx.llvm_builder.call(llfn, &typarams)
+            }
+            RtCall::VecCmpEq(ll_dst_value, ll_src_value, elt_mty) => {
+                let llfn = self.get_runtime_function(&rtcall);
+                let mut typarams: Vec<_> = self
+                    .get_rttydesc_ptrs(&[elt_mty.clone()])
+                    .iter()
+                    .map(|llval| llval.as_any_value()).collect();
+                typarams.push(*ll_dst_value);
+                typarams.push(*ll_src_value);
+                self.module_cx.llvm_builder.call(llfn, &typarams)
+            }
+            RtCall::VecEmpty(elt_mty) => {
+                let llfn = self.get_runtime_function(&rtcall);
+                let typarams: Vec<_> = self
+                    .get_rttydesc_ptrs(&[elt_mty.clone()])
+                    .iter()
+                    .map(|llval| llval.as_any_value()).collect();
+                self.module_cx.llvm_builder.call(llfn, &typarams)
+            }
+            _ => unreachable!(),
         }
     }
 
@@ -2102,6 +2326,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let name = match rtcall {
             RtCall::Abort(..) => "abort",
             RtCall::VecDestroy(..) => "vec_destroy",
+            RtCall::VecCopy(..) => "vec_copy",
+            RtCall::VecCmpEq(..) => "vec_cmp_eq",
+            RtCall::VecEmpty(..) => "vec_empty",
         };
         self.get_runtime_function_by_name(name)
     }
@@ -2131,6 +2358,36 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     let attrs = vec![];
                     (llty, attrs)
                 }
+                "vec_copy" => {
+                    let ret_ty = self.module_cx.llvm_cx.void_type();
+                    let tydesc_ty = self.module_cx.llvm_cx.int_type(8).ptr_type();
+                    // The vectors are passed by value, but the C ABI here passes structs by reference,
+                    // so it's another pointer.
+                    let vector_ty = self.module_cx.llvm_cx.int_type(8).ptr_type();
+                    let param_tys = &[tydesc_ty, vector_ty, vector_ty];
+                    let llty = llvm::FunctionType::new(ret_ty, param_tys);
+                    let attrs = vec![];
+                    (llty, attrs)
+                }
+                "vec_cmp_eq" => {
+                    let ret_ty = self.module_cx.llvm_cx.int_type(1);
+                    let tydesc_ty = self.module_cx.llvm_cx.int_type(8).ptr_type();
+                    // The vectors are passed by value, but the C ABI here passes structs by reference,
+                    // so it's another pointer.
+                    let vector_ty = self.module_cx.llvm_cx.int_type(8).ptr_type();
+                    let param_tys = &[tydesc_ty, vector_ty, vector_ty];
+                    let llty = llvm::FunctionType::new(ret_ty, param_tys);
+                    let attrs = vec![];
+                    (llty, attrs)
+                }
+                "vec_empty" => {
+                    let ret_ty = self.module_cx.get_llvm_type_for_move_native_vector();
+                    let tydesc_ty = self.module_cx.llvm_cx.int_type(8).ptr_type();
+                    let param_tys = &[tydesc_ty];
+                    let llty = llvm::FunctionType::new(ret_ty, param_tys);
+                    let attrs = vec![];
+                    (llty, attrs)
+                }
                 n => panic!("unknown runtime function {n}"),
             };
 
@@ -2154,6 +2411,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
 pub enum RtCall {
     Abort(mast::TempIndex),
     VecDestroy(mast::TempIndex, mty::Type),
+    VecCopy(llvm::AnyValue, llvm::AnyValue, mty::Type),
+    VecCmpEq(llvm::AnyValue, llvm::AnyValue, mty::Type),
+    VecEmpty(mty::Type),
 }
 
 /// Compile the module to object file.

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector03.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/mvector03.move
@@ -549,34 +549,32 @@ module 0x300::vector_tests {
         //);
     }
 
-    // TODO: Vector constants.
-    //public fun test_insert() {
-    //    let v = vector[7];
-    //    V::insert(&mut v, 6, 0);
-    //    assert!(v == vector[6, 7], 0);
+    public fun test_insert() {
+        let v = vector[7];
+        V::insert(&mut v, 6, 0);
+        assert!(v == vector[6, 7], 0);
 
-    //    let v = vector[7, 9];
-    //    V::insert(&mut v, 8, 1);
-    //    assert!(v == vector[7, 8, 9], 0);
+        let v = vector[7, 9];
+        V::insert(&mut v, 8, 1);
+        assert!(v == vector[7, 8, 9], 0);
 
-    //    let v = vector[6, 7];
-    //    V::insert(&mut v, 5, 0);
-    //    assert!(v == vector[5, 6, 7], 0);
+        let v = vector[6, 7];
+        V::insert(&mut v, 5, 0);
+        assert!(v == vector[5, 6, 7], 0);
 
-    //    let v = vector[5, 6, 8];
-    //    V::insert(&mut v, 7, 2);
-    //    assert!(v == vector[5, 6, 7, 8], 0);
-    //}
+        let v = vector[5, 6, 8];
+        V::insert(&mut v, 7, 2);
+        assert!(v == vector[5, 6, 7, 8], 0);
+    }
 
-    // TODO: Vector constants.
-    //public fun insert_at_end() {
-    //    let v = vector[];
-    //    V::insert(&mut v, 6, 0);
-    //    assert!(v == vector[6], 0);
+    public fun insert_at_end() {
+        let v = vector[];
+        V::insert(&mut v, 6, 0);
+        assert!(v == vector[6], 0);
 
-    //    V::insert(&mut v, 7, 1);
-    //    assert!(v == vector[6, 7], 0);
-    //}
+        V::insert(&mut v, 7, 1);
+        assert!(v == vector[6, 7], 0);
+    }
 }
 
 script {
@@ -613,7 +611,7 @@ script {
         VT::length();
         VT::pop_push_back();
         VT::test_natives_with_different_instantiations();
-        //VT::test_insert();
-        //VT::insert_at_end();
+        VT::test_insert();
+        VT::insert_at_end();
     }
 }


### PR DESCRIPTION
This patch implements some missing Move vector features and associated move-native runtime routines to support them.
- Move vector literals, e.g., "let v = vector[5, 6, 8]".
- Vector-vector comparisons.
- Vector-vector copies.
- New move-native runtime routines:
  * move_rt_vec_empty
  * move_rt_vec_copy
  * move_rt_vec_cmp_eq

Enabled some of the previously unsupported runnable move-stdlib vector unit tests in mvector3.move related to the above, which all now pass.