### PR TITLE
Apply some known parameter/function attributes to the native decls.

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -278,6 +278,8 @@ extern crate alloc;
 /// Types literally shared with the compiler through crate linkage.
 pub mod shared {
     pub use crate::rt_types::TypeDesc;
+    pub use crate::rt_types::MOVE_UNTYPED_VEC_DESC_SIZE;
+    pub use crate::rt_types::MOVE_TYPE_DESC_SIZE;
 }
 
 /// Types known to the compiler.
@@ -302,6 +304,7 @@ pub(crate) mod rt_types {
         pub capacity: u64, // in typed elements, not u8
         pub length: u64,   // in typed elements, not u8
     }
+    pub const MOVE_UNTYPED_VEC_DESC_SIZE: u64 = core::mem::size_of::<MoveUntypedVector>() as u64;
 
     /// A Move vector of bytes.
     ///
@@ -343,6 +346,7 @@ pub(crate) mod rt_types {
         pub type_desc: TypeDesc,
         pub type_info: *const TypeInfo,
     }
+    pub const MOVE_TYPE_DESC_SIZE: u64 = core::mem::size_of::<MoveType>() as u64;
 
     // Needed to make the MoveType, which contains raw pointers,
     // Sync, so that it can be stored in statics for test cases.

--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -26,8 +26,8 @@ use std::{
 };
 
 pub use llvm_sys::{
-    LLVMAttributeFunctionIndex, LLVMAttributeReturnIndex, LLVMIntPredicate, LLVMLinkage,
-    LLVMLinkage::LLVMInternalLinkage, LLVMTypeKind::LLVMIntegerTypeKind,
+    LLVMAttributeFunctionIndex, LLVMAttributeIndex, LLVMAttributeReturnIndex, LLVMIntPredicate,
+    LLVMLinkage, LLVMLinkage::LLVMInternalLinkage, LLVMTypeKind::LLVMIntegerTypeKind,
 };
 
 pub fn initialize_sbf() {

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -14,7 +14,7 @@ entry:
   unreachable
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -14,7 +14,7 @@ entry:
   unreachable
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -306,7 +306,7 @@ entry:
   ret i8 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -75,7 +75,7 @@ bb_2:                                             ; preds = %bb_1
   ret void
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -58,7 +58,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -659,7 +659,7 @@ entry:
   ret i8 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -151,11 +151,11 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
 ; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
 declare { i128, i1 } @llvm.umul.with.overflow.i128(i128, i128) #1
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }
 attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -122,11 +122,11 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
 ; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
 declare { i32, i1 } @llvm.umul.with.overflow.i32(i32, i32) #1
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }
 attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -122,11 +122,11 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
 ; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
 declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64) #1
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }
 attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -151,11 +151,11 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
 ; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
 declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8) #1
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }
 attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-; Function Attrs: noreturn
+; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-attributes #0 = { noreturn }
+attributes #0 = { cold noreturn }


### PR DESCRIPTION
This patch adds mainly `readonly`, `nonnull`, and `dereferenceable(n)` to the native declarations to potentially inform the LLVM optimizers.

These are applied to the various descriptor type pointers that are ubiquitous with the native functions.

Added move_native::shared::{MOVE_TYPE_DESC_SIZE, MOVE_UNTYPED_VEC_DESC_SIZE} to provide descriptor sizes to the translator.