### PR TITLE
Fix another move-native fmt::Debug crash (vector-of-structs).

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -830,24 +830,14 @@ impl Type {
     pub fn dump_properties_to_str(&self, data_layout: LLVMTargetDataRef) -> String {
         unsafe {
             let ty = self.0;
-            let mut s = "".to_string();
-            s += &format!(
-                "StoreSizeOfType: {}\n",
-                LLVMStoreSizeOfType(data_layout, ty) as u32
+            let s = &format!(
+                "StoreSizeOfType: {}\nABISizeOfType: {}\nABIAlignmnetOfType: {}\nSizeOfTypeInBits: {}\n",
+                LLVMStoreSizeOfType(data_layout, ty) as u32,
+                LLVMABISizeOfType(data_layout, ty) as u32,
+                LLVMABIAlignmentOfType(data_layout, ty),
+                LLVMSizeOfTypeInBits(data_layout, ty) as u32,
             );
-            s += &format!(
-                "ABISizeOfType: {}\n",
-                LLVMABISizeOfType(data_layout, ty) as u32
-            );
-            s += &format!(
-                "ABIAlignmnetOfType: {}\n",
-                LLVMABIAlignmentOfType(data_layout, ty)
-            );
-            s += &format!(
-                "SizeOfTypeInBits: {}\n",
-                LLVMSizeOfTypeInBits(data_layout, ty) as u32
-            );
-            s
+            s.to_string()
         }
     }
 

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -320,8 +320,8 @@ fn define_type_info_global_struct(
     ll_fld_array.set_unnamed_addr();
     ll_fld_array.set_initializer(aval.as_const());
 
-    // Create the overall `ll_struct_info_ty` runtime descriptor global. This LLVM type
-    // corresponds to `move_native::rt_types::StructFieldInfo`:
+    // Create the overall `ll_struct_type_info_ty` runtime descriptor global. This LLVM type
+    // corresponds to `move_native::rt_types::StructTypeInfo`:
     //   pub struct StructTypeInfo {
     //     pub field_array_ptr: *const StructFieldInfo,
     //     pub field_array_len: u64,

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct02.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct02.move
@@ -1,4 +1,4 @@
-// log [456, [true, 0, ], 0, ]
+// log ST::A1 {456, ST::A0 {true, 0, }, 0, }
 // log 456
 // log true
 

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct03.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/rtty-struct03.move
@@ -1,8 +1,8 @@
-// log ST::A1 {123000, 66000, 33000, @000000000000000000000000000000000000000000000000000000000000CAFE, 0, }
-// log 123000
-// log 66000
-// log 33000
-// log @000000000000000000000000000000000000000000000000000000000000CAFE
+// log ST::A1 {254, 36893488147419103232, 0, }
+// log [ST::A1 {254, 36893488147419103232, 0, }, ST::A1 {123, 456, 0, }, ]
+// log 123
+// log 456
+
 
 module 0x10::debug {
   native public fun print<T>(x: &T);
@@ -21,19 +21,17 @@ module 0x10::vector {
 
 module 0x200::ST {
     struct A1 has drop, copy {
-        f1: u64,
-        f2: u64,
-        f3: u16,
-        f4: address
+        f1: u8,
+        f2: u128
     }
 
-    public fun new(a1: u64, a2: u64, a3: u16, a4: address): A1 {
-        A1 { f1: a1, f2: a2, f3: a3, f4: a4 }
+    public fun new(a1: u8, a2: u128): A1 {
+        A1 { f1: a1, f2: a2 }
     }
 
-    public fun get(s: &A1): (u64, u64, u16, address) {
-        let A1 { f1: x, f2: y, f3: z, f4: w} = *s;
-        (x, y, z, w)
+    public fun get(s: &A1): (u8, u128) {
+        let A1 { f1: x, f2: y } = *s;
+        (x, y)
     }
 }
 
@@ -43,17 +41,20 @@ script {
   use 0x200::ST;
 
   fun main() {
-    let s = ST::new(123000, 66000, 33000, @0xcafe);
-    // We can debug print a structure now!
-    debug::print(&s);
+    let s1 = ST::new(254, 36893488147419103232_u128);
+    let s2 = ST::new(123, 456);
+    debug::print(&s1);
 
+    // Now we're really going gonzo and operating on and debug-printing
+    // a vector-of-structs.
     let v: vector<ST::A1> = vector::empty();
-    vector::push_back(&mut v, s);
-    let sref = vector::borrow<ST::A1>(&v, 0);
-    let (f1, f2, f3, f4) = ST::get(sref);
+    vector::push_back(&mut v, s1);
+    vector::push_back(&mut v, s2);
+    debug::print(&v);
+
+    let sref = vector::borrow<ST::A1>(&v, 1);
+    let (f1, f2) = ST::get(sref);
     debug::print(&f1);
     debug::print(&f2);
-    debug::print(&f3);
-    debug::print(&f4);
   }
 }


### PR DESCRIPTION
This patch fixes another occurrence of the move-native runtime defect where a debug formatter-- this time in the vector-of-structs case-- dereferenced and called a rogue pointer. This results in a callx out of the address space.  https://github.com/solana-labs/move/issues/191.

Also enhanced the fmt::Debug routines for structs to output the struct name and otherwise make the output more like what a default rust debug formatter for structs would do.

Other minor NFC clean-ups.

Added a runnable rbpf test cases demonstrating vector-of-struct operations and debug-printing. Updated the log messages of the other rtty tests since the output now includes names.