### PR TITLE
Implement comparisons of `signer`/`&signer` types.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/signer01.move
@@ -1,4 +1,4 @@
-// signers 0xcafe,0xf00d,0xc0ffee,0xb00
+// signers 0xcafe,0xf00d,0xc0ffee,0xb00,0xb00c,0xb00c,0x123
 
 // A phony `signer` module until we build `move-stdlib`.
 module 0x500::signer {
@@ -26,14 +26,38 @@ module 0x100::M5 {
         assert!(*signer::borrow_address(a) == @0xc0ffee, 0xf03);
         assert!(*signer::borrow_address(b) == @0xb00, 0xf04);
     }
+
+    public fun eq_signer_val(a: signer, b: signer): bool {
+        a == b
+    }
+
+    public fun ne_signer_val(a: signer, b: signer): bool {
+        a != b
+    }
+
+    public fun eq_signer_ref(a: &signer, b: &signer): bool {
+        a == b
+    }
+
+    public fun ne_signer_ref(a: &signer, b: &signer): bool {
+        a != b
+    }
 }
 
 script {
     use 0x100::M5;
 
-    fun main(s1: signer, s2: signer, s3: signer, s4: signer) {
+    fun main(s1: signer, s2: signer, s3: signer, s4: signer, s5: signer, s6: signer, s7: signer) {
+        // Test signer arguments and std::signer routines.
         M5::signer_by_val(s1);
         M5::signer_by_ref(&s2);
         M5::signers_by_ref(&s3, &s4);
+
+        // Test eq/ne comparisons of signers.
+        assert!(M5::eq_signer_val(s5, s6), 0xf10);
+        assert!(M5::ne_signer_val(s4, s7), 0xf11);
+
+        assert!(M5::ne_signer_ref(&s2, &s3), 0xf12);
+        assert!(!M5::eq_signer_ref(&s2, &s3), 0xf13);
     }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/stdlib-bcs.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/stdlib-bcs.move
@@ -77,12 +77,11 @@ module 0x10::tests {
     assert!(v == vv, 11);
   }
 
-  // fixme this asserts in the compiler
-  /*public fun test_signer(v: signer) {
+  public fun test_signer(v: signer) {
     let vs: vector<u8> = bcs::to_bytes(&v);
     let vv: signer = bcs::test_from_bytes(&vs);
     assert!(v == vv, 11);
-  }*/
+  }
 
   struct TestStruct has drop {
     a: u8,
@@ -214,7 +213,7 @@ script {
     tests::test_u256();
     tests::test_address();
     tests::test_struct();
-    //tests::test_signer(s); // fixme
+    tests::test_signer(s);
     tests::test_vec_bool();
     tests::test_vec_u8();
     tests::test_vec_u16();


### PR DESCRIPTION
These are handled like `address` as they are an address wrapped in a single-element struct.

Added additional comparison tests to signer01.move. 
Updated stdlib-bcs.move-- uncommented signer ser/des test which previously asserted due to above. The test now passes.