### PR TITLE
Fix generic function dep defect; rework function discovery approach.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
@@ -18,6 +18,21 @@ entry:
   ret %struct.M2__Coin_M2__Bitcoin_ %retval1
 }
 
+define private %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1__value = alloca i64, align 8
+  %local_2 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1__value, align 4
+  %fv.0 = load i64, ptr %local_1__value, align 4
+  %insert_0 = insertvalue %struct.M2__Coin_M2__Bitcoin_ undef, i64 %fv.0, 0
+  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 4
+  %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 4
+  ret %struct.M2__Coin_M2__Bitcoin_ %retval
+}
+
 define %struct.M2__Coin_M2__Sol_ @M2__mint_concrete(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
@@ -31,19 +46,4 @@ entry:
   store %struct.M2__Coin_M2__Sol_ %insert_0, ptr %local_2, align 4
   %retval = load %struct.M2__Coin_M2__Sol_, ptr %local_2, align 4
   ret %struct.M2__Coin_M2__Sol_ %retval
-}
-
-define %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %0) {
-entry:
-  %local_0 = alloca i64, align 8
-  %local_1__value = alloca i64, align 8
-  %local_2 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1__value, align 4
-  %fv.0 = load i64, ptr %local_1__value, align 4
-  %insert_0 = insertvalue %struct.M2__Coin_M2__Bitcoin_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 4
-  %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 4
-  ret %struct.M2__Coin_M2__Bitcoin_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
@@ -19,6 +19,19 @@ entry:
   ret i64 %retval1
 }
 
+define private i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %0) {
+entry:
+  %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  %local_2__value = alloca i64, align 8
+  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
+  %srcval = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
+  %ext_0 = extractvalue %struct.Coins__Coin_M11__USDC_ %srcval, 0
+  store i64 %ext_0, ptr %local_2__value, align 4
+  %retval = load i64, ptr %local_2__value, align 4
+  ret i64 %retval
+}
+
 define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @M11__mint_2coins_usdc_and_eth(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
@@ -47,34 +60,6 @@ entry:
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
 }
 
-define private %struct.Coins__Coin_M11__USDC_ @M11__mint_usdc(i64 %0) {
-entry:
-  %local_0 = alloca i64, align 8
-  %local_1 = alloca i64, align 8
-  %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %call_arg_0 = load i64, ptr %local_1, align 4
-  %retval = call %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %call_arg_0)
-  store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 4
-  %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
-  ret %struct.Coins__Coin_M11__USDC_ %retval1
-}
-
-define private i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %0) {
-entry:
-  %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
-  %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
-  %local_2__value = alloca i64, align 8
-  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
-  %srcval = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
-  %ext_0 = extractvalue %struct.Coins__Coin_M11__USDC_ %srcval, 0
-  store i64 %ext_0, ptr %local_2__value, align 4
-  %retval = load i64, ptr %local_2__value, align 4
-  ret i64 %retval
-}
-
 define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
@@ -100,6 +85,21 @@ entry:
   %insert_04 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
   %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_04, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
+}
+
+define private %struct.Coins__Coin_M11__USDC_ @M11__mint_usdc(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
+  store i64 %0, ptr %local_0, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 4
+  store i64 %load_store_tmp, ptr %local_1, align 4
+  %call_arg_0 = load i64, ptr %local_1, align 4
+  %retval = call %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %call_arg_0)
+  store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 4
+  %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
+  ret %struct.Coins__Coin_M11__USDC_ %retval1
 }
 
 define private %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %0) {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -17,6 +17,4 @@ entry:
   ret void
 }
 
-declare i8 @Test2__test2(i8, i8)
-
 declare i8 @Test1__test1(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -48,12 +48,12 @@ entry:
   ret void
 }
 
-declare i8 @Country__dropit(%struct.Country__Country)
-
-declare i8 @Country__get_id(ptr)
+declare %struct.Country__Country @Country__new_country(i8, i64)
 
 declare i64 @Country__get_pop(%struct.Country__Country)
 
-declare %struct.Country__Country @Country__new_country(i8, i64)
+declare i8 @Country__get_id(ptr)
 
 declare void @Country__set_id(ptr, i8)
+
+declare i8 @Country__dropit(%struct.Country__Country)

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/moption01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/moption01.move
@@ -301,13 +301,6 @@ module 0x300::option_tests {
     use 0x10::option;
     use 0x10::vector;
 
-    fun phony() {
-        // Work around dependency problem. Remove when that is gone.
-        let v = vector::singleton(31);
-        assert!(vector::contains(&v, &31), 0);
-        assert!(vector::is_empty(&vector::empty<u64>()), 0);
-    }
-
     public fun option_none_is_none() {
         let none = option::none<u64>();
         assert!(option::is_none(&none), 0);


### PR DESCRIPTION
We have previously discovered through experience that some of the model-provided information we once depended on to discover all module functions, called functions, and concrete instantiations are not always consistent or reliable.

For this reason, we now take a different approach and seed our discovery with just the list of functions provided by `ModuleEnv::get_functions`. For any other called functions (this module or foreign) and for any generic instantiations, we will expand the seed frontier incrementally by gleaning the remaining information from a visitation of every function call instruction (recursively) in every seed function.

This also fixes a dependence problem in the previous discovery approach where some transitively expanded generics were never seen or declared.

No new tests were added as the previous generics work covers this. We now, however, can eliminate the dependence defect work around that was originally in the moption01 test case. It now runs without the work around successfully.