### PR TITLE
Implement runtime descriptor support for Move structs.

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -1929,13 +1929,15 @@ pub(crate) mod conv {
                 },
                 BorrowedTypedMoveValue::Struct(t, v) => unsafe {
                     // fixme struct / field names
-                    let mut dbg = f.debug_list();
+                    f.write_str("[");
                     let fields = walk_struct_fields(t, v);
                     for (type_, ref_) in fields {
                         let rv = borrow_move_value_as_rust_value(type_, ref_);
-                        dbg.entry(&rv);
+                        rv.fmt(f);
+                        f.write_str(", ");
                     }
-                    dbg.finish()
+                    f.write_str("]");
+                    Ok(())
                 },
                 BorrowedTypedMoveValue::Reference(t, v) => unsafe {
                     let rv = borrow_move_value_as_rust_value(t, &*v.0);

--- a/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/extensions.rs
@@ -67,7 +67,7 @@ pub impl TypeExt for mty::Type {
     /// Used by rttydesc to name type descriptors.
     fn sanitized_display_name(&self, type_display_ctx: &mty::TypeDisplayContext) -> String {
         let name = format!("{}", self.display(type_display_ctx));
-        name.replace(['<', '>'], "_")
+        name.replace(['<', '>', ':'], "_")
     }
 
     fn is_number_u8(&self) -> bool {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/translate.rs
@@ -176,9 +176,9 @@ impl<'up> GlobalContext<'up> {
 }
 
 pub struct ModuleContext<'mm, 'up> {
-    env: mm::ModuleEnv<'mm>,
-    llvm_cx: &'up llvm::Context,
-    llvm_module: llvm::Module,
+    pub env: mm::ModuleEnv<'mm>,
+    pub llvm_cx: &'up llvm::Context,
+    pub llvm_module: llvm::Module,
     llvm_builder: llvm::Builder,
     /// A map of move function id's to llvm function ids
     ///
@@ -400,7 +400,7 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
         format!("{}", s.display(&self.env.env.get_type_display_ctx()))
     }
 
-    fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv, tys: &[mty::Type]) -> String {
+    pub fn ll_struct_name_from_raw_name(&self, s_env: &mm::StructEnv, tys: &[mty::Type]) -> String {
         let raw_name = self.struct_raw_type_name(s_env, tys);
         let xs = raw_name.replace([':', '<', '>'], "_").replace(", ", ".");
         format!("struct.{}", xs)
@@ -2148,8 +2148,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         let mut ll_global_ptrs = vec![];
         for type_ in types {
             let ll_tydesc = rttydesc::define_llvm_tydesc(
-                self.module_cx.llvm_cx,
-                &self.module_cx.llvm_module,
+                self.module_cx,
                 type_,
                 &self.env.get_type_display_ctx(),
             );

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct01.move
@@ -1,0 +1,59 @@
+// log [123000, 66000, 33000, @000000000000000000000000000000000000000000000000000000000000CAFE, 0, ]
+// log 123000
+// log 66000
+// log 33000
+// log @000000000000000000000000000000000000000000000000000000000000CAFE
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module 0x10::vector {
+  native public fun empty<Element>(): vector<Element>;
+  native public fun length<Element>(v: &vector<Element>): u64;
+  native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+  native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+  native public fun destroy_empty<Element>(v: vector<Element>);
+  native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+  native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+  native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+}
+
+module 0x200::ST {
+    struct A1 has drop, copy {
+        f1: u64,
+        f2: u64,
+        f3: u16,
+        f4: address
+    }
+
+    public fun new(a1: u64, a2: u64, a3: u16, a4: address): A1 {
+        A1 { f1: a1, f2: a2, f3: a3, f4: a4 }
+    }
+
+    public fun get(s: &A1): (u64, u64, u16, address) {
+        let A1 { f1: x, f2: y, f3: z, f4: w} = *s;
+        (x, y, z, w)
+    }
+}
+
+script {
+  use 0x10::debug;
+  use 0x10::vector;
+  use 0x200::ST;
+
+  fun main() {
+    let s = ST::new(123000, 66000, 33000, @0xcafe);
+    // We can debug print a structure now!
+    debug::print(&s);
+
+    let v: vector<ST::A1> = vector::empty();
+    vector::push_back(&mut v, s);
+    let sref = vector::borrow<ST::A1>(&v, 0);
+    let (f1, f2, f3, f4) = ST::get(sref);
+    debug::print(&f1);
+    debug::print(&f2);
+    debug::print(&f3);
+    debug::print(&f4);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct02.move
@@ -1,0 +1,60 @@
+// log [456, [true, 0, ], 0, ]
+// log 456
+// log true
+
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module 0x10::vector {
+  native public fun empty<Element>(): vector<Element>;
+  native public fun length<Element>(v: &vector<Element>): u64;
+  native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+  native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+  native public fun destroy_empty<Element>(v: vector<Element>);
+  native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+  native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+  native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+}
+
+module 0x200::ST {
+    struct A0 has drop, copy {
+        a: bool
+    }
+
+    struct A1 has drop, copy {
+        f1: u64,
+        f2: A0
+    }
+
+    public fun new(a1: u64, inner_a: bool): A1 {
+        let sa0 = A0 { a: inner_a };
+        A1 { f1: a1, f2: sa0 }
+    }
+
+    public fun get(s: &A1): (u64, bool) {
+        let A1 { f1: x, f2: y } = *s;
+        (x, y.a)
+    }
+}
+
+script {
+  use 0x10::debug;
+  use 0x10::vector;
+  use 0x200::ST;
+
+  fun main() {
+    let s = ST::new(456, true);
+    // We can print a nested struct too.
+    debug::print(&s);
+
+    let v: vector<ST::A1> = vector::empty();
+    vector::push_back(&mut v, s);
+
+    let sref = vector::borrow<ST::A1>(&v, 0);
+    let (f1, f2) = ST::get(sref);
+    debug::print(&f1);
+    debug::print(&f2);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -222,7 +222,7 @@ fn load_directives(test_path: &Path) -> anyhow::Result<Vec<TestDirective>> {
             directives.push(TestDirective::Abort(code));
         }
         if line.starts_with("log ") {
-            let s = line.split(' ').nth(1).expect("log value");
+            let s = line.strip_prefix("log ").unwrap().to_string();
             directives.push(TestDirective::Log(s.to_string()));
         }
         if line.starts_with("input ") {


### PR DESCRIPTION
This patch adds support for structs in the rttydesc module. Various places were fixed to grok and properly process Type::Struct. A new routine define_type_info_global struct was added to do the rather involved and intricate visitation of struct fields and creation of StructTypeInfo and StructFieldInfos.

Did minor clean-up of value transmission across rttydesc calls. Instead of passing N module variables to every routine, pass a single ModuleContext.

Added a number of new supporting LLVM routines.

Fixed an existing defect in the move-native runtime library where a debug formatter dereferenced and called a rogue pointer resulting in a hard crash.  https://github.com/solana-labs/move/issues/191. There are other similar formatters/serializers which also appear to be defective. Those will be analyzed at a later date and are not exercised by the new tests in this patch.

Fixed an existing defect in the test-common driver where it incorrectly split a log line into multiple lines.

Added two runnable rbpf test cases demonstrating the functionality:
- Pass a struct to a native vector routine which needs a struct rtty desc-- for both simple and nested structs.
- Demonstrate debug::print working correctly for a single struct argument.