### PR TITLE
Apply basic parameter attributes to ordinary Move function decls.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -48,7 +48,7 @@ entry:
   ret i1 %retval
 }
 
-define ptr @M3__ret_address_ref(ptr %0) {
+define ptr @M3__ret_address_ref(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -59,7 +59,7 @@ entry:
   ret ptr %retval
 }
 
-define [32 x i8] @M3__use_address_ref(ptr %0) {
+define [32 x i8] @M3__use_address_ref(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
@@ -18,7 +18,7 @@ entry:
   ret { i1, i1 } %insert_1
 }
 
-define private { ptr, i8, i128, i32 } @Test__ret_4vals(ptr %0) {
+define private { ptr, i8, i128, i32 } @Test__ret_4vals(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -27,7 +27,7 @@ entry:
   ret i8 %retval
 }
 
-define i8 @Country__get_id(ptr %0) {
+define i8 @Country__get_id(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -116,7 +116,7 @@ entry:
   ret %struct.Country__Country %retval
 }
 
-define void @Country__set_id(ptr %0, i8 %1) {
+define void @Country__set_id(ptr noalias nonnull %0, i8 %1) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -54,8 +54,8 @@ declare %struct.Country__Country @Country__new_country(i8, i64)
 
 declare i64 @Country__get_pop(%struct.Country__Country)
 
-declare i8 @Country__get_id(ptr)
+declare i8 @Country__get_id(ptr nonnull readonly)
 
-declare void @Country__set_id(ptr, i8)
+declare void @Country__set_id(ptr noalias nonnull, i8)
 
 declare i8 @Country__dropit(%struct.Country__Country)


### PR DESCRIPTION
This patch adds parameter attributes to Move functions, where we can infer directly from incoming parameters that:
- `&` and `&mut` will be `nonnull` pointers in the generated LLVM IR.
- '&' is `readonly` (shared, read only).
- '&mut' is `noalias` (exclusive, writeable).

Mutable references might also be `writeonly` (which we could infer from abilities), but we don't yet do this.

There are other attributes we may infer in the future with more analysis.