### PR TITLE
NFC: added some debug

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -788,7 +788,7 @@ impl Builder {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Type(pub LLVMTypeRef);
 
 impl Type {


### PR DESCRIPTION
Mapping mty -> llty used here only for debugging.

Today we allocate the very structure (actually it is just an address) as a local field, so the debug printout for this will be something like:
 ```
[2023-06-12 23:30:02.939008436] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:725 [DEBUG] Type::Struct... found struct struct.M7__Y
[2023-06-12 23:30:02.939076757] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:725 [DEBUG] Type::Struct... found struct struct.M7__A
[2023-06-12 23:30:02.939105211] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:725 [DEBUG] Type::Struct... found struct struct.M7__Y
[2023-06-12 23:30:02.939130690] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:725 [DEBUG] Type::Struct... found struct struct.M7__Y
[2023-06-12 23:30:02.939155136] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:725 [DEBUG] Type::Struct... found struct struct.M7__A
[2023-06-12 23:30:02.939215041] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:1830 [DEBUG] stype %struct.M7__A = type { i32, i8 }
[2023-06-12 23:30:02.939232644] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:1837 [DEBUG] local_src_ty_0 i32
[2023-06-12 23:30:02.939244146] move_mv_llvm_compiler::stackless::translate - language/tools/move-mv-llvm-compiler/src/stackless/translate.rs:1840 [DEBUG] ty is struct 
```

A farther analysis will require if we want to eliminate these fields before we translate to llvm.
Ideally it should be SSA. We have SSA in llvm, but for many reasons it will be useful to have it also at the stage of codegen while we translate move bc to llvm ir.