### PR TITLE
Fix defects: TargetMachine created too late and DataLayout incorrect.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -188,14 +188,17 @@ impl Context {
         }
     }
 
-    pub fn abi_size_of_type(&self, data_layout: LLVMTargetDataRef, ty: Type) -> usize {
-        unsafe { LLVMABISizeOfType(data_layout, ty.0) as usize }
+    pub fn abi_size_of_type(&self, data_layout: TargetData, ty: Type) -> usize {
+        unsafe { LLVMABISizeOfType(data_layout.0, ty.0) as usize }
     }
 
-    pub fn abi_alignment_of_type(&self, data_layout: LLVMTargetDataRef, ty: Type) -> usize {
-        unsafe { LLVMABIAlignmentOfType(data_layout, ty.0) as usize }
+    pub fn abi_alignment_of_type(&self, data_layout: TargetData, ty: Type) -> usize {
+        unsafe { LLVMABIAlignmentOfType(data_layout.0, ty.0) as usize }
     }
 }
+
+#[derive(Copy, Clone)]
+pub struct TargetData(LLVMTargetDataRef);
 
 pub struct Module(LLVMModuleRef);
 
@@ -217,6 +220,12 @@ impl Module {
     pub fn set_target(&self, triple: &str) {
         unsafe {
             LLVMSetTarget(self.0, triple.cstr());
+        }
+    }
+
+    pub fn dump(&self) {
+        unsafe {
+            LLVMDumpModule(self.0);
         }
     }
 
@@ -296,11 +305,12 @@ impl Module {
         }
     }
 
-    pub fn get_module_data_layout(&self) -> LLVMTargetDataRef {
+    pub fn get_module_data_layout(&self) -> TargetData {
+        use log::debug;
         unsafe {
-            // Ordinarily we'd call LLVMGetModuleDataLayout(self.0), but there is an existing
-            // defect elsewhere in setting up the data layout.
-            LLVMCreateTargetData("e-m:e-p:64:64-i64:64-n32:64-S128".cstr())
+            let dl = LLVMGetModuleDataLayout(self.0);
+            debug!(target: "dl", "\n{}", CStr::from_ptr(LLVMCopyStringRepOfTargetData(dl)).to_str().unwrap());
+            TargetData(dl)
         }
     }
 
@@ -556,9 +566,9 @@ impl Builder {
         }
     }
 
-    pub fn build_cond_br(&self, cnd_reg: LLVMValueRef, bb0: BasicBlock, bb1: BasicBlock) {
+    pub fn build_cond_br(&self, cnd_reg: AnyValue, bb0: BasicBlock, bb1: BasicBlock) {
         unsafe {
-            LLVMBuildCondBr(self.0, cnd_reg, bb0.0, bb1.0);
+            LLVMBuildCondBr(self.0, cnd_reg.0, bb0.0, bb1.0);
         }
     }
 
@@ -569,13 +579,8 @@ impl Builder {
         }
     }
 
-    pub fn build_extract_value(
-        &self,
-        agg_val: LLVMValueRef,
-        index: u32,
-        name: &str,
-    ) -> LLVMValueRef {
-        unsafe { LLVMBuildExtractValue(self.0, agg_val, index, name.cstr()) }
+    pub fn build_extract_value(&self, agg_val: AnyValue, index: u32, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildExtractValue(self.0, agg_val.0, index, name.cstr())) }
     }
 
     // Build call to an intrinsic (use the 'types' parameter for overloaded intrinsics).
@@ -584,11 +589,11 @@ impl Builder {
         module: &Module,
         iname: &str,
         types: &[Type],
-        args: &[LLVMValueRef],
+        args: &[AnyValue],
         resname: &str,
-    ) -> LLVMValueRef {
+    ) -> AnyValue {
         let mut tys = types.iter().map(|ty| ty.0).collect::<Vec<_>>();
-        let mut args = args.to_vec();
+        let mut args = args.iter().map(|arg| arg.0).collect::<Vec<_>>();
 
         unsafe {
             let iid = LLVMLookupIntrinsicID(iname.cstr(), iname.len());
@@ -597,14 +602,14 @@ impl Builder {
 
             let cx = LLVMGetModuleContext(module.0);
             let fnty = LLVMIntrinsicGetType(cx, iid, tys.as_mut_ptr(), tys.len());
-            LLVMBuildCall2(
+            AnyValue(LLVMBuildCall2(
                 self.0,
                 fnty,
                 fv,
                 args.as_mut_ptr(),
                 args.len() as libc::c_uint,
                 resname.cstr(),
-            )
+            ))
         }
     }
 
@@ -716,13 +721,8 @@ impl Builder {
         unsafe { AnyValue(LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr())) }
     }
 
-    pub fn build_load_from_valref(
-        &self,
-        ty: Type,
-        src0_reg: LLVMValueRef,
-        name: &str,
-    ) -> LLVMValueRef {
-        unsafe { LLVMBuildLoad2(self.0, ty.0, src0_reg, name.cstr()) }
+    pub fn build_load_from_valref(&self, ty: Type, src0_reg: AnyValue, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildLoad2(self.0, ty.0, src0_reg.0, name.cstr())) }
     }
 
     pub fn build_load_global_const(&self, gval: Global) -> Constant {
@@ -732,9 +732,9 @@ impl Builder {
         }
     }
 
-    pub fn build_store(&self, dst_reg: LLVMValueRef, dst: Alloca) {
+    pub fn build_store(&self, dst_reg: AnyValue, dst: Alloca) {
         unsafe {
-            LLVMBuildStore(self.0, dst_reg, dst.0);
+            LLVMBuildStore(self.0, dst_reg.0, dst.0);
         }
     }
 
@@ -752,35 +752,30 @@ impl Builder {
     pub fn build_binop(
         &self,
         op: LLVMOpcode,
-        lhs: LLVMValueRef,
-        rhs: LLVMValueRef,
+        lhs: AnyValue,
+        rhs: AnyValue,
         name: &str,
-    ) -> LLVMValueRef {
-        unsafe { LLVMBuildBinOp(self.0, op, lhs, rhs, name.cstr()) }
+    ) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildBinOp(self.0, op, lhs.0, rhs.0, name.cstr())) }
     }
     pub fn build_compare(
         &self,
         pred: LLVMIntPredicate,
-        lhs: LLVMValueRef,
-        rhs: LLVMValueRef,
+        lhs: AnyValue,
+        rhs: AnyValue,
         name: &str,
-    ) -> LLVMValueRef {
-        unsafe { LLVMBuildICmp(self.0, pred, lhs, rhs, name.cstr()) }
+    ) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildICmp(self.0, pred, lhs.0, rhs.0, name.cstr())) }
     }
     #[allow(dead_code)]
-    pub fn build_unary_bitcast(
-        &self,
-        val: LLVMValueRef,
-        dest_ty: LLVMTypeRef,
-        name: &str,
-    ) -> LLVMValueRef {
-        unsafe { LLVMBuildBitCast(self.0, val, dest_ty, name.cstr()) }
+    pub fn build_unary_bitcast(&self, val: AnyValue, dest_ty: Type, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildBitCast(self.0, val.0, dest_ty.0, name.cstr())) }
     }
-    pub fn build_zext(&self, val: LLVMValueRef, dest_ty: LLVMTypeRef, name: &str) -> LLVMValueRef {
-        unsafe { LLVMBuildZExt(self.0, val, dest_ty, name.cstr()) }
+    pub fn build_zext(&self, val: AnyValue, dest_ty: Type, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildZExt(self.0, val.0, dest_ty.0, name.cstr())) }
     }
-    pub fn build_trunc(&self, val: LLVMValueRef, dest_ty: LLVMTypeRef, name: &str) -> LLVMValueRef {
-        unsafe { LLVMBuildTrunc(self.0, val, dest_ty, name.cstr()) }
+    pub fn build_trunc(&self, val: AnyValue, dest_ty: Type, name: &str) -> AnyValue {
+        unsafe { AnyValue(LLVMBuildTrunc(self.0, val.0, dest_ty.0, name.cstr())) }
     }
 
     pub fn wrap_as_any_value(&self, val: LLVMValueRef) -> AnyValue {
@@ -827,15 +822,15 @@ impl Type {
         }
     }
 
-    pub fn dump_properties_to_str(&self, data_layout: LLVMTargetDataRef) -> String {
+    pub fn dump_properties_to_str(&self, data_layout: TargetData) -> String {
         unsafe {
             let ty = self.0;
             let s = &format!(
                 "StoreSizeOfType: {}\nABISizeOfType: {}\nABIAlignmnetOfType: {}\nSizeOfTypeInBits: {}\n",
-                LLVMStoreSizeOfType(data_layout, ty) as u32,
-                LLVMABISizeOfType(data_layout, ty) as u32,
-                LLVMABIAlignmentOfType(data_layout, ty),
-                LLVMSizeOfTypeInBits(data_layout, ty) as u32,
+                LLVMStoreSizeOfType(data_layout.0, ty) as u32,
+                LLVMABISizeOfType(data_layout.0, ty) as u32,
+                LLVMABIAlignmentOfType(data_layout.0, ty),
+                LLVMSizeOfTypeInBits(data_layout.0, ty) as u32,
             );
             s.to_string()
         }
@@ -885,8 +880,8 @@ impl StructType {
         unsafe { Type(LLVMStructGetTypeAtIndex(self.0, idx as libc::c_uint)) }
     }
 
-    pub fn offset_of_element(&self, data_layout: LLVMTargetDataRef, idx: usize) -> usize {
-        unsafe { LLVMOffsetOfElement(data_layout, self.0, idx as libc::c_uint) as usize }
+    pub fn offset_of_element(&self, data_layout: TargetData, idx: usize) -> usize {
+        unsafe { LLVMOffsetOfElement(data_layout.0, self.0, idx as libc::c_uint) as usize }
     }
 
     pub fn dump(&self) {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/mod.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/mod.rs
@@ -7,4 +7,5 @@ mod llvm;
 mod rttydesc;
 mod translate;
 
+pub use llvm::*;
 pub use translate::*;

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/empty-module.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/empty-module.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/friend.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/friend.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x42__A'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct-pair.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct-pair.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x1__TestBinaryOps'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct_arguments.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/ir-tests/struct_arguments.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x42__M'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -1,13 +1,15 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
 define private void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
-  store i64 10, ptr %local_0, align 4
-  %call_arg_0 = load i64, ptr %local_0, align 4
+  store i64 10, ptr %local_0, align 8
+  %call_arg_0 = load i64, ptr %local_0, align 8
   call void @move_rt_abort(i64 %call_arg_0)
   unreachable
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__M3'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 @acct.addr = internal constant [32 x i8] c"\1F\1E\1D\1C\1B\1A\19\18\17\16\15\14\13\12\11\10\0F\0E\0D\0C\0B\0A\09\08\07\06\05\04\03\02\01\00"
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -1,13 +1,15 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
 define private void @Test__test() {
 entry:
   %local_0 = alloca i64, align 8
-  store i64 10, ptr %local_0, align 4
-  %call_arg_0 = load i64, ptr %local_0, align 4
+  store i64 10, ptr %local_0, align 8
+  %call_arg_0 = load i64, ptr %local_0, align 8
   call void @move_rt_abort(i64 %call_arg_0)
   unreachable
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assign-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assign-build/scripts/main.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -52,13 +54,13 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i8, align 1
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
+  store i128 %0, ptr %local_0, align 8
   store i8 %1, ptr %local_1, align 1
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
   %load_store_tmp1 = load i8, ptr %local_1, align 1
   store i8 %load_store_tmp1, ptr %local_3, align 1
-  %shl_src_0 = load i128, ptr %local_2, align 4
+  %shl_src_0 = load i128, ptr %local_2, align 8
   %shl_src_1 = load i8, ptr %local_3, align 1
   %rangecond = icmp uge i8 %shl_src_1, -128
   br i1 %rangecond, label %then_bb, label %join_bb
@@ -70,8 +72,8 @@ then_bb:                                          ; preds = %entry
 join_bb:                                          ; preds = %entry
   %zext_dst = zext i8 %shl_src_1 to i128
   %shl_dst = shl i128 %shl_src_0, %zext_dst
-  store i128 %shl_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %shl_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -112,13 +114,13 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i8, align 1
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   store i8 %1, ptr %local_1, align 1
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
   %load_store_tmp1 = load i8, ptr %local_1, align 1
   store i8 %load_store_tmp1, ptr %local_3, align 1
-  %shl_src_0 = load i64, ptr %local_2, align 4
+  %shl_src_0 = load i64, ptr %local_2, align 8
   %shl_src_1 = load i8, ptr %local_3, align 1
   %rangecond = icmp uge i8 %shl_src_1, 64
   br i1 %rangecond, label %then_bb, label %join_bb
@@ -130,8 +132,8 @@ then_bb:                                          ; preds = %entry
 join_bb:                                          ; preds = %entry
   %zext_dst = zext i8 %shl_src_1 to i64
   %shl_dst = shl i64 %shl_src_0, %zext_dst
-  store i64 %shl_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %shl_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 
@@ -171,13 +173,13 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i8, align 1
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
+  store i128 %0, ptr %local_0, align 8
   store i8 %1, ptr %local_1, align 1
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
   %load_store_tmp1 = load i8, ptr %local_1, align 1
   store i8 %load_store_tmp1, ptr %local_3, align 1
-  %shr_src_0 = load i128, ptr %local_2, align 4
+  %shr_src_0 = load i128, ptr %local_2, align 8
   %shr_src_1 = load i8, ptr %local_3, align 1
   %rangecond = icmp uge i8 %shr_src_1, -128
   br i1 %rangecond, label %then_bb, label %join_bb
@@ -189,8 +191,8 @@ then_bb:                                          ; preds = %entry
 join_bb:                                          ; preds = %entry
   %zext_dst = zext i8 %shr_src_1 to i128
   %shr_dst = lshr i128 %shr_src_0, %zext_dst
-  store i128 %shr_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %shr_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -231,13 +233,13 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i8, align 1
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   store i8 %1, ptr %local_1, align 1
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
   %load_store_tmp1 = load i8, ptr %local_1, align 1
   store i8 %load_store_tmp1, ptr %local_3, align 1
-  %shr_src_0 = load i64, ptr %local_2, align 4
+  %shr_src_0 = load i64, ptr %local_2, align 8
   %shr_src_1 = load i8, ptr %local_3, align 1
   %rangecond = icmp uge i8 %shr_src_1, 64
   br i1 %rangecond, label %then_bb, label %join_bb
@@ -249,8 +251,8 @@ then_bb:                                          ; preds = %entry
 join_bb:                                          ; preds = %entry
   %zext_dst = zext i8 %shr_src_1 to i64
   %shr_dst = lshr i64 %shr_src_0, %zext_dst
-  store i64 %shr_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %shr_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -64,8 +66,8 @@ bb_1:                                             ; preds = %entry
   br label %bb_2
 
 bb_0:                                             ; preds = %entry
-  store i64 10, ptr %local_7, align 4
-  %call_arg_02 = load i64, ptr %local_7, align 4
+  store i64 10, ptr %local_7, align 8
+  %call_arg_02 = load i64, ptr %local_7, align 8
   call void @move_rt_abort(i64 %call_arg_02)
   unreachable
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -28,8 +30,8 @@ entry:
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
   %zext_dst = zext i8 %cast_src to i64
-  store i64 %zext_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %zext_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -8,12 +10,12 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
-  store i128 %cast_src, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
+  store i128 %cast_src, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -22,10 +24,10 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i16, align 2
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
   %castcond = icmp ugt i128 %cast_src, 65535
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -45,13 +47,13 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i256, align 8
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
   %zext_dst = zext i128 %cast_src to i256
-  store i256 %zext_dst, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %zext_dst, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -60,10 +62,10 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i32, align 4
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
   %castcond = icmp ugt i128 %cast_src, 4294967295
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -83,10 +85,10 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i64, align 8
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
   %castcond = icmp ugt i128 %cast_src, 18446744073709551615
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -96,8 +98,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i128 %cast_src to i64
-  store i64 %trunc_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %trunc_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 
@@ -106,10 +108,10 @@ entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
   %local_2 = alloca i8, align 1
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i128, ptr %local_1, align 8
   %castcond = icmp ugt i128 %cast_src, 255
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -134,8 +136,8 @@ entry:
   store i16 %load_store_tmp, ptr %local_1, align 2
   %cast_src = load i16, ptr %local_1, align 2
   %zext_dst = zext i16 %cast_src to i128
-  store i128 %zext_dst, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %zext_dst, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -163,8 +165,8 @@ entry:
   store i16 %load_store_tmp, ptr %local_1, align 2
   %cast_src = load i16, ptr %local_1, align 2
   %zext_dst = zext i16 %cast_src to i256
-  store i256 %zext_dst, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %zext_dst, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -193,8 +195,8 @@ entry:
   store i16 %load_store_tmp, ptr %local_1, align 2
   %cast_src = load i16, ptr %local_1, align 2
   %zext_dst = zext i16 %cast_src to i64
-  store i64 %zext_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %zext_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 
@@ -226,10 +228,10 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i128, align 8
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
   %castcond = icmp ugt i256 %cast_src, 340282366920938463463374607431768211455
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -239,8 +241,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i128
-  store i128 %trunc_dst, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %trunc_dst, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -249,10 +251,10 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i16, align 2
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
   %castcond = icmp ugt i256 %cast_src, 65535
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -272,12 +274,12 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i256, align 8
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
-  store i256 %cast_src, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
+  store i256 %cast_src, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -286,10 +288,10 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i32, align 4
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
   %castcond = icmp ugt i256 %cast_src, 4294967295
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -309,10 +311,10 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i64, align 8
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
   %castcond = icmp ugt i256 %cast_src, 18446744073709551615
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -322,8 +324,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %trunc_dst = trunc i256 %cast_src to i64
-  store i64 %trunc_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %trunc_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 
@@ -332,10 +334,10 @@ entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
   %local_2 = alloca i8, align 1
-  store i256 %0, ptr %local_0, align 4
-  %load_store_tmp = load i256, ptr %local_0, align 4
-  store i256 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i256, ptr %local_1, align 4
+  store i256 %0, ptr %local_0, align 8
+  %load_store_tmp = load i256, ptr %local_0, align 8
+  store i256 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i256, ptr %local_1, align 8
   %castcond = icmp ugt i256 %cast_src, 255
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -360,8 +362,8 @@ entry:
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
   %zext_dst = zext i32 %cast_src to i128
-  store i128 %zext_dst, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %zext_dst, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -398,8 +400,8 @@ entry:
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
   %zext_dst = zext i32 %cast_src to i256
-  store i256 %zext_dst, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %zext_dst, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -427,8 +429,8 @@ entry:
   store i32 %load_store_tmp, ptr %local_1, align 4
   %cast_src = load i32, ptr %local_1, align 4
   %zext_dst = zext i32 %cast_src to i64
-  store i64 %zext_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %zext_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 
@@ -460,13 +462,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i128, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
   %zext_dst = zext i64 %cast_src to i128
-  store i128 %zext_dst, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %zext_dst, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -475,10 +477,10 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i16, align 2
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
   %castcond = icmp ugt i64 %cast_src, 65535
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -498,13 +500,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i256, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
   %zext_dst = zext i64 %cast_src to i256
-  store i256 %zext_dst, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %zext_dst, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -513,10 +515,10 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i32, align 4
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
   %castcond = icmp ugt i64 %cast_src, 4294967295
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -536,12 +538,12 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
-  store i64 %cast_src, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
+  store i64 %cast_src, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 
@@ -550,10 +552,10 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i8, align 1
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %cast_src = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %cast_src = load i64, ptr %local_1, align 8
   %castcond = icmp ugt i64 %cast_src, 255
   br i1 %castcond, label %then_bb, label %join_bb
 
@@ -578,8 +580,8 @@ entry:
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
   %zext_dst = zext i8 %cast_src to i128
-  store i128 %zext_dst, ptr %local_2, align 4
-  %retval = load i128, ptr %local_2, align 4
+  store i128 %zext_dst, ptr %local_2, align 8
+  %retval = load i128, ptr %local_2, align 8
   ret i128 %retval
 }
 
@@ -608,8 +610,8 @@ entry:
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
   %zext_dst = zext i8 %cast_src to i256
-  store i256 %zext_dst, ptr %local_2, align 4
-  %retval = load i256, ptr %local_2, align 4
+  store i256 %zext_dst, ptr %local_2, align 8
+  %retval = load i256, ptr %local_2, align 8
   ret i256 %retval
 }
 
@@ -638,8 +640,8 @@ entry:
   store i8 %load_store_tmp, ptr %local_1, align 1
   %cast_src = load i8, ptr %local_1, align 1
   %zext_dst = zext i8 %cast_src to i64
-  store i64 %zext_dst, ptr %local_2, align 4
-  %retval = load i64, ptr %local_2, align 4
+  store i64 %zext_dst, ptr %local_2, align 8
+  %retval = load i64, ptr %local_2, align 8
   ret i64 %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -7,10 +9,10 @@ define private i128 @Test__takes_u128(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_1, align 4
-  %retval = load i128, ptr %local_1, align 4
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %retval = load i128, ptr %local_1, align 8
   ret i128 %retval
 }
 
@@ -24,22 +26,22 @@ entry:
   %local_5 = alloca i128, align 8
   %local_6 = alloca i128, align 8
   %local_7 = alloca i128, align 8
-  store i128 7, ptr %local_0, align 4
-  %call_arg_0 = load i128, ptr %local_0, align 4
+  store i128 7, ptr %local_0, align 8
+  %call_arg_0 = load i128, ptr %local_0, align 8
   %retval = call i128 @Test__takes_u128(i128 %call_arg_0)
-  store i128 %retval, ptr %local_1, align 4
-  store i128 4294967296, ptr %local_2, align 4
-  %call_arg_01 = load i128, ptr %local_2, align 4
+  store i128 %retval, ptr %local_1, align 8
+  store i128 4294967296, ptr %local_2, align 8
+  %call_arg_01 = load i128, ptr %local_2, align 8
   %retval2 = call i128 @Test__takes_u128(i128 %call_arg_01)
-  store i128 %retval2, ptr %local_3, align 4
-  store i128 18446744073709551616, ptr %local_4, align 4
-  %call_arg_03 = load i128, ptr %local_4, align 4
+  store i128 %retval2, ptr %local_3, align 8
+  store i128 18446744073709551616, ptr %local_4, align 8
+  %call_arg_03 = load i128, ptr %local_4, align 8
   %retval4 = call i128 @Test__takes_u128(i128 %call_arg_03)
-  store i128 %retval4, ptr %local_5, align 4
-  store i128 -170141183460469231731687303715884105728, ptr %local_6, align 4
-  %call_arg_05 = load i128, ptr %local_6, align 4
+  store i128 %retval4, ptr %local_5, align 8
+  store i128 -170141183460469231731687303715884105728, ptr %local_6, align 8
+  %call_arg_05 = load i128, ptr %local_6, align 8
   %retval6 = call i128 @Test__takes_u128(i128 %call_arg_05)
-  store i128 %retval6, ptr %local_7, align 4
-  %retval7 = load i128, ptr %local_7, align 4
+  store i128 %retval6, ptr %local_7, align 8
+  %retval7 = load i128, ptr %local_7, align 8
   ret i128 %retval7
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/modules/0_debug.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x10__debug'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/debug-print-build/scripts/main.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %__move_rt_type = type { { ptr, i64 }, i64, ptr }
 
@@ -14,9 +16,9 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca ptr, align 8
-  store i64 10, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp, ptr %local_0, align 4
+  store i64 10, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp, ptr %local_0, align 8
   store ptr %local_0, ptr %local_2, align 8
   %loaded_alloca = load ptr, ptr %local_2, align 8
   call void @move_native_debug_print(ptr @__move_rttydesc_u64, ptr %loaded_alloca)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/empty-module-build/modules/0_Empty.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/empty-module-build/modules/0_Empty.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x100__Empty'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__M2'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.M2__Coin_M2__Currency1_ = type { i64, i8 }
 
@@ -10,12 +12,12 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8
   %local_2 = alloca %struct.M2__Coin_M2__Currency1_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1__value, align 4
-  %fv.0 = load i64, ptr %local_1__value, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1__value, align 8
+  %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Currency1_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Currency1_ %insert_0, ptr %local_2, align 4
-  %retval = load %struct.M2__Coin_M2__Currency1_, ptr %local_2, align 4
+  store %struct.M2__Coin_M2__Currency1_ %insert_0, ptr %local_2, align 8
+  %retval = load %struct.M2__Coin_M2__Currency1_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Currency1_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__M6'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.M6__Foo_bool_ = type { i1, i8 }
 %struct.M6__Bar_u8.u64_ = type { i8, i64, i8 }
@@ -35,19 +37,19 @@ entry:
   %local_3__x = alloca i8, align 1
   %local_4__y = alloca i64, align 8
   store i8 123, ptr %local_0__x, align 1
-  store i64 456, ptr %local_1__y, align 4
+  store i64 456, ptr %local_1__y, align 8
   %fv.0 = load i8, ptr %local_0__x, align 1
-  %fv.1 = load i64, ptr %local_1__y, align 4
+  %fv.1 = load i64, ptr %local_1__y, align 8
   %insert_0 = insertvalue %struct.M6__Bar_u8.u64_ undef, i8 %fv.0, 0
   %insert_1 = insertvalue %struct.M6__Bar_u8.u64_ %insert_0, i64 %fv.1, 1
-  store %struct.M6__Bar_u8.u64_ %insert_1, ptr %local_2, align 4
-  %srcval = load %struct.M6__Bar_u8.u64_, ptr %local_2, align 4
+  store %struct.M6__Bar_u8.u64_ %insert_1, ptr %local_2, align 8
+  %srcval = load %struct.M6__Bar_u8.u64_, ptr %local_2, align 8
   %ext_0 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 0
   %ext_1 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 1
   store i8 %ext_0, ptr %local_3__x, align 1
-  store i64 %ext_1, ptr %local_4__y, align 4
+  store i64 %ext_1, ptr %local_4__y, align 8
   %rv.0 = load i8, ptr %local_3__x, align 1
-  %rv.1 = load i64, ptr %local_4__y, align 4
+  %rv.1 = load i64, ptr %local_4__y, align 8
   %insert_01 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
   %insert_12 = insertvalue { i8, i64 } %insert_01, i64 %rv.1, 1
   ret { i8, i64 } %insert_12
@@ -97,31 +99,31 @@ entry:
   %local_8__x = alloca ptr, align 8
   %local_9 = alloca i64, align 8
   store i8 123, ptr %local_1__x, align 1
-  store i64 1992, ptr %local_2__x, align 4
-  %fv.0 = load i64, ptr %local_2__x, align 4
+  store i64 1992, ptr %local_2__x, align 8
+  %fv.0 = load i64, ptr %local_2__x, align 8
   %insert_0 = insertvalue %struct.M6__Foo_u64_ undef, i64 %fv.0, 0
-  store %struct.M6__Foo_u64_ %insert_0, ptr %local_3__y, align 4
+  store %struct.M6__Foo_u64_ %insert_0, ptr %local_3__y, align 8
   %fv.01 = load i8, ptr %local_1__x, align 1
-  %fv.1 = load %struct.M6__Foo_u64_, ptr %local_3__y, align 4
+  %fv.1 = load %struct.M6__Foo_u64_, ptr %local_3__y, align 8
   %insert_02 = insertvalue %struct.M6__Baz_u8.u64_ undef, i8 %fv.01, 0
   %insert_1 = insertvalue %struct.M6__Baz_u8.u64_ %insert_02, %struct.M6__Foo_u64_ %fv.1, 1
-  store %struct.M6__Baz_u8.u64_ %insert_1, ptr %local_4, align 4
-  %srcval = load %struct.M6__Baz_u8.u64_, ptr %local_4, align 4
+  store %struct.M6__Baz_u8.u64_ %insert_1, ptr %local_4, align 8
+  %srcval = load %struct.M6__Baz_u8.u64_, ptr %local_4, align 8
   %ext_0 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 0
   %ext_1 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 1
   store i8 %ext_0, ptr %local_5__x, align 1
-  store %struct.M6__Foo_u64_ %ext_1, ptr %local_6__y, align 4
-  %load_store_tmp = load %struct.M6__Foo_u64_, ptr %local_6__y, align 4
-  store %struct.M6__Foo_u64_ %load_store_tmp, ptr %local_0, align 4
+  store %struct.M6__Foo_u64_ %ext_1, ptr %local_6__y, align 8
+  %load_store_tmp = load %struct.M6__Foo_u64_, ptr %local_6__y, align 8
+  store %struct.M6__Foo_u64_ %load_store_tmp, ptr %local_0, align 8
   store ptr %local_0, ptr %local_7, align 8
   %tmp = load ptr, ptr %local_7, align 8
   %fld_ref = getelementptr inbounds %struct.M6__Foo_u64_, ptr %tmp, i32 0, i32 0
   store ptr %fld_ref, ptr %local_8__x, align 8
   %load_deref_store_tmp1 = load ptr, ptr %local_8__x, align 8
-  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
-  store i64 %load_deref_store_tmp2, ptr %local_9, align 4
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 8
+  store i64 %load_deref_store_tmp2, ptr %local_9, align 8
   %rv.0 = load i8, ptr %local_5__x, align 1
-  %rv.1 = load i64, ptr %local_9, align 4
+  %rv.1 = load i64, ptr %local_9, align 8
   %insert_03 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
   %insert_14 = insertvalue { i8, i64 } %insert_03, i64 %rv.1, 1
   ret { i8, i64 } %insert_14

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__M2'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.M2__Coin_M2__Bitcoin_ = type { i64, i8 }
 %struct.M2__Coin_M2__Sol_ = type { i64, i8 }
@@ -10,11 +12,11 @@ define private %struct.M2__Coin_M2__Bitcoin_ @M2__call_mint_generic() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
-  store i64 4, ptr %local_0, align 4
-  %call_arg_0 = load i64, ptr %local_0, align 4
+  store i64 4, ptr %local_0, align 8
+  %call_arg_0 = load i64, ptr %local_0, align 8
   %retval = call %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %call_arg_0)
-  store %struct.M2__Coin_M2__Bitcoin_ %retval, ptr %local_1, align 4
-  %retval1 = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_1, align 4
+  store %struct.M2__Coin_M2__Bitcoin_ %retval, ptr %local_1, align 8
+  %retval1 = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_1, align 8
   ret %struct.M2__Coin_M2__Bitcoin_ %retval1
 }
 
@@ -23,13 +25,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8
   %local_2 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1__value, align 4
-  %fv.0 = load i64, ptr %local_1__value, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1__value, align 8
+  %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Bitcoin_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 4
-  %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 4
+  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 8
+  %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Bitcoin_ %retval
 }
 
@@ -38,12 +40,12 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8
   %local_2 = alloca %struct.M2__Coin_M2__Sol_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1__value, align 4
-  %fv.0 = load i64, ptr %local_1__value, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1__value, align 8
+  %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Sol_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Sol_ %insert_0, ptr %local_2, align 4
-  %retval = load %struct.M2__Coin_M2__Sol_, ptr %local_2, align 4
+  store %struct.M2__Coin_M2__Sol_ %insert_0, ptr %local_2, align 8
+  %retval = load %struct.M2__Coin_M2__Sol_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Sol_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/0_Coins.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/0_Coins.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x100__Coins'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x200__M11'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.Coins__Coin_M11__USDC_ = type { i64, i8 }
 %struct.Coins__Coin_M11__Eth_ = type { i64, i8 }
@@ -11,11 +13,11 @@ entry:
   %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_2 = alloca i64, align 8
-  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
-  %call_arg_0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
+  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 8
+  %call_arg_0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 8
   %retval = call i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %call_arg_0)
-  store i64 %retval, ptr %local_2, align 4
-  %retval1 = load i64, ptr %local_2, align 4
+  store i64 %retval, ptr %local_2, align 8
+  %retval1 = load i64, ptr %local_2, align 8
   ret i64 %retval1
 }
 
@@ -24,11 +26,11 @@ entry:
   %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_2__value = alloca i64, align 8
-  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 4
-  %srcval = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 4
+  store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 8
+  %srcval = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 8
   %ext_0 = extractvalue %struct.Coins__Coin_M11__USDC_ %srcval, 0
-  store i64 %ext_0, ptr %local_2__value, align 4
-  %retval = load i64, ptr %local_2__value, align 4
+  store i64 %ext_0, ptr %local_2__value, align 8
+  %retval = load i64, ptr %local_2__value, align 8
   ret i64 %retval
 }
 
@@ -40,21 +42,21 @@ entry:
   %local_3 = alloca i64, align 8
   %local_4 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_5 = alloca %struct.Coins__Coin_M11__Eth_, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  %call_arg_0 = load i64, ptr %local_2, align 4
-  %call_arg_1 = load i64, ptr %local_3, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  %call_arg_0 = load i64, ptr %local_2, align 8
+  %call_arg_1 = load i64, ptr %local_3, align 8
   %retval = call { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %call_arg_0, i64 %call_arg_1)
   %extract_0 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 0
   %extract_1 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 1
-  store %struct.Coins__Coin_M11__USDC_ %extract_0, ptr %local_4, align 4
-  store %struct.Coins__Coin_M11__Eth_ %extract_1, ptr %local_5, align 4
-  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_4, align 4
-  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 4
+  store %struct.Coins__Coin_M11__USDC_ %extract_0, ptr %local_4, align 8
+  store %struct.Coins__Coin_M11__Eth_ %extract_1, ptr %local_5, align 8
+  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_4, align 8
+  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 8
   %insert_0 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
   %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_0, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
@@ -68,20 +70,20 @@ entry:
   %local_3 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_4__value = alloca i64, align 8
   %local_5 = alloca %struct.Coins__Coin_M11__Eth_, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2__value, align 4
-  %fv.0 = load i64, ptr %local_2__value, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2__value, align 8
+  %fv.0 = load i64, ptr %local_2__value, align 8
   %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
-  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_3, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_4__value, align 4
-  %fv.02 = load i64, ptr %local_4__value, align 4
+  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_3, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_4__value, align 8
+  %fv.02 = load i64, ptr %local_4__value, align 8
   %insert_03 = insertvalue %struct.Coins__Coin_M11__Eth_ undef, i64 %fv.02, 0
-  store %struct.Coins__Coin_M11__Eth_ %insert_03, ptr %local_5, align 4
-  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_3, align 4
-  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 4
+  store %struct.Coins__Coin_M11__Eth_ %insert_03, ptr %local_5, align 8
+  %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_3, align 8
+  %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 8
   %insert_04 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
   %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_04, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
@@ -92,13 +94,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1, align 4
-  %call_arg_0 = load i64, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %call_arg_0 = load i64, ptr %local_1, align 8
   %retval = call %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %call_arg_0)
-  store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 4
-  %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
+  store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 8
+  %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 8
   ret %struct.Coins__Coin_M11__USDC_ %retval1
 }
 
@@ -107,12 +109,12 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8
   %local_2 = alloca %struct.Coins__Coin_M11__USDC_, align 8
-  store i64 %0, ptr %local_0, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_1__value, align 4
-  %fv.0 = load i64, ptr %local_1__value, align 4
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1__value, align 8
+  %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
-  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_2, align 4
-  %retval = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 4
+  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_2, align 8
+  %retval = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 8
   ret %struct.Coins__Coin_M11__USDC_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -10,14 +12,14 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i128, align 8
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  store i128 %1, ptr %local_1, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i128, ptr %local_1, align 4
-  store i128 %load_store_tmp1, ptr %local_3, align 4
-  %add_src_0 = load i128, ptr %local_2, align 4
-  %add_src_1 = load i128, ptr %local_3, align 4
+  store i128 %0, ptr %local_0, align 8
+  store i128 %1, ptr %local_1, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp1, ptr %local_3, align 8
+  %add_src_0 = load i128, ptr %local_2, align 8
+  %add_src_1 = load i128, ptr %local_3, align 8
   %add_dst = add i128 %add_src_0, %add_src_1
   %ovfcond = icmp ult i128 %add_dst, %add_src_0
   br i1 %ovfcond, label %then_bb, label %join_bb
@@ -27,8 +29,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i128 %add_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %add_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -39,14 +41,14 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i128, align 8
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  store i128 %1, ptr %local_1, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i128, ptr %local_1, align 4
-  store i128 %load_store_tmp1, ptr %local_3, align 4
-  %div_src_0 = load i128, ptr %local_2, align 4
-  %div_src_1 = load i128, ptr %local_3, align 4
+  store i128 %0, ptr %local_0, align 8
+  store i128 %1, ptr %local_1, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp1, ptr %local_3, align 8
+  %div_src_0 = load i128, ptr %local_2, align 8
+  %div_src_1 = load i128, ptr %local_3, align 8
   %zerocond = icmp eq i128 %div_src_1, 0
   br i1 %zerocond, label %then_bb, label %join_bb
 
@@ -56,8 +58,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %div_dst = udiv i128 %div_src_0, %div_src_1
-  store i128 %div_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %div_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -68,14 +70,14 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i128, align 8
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  store i128 %1, ptr %local_1, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i128, ptr %local_1, align 4
-  store i128 %load_store_tmp1, ptr %local_3, align 4
-  %mod_src_0 = load i128, ptr %local_2, align 4
-  %mod_src_1 = load i128, ptr %local_3, align 4
+  store i128 %0, ptr %local_0, align 8
+  store i128 %1, ptr %local_1, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp1, ptr %local_3, align 8
+  %mod_src_0 = load i128, ptr %local_2, align 8
+  %mod_src_1 = load i128, ptr %local_3, align 8
   %zerocond = icmp eq i128 %mod_src_1, 0
   br i1 %zerocond, label %then_bb, label %join_bb
 
@@ -85,8 +87,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %mod_dst = urem i128 %mod_src_0, %mod_src_1
-  store i128 %mod_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %mod_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -97,14 +99,14 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i128, align 8
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  store i128 %1, ptr %local_1, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i128, ptr %local_1, align 4
-  store i128 %load_store_tmp1, ptr %local_3, align 4
-  %mul_src_0 = load i128, ptr %local_2, align 4
-  %mul_src_1 = load i128, ptr %local_3, align 4
+  store i128 %0, ptr %local_0, align 8
+  store i128 %1, ptr %local_1, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp1, ptr %local_3, align 8
+  %mul_src_0 = load i128, ptr %local_2, align 8
+  %mul_src_1 = load i128, ptr %local_3, align 8
   %mul_val = call { i128, i1 } @llvm.umul.with.overflow.i128(i128 %mul_src_0, i128 %mul_src_1)
   %mul_dst = extractvalue { i128, i1 } %mul_val, 0
   %mul_ovf = extractvalue { i128, i1 } %mul_val, 1
@@ -115,8 +117,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i128 %mul_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %mul_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 
@@ -127,14 +129,14 @@ entry:
   %local_2 = alloca i128, align 8
   %local_3 = alloca i128, align 8
   %local_4 = alloca i128, align 8
-  store i128 %0, ptr %local_0, align 4
-  store i128 %1, ptr %local_1, align 4
-  %load_store_tmp = load i128, ptr %local_0, align 4
-  store i128 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i128, ptr %local_1, align 4
-  store i128 %load_store_tmp1, ptr %local_3, align 4
-  %sub_src_0 = load i128, ptr %local_2, align 4
-  %sub_src_1 = load i128, ptr %local_3, align 4
+  store i128 %0, ptr %local_0, align 8
+  store i128 %1, ptr %local_1, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp1, ptr %local_3, align 8
+  %sub_src_0 = load i128, ptr %local_2, align 8
+  %sub_src_1 = load i128, ptr %local_3, align 8
   %sub_dst = sub i128 %sub_src_0, %sub_src_1
   %ovfcond = icmp ugt i128 %sub_dst, %sub_src_0
   br i1 %ovfcond, label %then_bb, label %join_bb
@@ -144,8 +146,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i128 %sub_dst, ptr %local_4, align 4
-  %retval = load i128, ptr %local_4, align 4
+  store i128 %sub_dst, ptr %local_4, align 8
+  %retval = load i128, ptr %local_4, align 8
   ret i128 %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -10,14 +12,14 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  %add_src_0 = load i64, ptr %local_2, align 4
-  %add_src_1 = load i64, ptr %local_3, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  %add_src_0 = load i64, ptr %local_2, align 8
+  %add_src_1 = load i64, ptr %local_3, align 8
   %add_dst = add i64 %add_src_0, %add_src_1
   %ovfcond = icmp ult i64 %add_dst, %add_src_0
   br i1 %ovfcond, label %then_bb, label %join_bb
@@ -27,8 +29,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i64 %add_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %add_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 
@@ -39,14 +41,14 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  %div_src_0 = load i64, ptr %local_2, align 4
-  %div_src_1 = load i64, ptr %local_3, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  %div_src_0 = load i64, ptr %local_2, align 8
+  %div_src_1 = load i64, ptr %local_3, align 8
   %zerocond = icmp eq i64 %div_src_1, 0
   br i1 %zerocond, label %then_bb, label %join_bb
 
@@ -56,8 +58,8 @@ then_bb:                                          ; preds = %entry
 
 join_bb:                                          ; preds = %entry
   %div_dst = udiv i64 %div_src_0, %div_src_1
-  store i64 %div_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %div_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 
@@ -68,14 +70,14 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  %mul_src_0 = load i64, ptr %local_2, align 4
-  %mul_src_1 = load i64, ptr %local_3, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  %mul_src_0 = load i64, ptr %local_2, align 8
+  %mul_src_1 = load i64, ptr %local_3, align 8
   %mul_val = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %mul_src_0, i64 %mul_src_1)
   %mul_dst = extractvalue { i64, i1 } %mul_val, 0
   %mul_ovf = extractvalue { i64, i1 } %mul_val, 1
@@ -86,8 +88,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i64 %mul_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %mul_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 
@@ -98,14 +100,14 @@ entry:
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
-  %load_store_tmp = load i64, ptr %local_0, align 4
-  store i64 %load_store_tmp, ptr %local_2, align 4
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3, align 4
-  %sub_src_0 = load i64, ptr %local_2, align 4
-  %sub_src_1 = load i64, ptr %local_3, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  %sub_src_0 = load i64, ptr %local_2, align 8
+  %sub_src_1 = load i64, ptr %local_3, align 8
   %sub_dst = sub i64 %sub_src_0, %sub_src_1
   %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
   br i1 %ovfcond, label %then_bb, label %join_bb
@@ -115,8 +117,8 @@ then_bb:                                          ; preds = %entry
   unreachable
 
 join_bb:                                          ; preds = %entry
-  store i64 %sub_dst, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  store i64 %sub_dst, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x101__Test2'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test1'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
@@ -27,11 +29,11 @@ entry:
   %load_store_tmp = load ptr, ptr %local_0, align 8
   store ptr %load_store_tmp, ptr %local_1, align 8
   store i8 8, ptr %local_2, align 1
-  store i128 128, ptr %local_3, align 4
+  store i128 128, ptr %local_3, align 8
   store i32 32, ptr %local_4, align 4
   %rv.0 = load ptr, ptr %local_1, align 8
   %rv.1 = load i8, ptr %local_2, align 1
-  %rv.2 = load i128, ptr %local_3, align 4
+  %rv.2 = load i128, ptr %local_3, align 8
   %rv.3 = load i32, ptr %local_4, align 4
   %insert_0 = insertvalue { ptr, i8, i128, i32 } undef, ptr %rv.0, 0
   %insert_1 = insertvalue { ptr, i8, i128, i32 } %insert_0, i8 %rv.1, 1
@@ -73,9 +75,9 @@ entry:
   %local_11 = alloca i8, align 1
   %local_12 = alloca i128, align 8
   %local_13 = alloca i32, align 4
-  store i64 0, ptr %local_4, align 4
-  %load_store_tmp = load i64, ptr %local_4, align 4
-  store i64 %load_store_tmp, ptr %local_0, align 4
+  store i64 0, ptr %local_4, align 8
+  %load_store_tmp = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp, ptr %local_0, align 8
   store ptr %local_0, ptr %local_5, align 8
   %call_arg_0 = load ptr, ptr %local_5, align 8
   %retval = call { ptr, i8, i128, i32 } @Test__ret_4vals(ptr %call_arg_0)
@@ -85,21 +87,21 @@ entry:
   %extract_3 = extractvalue { ptr, i8, i128, i32 } %retval, 3
   store ptr %extract_0, ptr %local_6, align 8
   store i8 %extract_1, ptr %local_7, align 1
-  store i128 %extract_2, ptr %local_8, align 4
+  store i128 %extract_2, ptr %local_8, align 8
   store i32 %extract_3, ptr %local_9, align 4
   %load_store_tmp1 = load i32, ptr %local_9, align 4
   store i32 %load_store_tmp1, ptr %local_3, align 4
-  %load_store_tmp2 = load i128, ptr %local_8, align 4
-  store i128 %load_store_tmp2, ptr %local_2, align 4
+  %load_store_tmp2 = load i128, ptr %local_8, align 8
+  store i128 %load_store_tmp2, ptr %local_2, align 8
   %load_store_tmp3 = load i8, ptr %local_7, align 1
   store i8 %load_store_tmp3, ptr %local_1, align 1
   %load_deref_store_tmp1 = load ptr, ptr %local_6, align 8
-  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
-  store i64 %load_deref_store_tmp2, ptr %local_10, align 4
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 8
+  store i64 %load_deref_store_tmp2, ptr %local_10, align 8
   %load_store_tmp4 = load i8, ptr %local_1, align 1
   store i8 %load_store_tmp4, ptr %local_11, align 1
-  %load_store_tmp5 = load i128, ptr %local_2, align 4
-  store i128 %load_store_tmp5, ptr %local_12, align 4
+  %load_store_tmp5 = load i128, ptr %local_2, align 8
+  store i128 %load_store_tmp5, ptr %local_12, align 8
   %load_store_tmp6 = load i32, ptr %local_3, align 4
   store i32 %load_store_tmp6, ptr %local_13, align 4
   ret void

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/num-build/modules/0_M.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x42__M'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/range-build/modules/0_M.expected.ll
@@ -1,4 +1,6 @@
 ; ModuleID = '0x42__M'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Test'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/script-build/scripts/main.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '<SELF>'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__M'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.M__MyStruct = type { i32, i1, %struct.M__EmptyStruct, i8 }
 %struct.M__EmptyStruct = type { i1, i8 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x100__Country'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
 %struct.Country__Dunno = type { i64, i8 }
@@ -13,14 +15,14 @@ entry:
   %local_2__id = alloca i8, align 1
   %local_3__population = alloca i64, align 8
   %local_4__phony = alloca %struct.Country__Dunno, align 8
-  store %struct.Country__Country %0, ptr %local_0, align 4
-  %srcval = load %struct.Country__Country, ptr %local_0, align 4
+  store %struct.Country__Country %0, ptr %local_0, align 8
+  %srcval = load %struct.Country__Country, ptr %local_0, align 8
   %ext_0 = extractvalue %struct.Country__Country %srcval, 0
   %ext_1 = extractvalue %struct.Country__Country %srcval, 1
   %ext_2 = extractvalue %struct.Country__Country %srcval, 2
   store i8 %ext_0, ptr %local_2__id, align 1
-  store i64 %ext_1, ptr %local_3__population, align 4
-  store %struct.Country__Dunno %ext_2, ptr %local_4__phony, align 4
+  store i64 %ext_1, ptr %local_3__population, align 8
+  store %struct.Country__Dunno %ext_2, ptr %local_4__phony, align 8
   %retval = load i8, ptr %local_2__id, align 1
   ret i8 %retval
 }
@@ -51,7 +53,7 @@ entry:
   %local_2__phony = alloca ptr, align 8
   %local_3__x = alloca ptr, align 8
   %local_4 = alloca i64, align 8
-  store %struct.Country__Country %0, ptr %local_0, align 4
+  store %struct.Country__Country %0, ptr %local_0, align 8
   store ptr %local_0, ptr %local_1, align 8
   %tmp = load ptr, ptr %local_1, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 2
@@ -60,9 +62,9 @@ entry:
   %fld_ref2 = getelementptr inbounds %struct.Country__Dunno, ptr %tmp1, i32 0, i32 0
   store ptr %fld_ref2, ptr %local_3__x, align 8
   %load_deref_store_tmp1 = load ptr, ptr %local_3__x, align 8
-  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
-  store i64 %load_deref_store_tmp2, ptr %local_4, align 4
-  %retval = load i64, ptr %local_4, align 4
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 8
+  store i64 %load_deref_store_tmp2, ptr %local_4, align 8
+  %retval = load i64, ptr %local_4, align 8
   ret i64 %retval
 }
 
@@ -72,15 +74,15 @@ entry:
   %local_1 = alloca ptr, align 8
   %local_2__population = alloca ptr, align 8
   %local_3 = alloca i64, align 8
-  store %struct.Country__Country %0, ptr %local_0, align 4
+  store %struct.Country__Country %0, ptr %local_0, align 8
   store ptr %local_0, ptr %local_1, align 8
   %tmp = load ptr, ptr %local_1, align 8
   %fld_ref = getelementptr inbounds %struct.Country__Country, ptr %tmp, i32 0, i32 1
   store ptr %fld_ref, ptr %local_2__population, align 8
   %load_deref_store_tmp1 = load ptr, ptr %local_2__population, align 8
-  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 4
-  store i64 %load_deref_store_tmp2, ptr %local_3, align 4
-  %retval = load i64, ptr %local_3, align 4
+  %load_deref_store_tmp2 = load i64, ptr %load_deref_store_tmp1, align 8
+  store i64 %load_deref_store_tmp2, ptr %local_3, align 8
+  %retval = load i64, ptr %local_3, align 8
   ret i64 %retval
 }
 
@@ -94,23 +96,23 @@ entry:
   %local_5__phony = alloca %struct.Country__Dunno, align 8
   %local_6 = alloca %struct.Country__Country, align 8
   store i8 %0, ptr %local_0, align 1
-  store i64 %1, ptr %local_1, align 4
+  store i64 %1, ptr %local_1, align 8
   %load_store_tmp = load i8, ptr %local_0, align 1
   store i8 %load_store_tmp, ptr %local_2__id, align 1
-  %load_store_tmp1 = load i64, ptr %local_1, align 4
-  store i64 %load_store_tmp1, ptr %local_3__population, align 4
-  store i64 32, ptr %local_4__x, align 4
-  %fv.0 = load i64, ptr %local_4__x, align 4
+  %load_store_tmp1 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp1, ptr %local_3__population, align 8
+  store i64 32, ptr %local_4__x, align 8
+  %fv.0 = load i64, ptr %local_4__x, align 8
   %insert_0 = insertvalue %struct.Country__Dunno undef, i64 %fv.0, 0
-  store %struct.Country__Dunno %insert_0, ptr %local_5__phony, align 4
+  store %struct.Country__Dunno %insert_0, ptr %local_5__phony, align 8
   %fv.02 = load i8, ptr %local_2__id, align 1
-  %fv.1 = load i64, ptr %local_3__population, align 4
-  %fv.2 = load %struct.Country__Dunno, ptr %local_5__phony, align 4
+  %fv.1 = load i64, ptr %local_3__population, align 8
+  %fv.2 = load %struct.Country__Dunno, ptr %local_5__phony, align 8
   %insert_03 = insertvalue %struct.Country__Country undef, i8 %fv.02, 0
   %insert_1 = insertvalue %struct.Country__Country %insert_03, i64 %fv.1, 1
   %insert_2 = insertvalue %struct.Country__Country %insert_1, %struct.Country__Dunno %fv.2, 2
-  store %struct.Country__Country %insert_2, ptr %local_6, align 4
-  %retval = load %struct.Country__Country, ptr %local_6, align 4
+  store %struct.Country__Country %insert_2, ptr %local_6, align 8
+  %retval = load %struct.Country__Country, ptr %local_6, align 8
   ret %struct.Country__Country %retval
 }
 

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -1,5 +1,7 @@
 ; ModuleID = '0x200__UseIt'
 source_filename = "<unknown>"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
 
 %struct.Country__Country = type { i8, i64, %struct.Country__Dunno, i8 }
 %struct.Country__Dunno = type { i64, i8 }
@@ -21,18 +23,18 @@ entry:
   %local_10 = alloca %struct.Country__Country, align 8
   %local_11 = alloca i8, align 1
   store i8 1, ptr %local_1, align 1
-  store i64 1000000, ptr %local_2, align 4
+  store i64 1000000, ptr %local_2, align 8
   %call_arg_0 = load i8, ptr %local_1, align 1
-  %call_arg_1 = load i64, ptr %local_2, align 4
+  %call_arg_1 = load i64, ptr %local_2, align 8
   %retval = call %struct.Country__Country @Country__new_country(i8 %call_arg_0, i64 %call_arg_1)
-  store %struct.Country__Country %retval, ptr %local_3, align 4
-  %load_store_tmp = load %struct.Country__Country, ptr %local_3, align 4
-  store %struct.Country__Country %load_store_tmp, ptr %local_0, align 4
-  %load_store_tmp1 = load %struct.Country__Country, ptr %local_0, align 4
-  store %struct.Country__Country %load_store_tmp1, ptr %local_4, align 4
-  %call_arg_02 = load %struct.Country__Country, ptr %local_4, align 4
+  store %struct.Country__Country %retval, ptr %local_3, align 8
+  %load_store_tmp = load %struct.Country__Country, ptr %local_3, align 8
+  store %struct.Country__Country %load_store_tmp, ptr %local_0, align 8
+  %load_store_tmp1 = load %struct.Country__Country, ptr %local_0, align 8
+  store %struct.Country__Country %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load %struct.Country__Country, ptr %local_4, align 8
   %retval3 = call i64 @Country__get_pop(%struct.Country__Country %call_arg_02)
-  store i64 %retval3, ptr %local_5, align 4
+  store i64 %retval3, ptr %local_5, align 8
   store ptr %local_0, ptr %local_6, align 8
   %call_arg_04 = load ptr, ptr %local_6, align 8
   %retval5 = call i8 @Country__get_id(ptr %call_arg_04)
@@ -42,7 +44,7 @@ entry:
   %call_arg_06 = load ptr, ptr %local_8, align 8
   %call_arg_17 = load i8, ptr %local_9, align 1
   call void @Country__set_id(ptr %call_arg_06, i8 %call_arg_17)
-  %call_arg_08 = load %struct.Country__Country, ptr %local_0, align 4
+  %call_arg_08 = load %struct.Country__Country, ptr %local_0, align 8
   %retval9 = call i8 @Country__dropit(%struct.Country__Country %call_arg_08)
   store i8 %retval9, ptr %local_11, align 1
   ret void


### PR DESCRIPTION
This patch fixes the two defects in:
https://github.com/solana-labs/move/issues/198.

To summarize: Previously the TargetMachine was created too late so that the incorrect DataLayout was in effect during translation (resulting in incorrect alignments, etc). The TargetMachine is now created before translation and the data layout is set upon module processing.

Secondly, the target triple and data layout specifiers previously were never set on the Module when outputting either textual or bitcode LLVM IR for the module.

This patch also fixes all the "unsafe leakage" from module llvm. This really is an orthogonal set of changes and should be a separate patch, however, the custom clippy insisted I do this now. Wrap up all LLVM references such as LLVMValueRef and so forth into structs, and reference only those within the translator.

Test results were remastered (eyeball checked for correctness). The changes are of two kinds (due to the fixes):
1. All LLVM IR expected result files now contain the expected "target datalayout" and "target triple" specifiers.
2. Various alignment specifiers on loads and stores increased (e.g., 4 to 8). This is as expected and the values were previously incorrectly under-aligned.