### PR TITLE
Implement `move-native` support for struct comparisons, more vec cmp.

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/llvm.rs
@@ -452,7 +452,7 @@ impl Builder {
         stype: StructType,
     ) {
         unsafe {
-            let loads = src
+            let mut loads = src
                 .iter()
                 .enumerate()
                 .map(|(i, (ty, val))| {
@@ -460,6 +460,14 @@ impl Builder {
                     LLVMBuildLoad2(self.0, ty.0, val.0, name.cstr())
                 })
                 .collect::<Vec<_>>();
+
+            // The LLVM struct currently has one additional compiler-generated field. We will
+            // write a zero initializer for now.
+            let user_field_count = src.len();
+            let ll_field_count = LLVMCountStructElementTypes(stype.0) as usize;
+            assert_eq!(user_field_count + 1, ll_field_count);
+            let cgty = LLVMStructGetTypeAtIndex(stype.0, (ll_field_count - 1) as libc::c_uint);
+            loads.push(Constant::int(Type(cgty), u256::U256::zero()).0);
 
             let mut agg_val = LLVMGetUndef(stype.0);
             for (i, ld) in loads.iter().enumerate() {

--- a/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
+++ b/language/tools/move-mv-llvm-compiler/src/stackless/rttydesc.rs
@@ -185,6 +185,7 @@ fn define_type_info_global(
                     | Type::Primitive(PrimitiveType::U128)
                     | Type::Primitive(PrimitiveType::U256)
                     | Type::Primitive(PrimitiveType::Address)
+                    | Type::Primitive(PrimitiveType::Signer)
                     | Type::Vector(_)
                     | Type::Struct(_, _, _) => define_type_info_global_vec(
                         module_cx,

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
@@ -17,7 +17,8 @@ entry:
   store i64 %load_store_tmp, ptr %local_1__value, align 8
   %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Currency1_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Currency1_ %insert_0, ptr %local_2, align 8
+  %insert_1 = insertvalue %struct.M2__Coin_M2__Currency1_ %insert_0, i8 0, 1
+  store %struct.M2__Coin_M2__Currency1_ %insert_1, ptr %local_2, align 8
   %retval = load %struct.M2__Coin_M2__Currency1_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Currency1_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
@@ -21,7 +21,8 @@ entry:
   store i1 true, ptr %local_0__x, align 1
   %fv.0 = load i1, ptr %local_0__x, align 1
   %insert_0 = insertvalue %struct.M6__Foo_bool_ undef, i1 %fv.0, 0
-  store %struct.M6__Foo_bool_ %insert_0, ptr %local_1, align 1
+  %insert_1 = insertvalue %struct.M6__Foo_bool_ %insert_0, i8 0, 1
+  store %struct.M6__Foo_bool_ %insert_1, ptr %local_1, align 1
   %srcval = load %struct.M6__Foo_bool_, ptr %local_1, align 1
   %ext_0 = extractvalue %struct.M6__Foo_bool_ %srcval, 0
   store i1 %ext_0, ptr %local_2__x, align 1
@@ -42,7 +43,8 @@ entry:
   %fv.1 = load i64, ptr %local_1__y, align 8
   %insert_0 = insertvalue %struct.M6__Bar_u8.u64_ undef, i8 %fv.0, 0
   %insert_1 = insertvalue %struct.M6__Bar_u8.u64_ %insert_0, i64 %fv.1, 1
-  store %struct.M6__Bar_u8.u64_ %insert_1, ptr %local_2, align 8
+  %insert_2 = insertvalue %struct.M6__Bar_u8.u64_ %insert_1, i8 0, 2
+  store %struct.M6__Bar_u8.u64_ %insert_2, ptr %local_2, align 8
   %srcval = load %struct.M6__Bar_u8.u64_, ptr %local_2, align 8
   %ext_0 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 0
   %ext_1 = extractvalue %struct.M6__Bar_u8.u64_ %srcval, 1
@@ -102,12 +104,14 @@ entry:
   store i64 1992, ptr %local_2__x, align 8
   %fv.0 = load i64, ptr %local_2__x, align 8
   %insert_0 = insertvalue %struct.M6__Foo_u64_ undef, i64 %fv.0, 0
-  store %struct.M6__Foo_u64_ %insert_0, ptr %local_3__y, align 8
+  %insert_1 = insertvalue %struct.M6__Foo_u64_ %insert_0, i8 0, 1
+  store %struct.M6__Foo_u64_ %insert_1, ptr %local_3__y, align 8
   %fv.01 = load i8, ptr %local_1__x, align 1
   %fv.1 = load %struct.M6__Foo_u64_, ptr %local_3__y, align 8
   %insert_02 = insertvalue %struct.M6__Baz_u8.u64_ undef, i8 %fv.01, 0
-  %insert_1 = insertvalue %struct.M6__Baz_u8.u64_ %insert_02, %struct.M6__Foo_u64_ %fv.1, 1
-  store %struct.M6__Baz_u8.u64_ %insert_1, ptr %local_4, align 8
+  %insert_13 = insertvalue %struct.M6__Baz_u8.u64_ %insert_02, %struct.M6__Foo_u64_ %fv.1, 1
+  %insert_2 = insertvalue %struct.M6__Baz_u8.u64_ %insert_13, i8 0, 2
+  store %struct.M6__Baz_u8.u64_ %insert_2, ptr %local_4, align 8
   %srcval = load %struct.M6__Baz_u8.u64_, ptr %local_4, align 8
   %ext_0 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 0
   %ext_1 = extractvalue %struct.M6__Baz_u8.u64_ %srcval, 1
@@ -124,7 +128,7 @@ entry:
   store i64 %load_deref_store_tmp2, ptr %local_9, align 8
   %rv.0 = load i8, ptr %local_5__x, align 1
   %rv.1 = load i64, ptr %local_9, align 8
-  %insert_03 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
-  %insert_14 = insertvalue { i8, i64 } %insert_03, i64 %rv.1, 1
-  ret { i8, i64 } %insert_14
+  %insert_04 = insertvalue { i8, i64 } undef, i8 %rv.0, 0
+  %insert_15 = insertvalue { i8, i64 } %insert_04, i64 %rv.1, 1
+  ret { i8, i64 } %insert_15
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
@@ -30,7 +30,8 @@ entry:
   store i64 %load_store_tmp, ptr %local_1__value, align 8
   %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Bitcoin_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Bitcoin_ %insert_0, ptr %local_2, align 8
+  %insert_1 = insertvalue %struct.M2__Coin_M2__Bitcoin_ %insert_0, i8 0, 1
+  store %struct.M2__Coin_M2__Bitcoin_ %insert_1, ptr %local_2, align 8
   %retval = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Bitcoin_ %retval
 }
@@ -45,7 +46,8 @@ entry:
   store i64 %load_store_tmp, ptr %local_1__value, align 8
   %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.M2__Coin_M2__Sol_ undef, i64 %fv.0, 0
-  store %struct.M2__Coin_M2__Sol_ %insert_0, ptr %local_2, align 8
+  %insert_1 = insertvalue %struct.M2__Coin_M2__Sol_ %insert_0, i8 0, 1
+  store %struct.M2__Coin_M2__Sol_ %insert_1, ptr %local_2, align 8
   %retval = load %struct.M2__Coin_M2__Sol_, ptr %local_2, align 8
   ret %struct.M2__Coin_M2__Sol_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
@@ -76,17 +76,19 @@ entry:
   store i64 %load_store_tmp, ptr %local_2__value, align 8
   %fv.0 = load i64, ptr %local_2__value, align 8
   %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
-  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_3, align 8
+  %insert_1 = insertvalue %struct.Coins__Coin_M11__USDC_ %insert_0, i8 0, 1
+  store %struct.Coins__Coin_M11__USDC_ %insert_1, ptr %local_3, align 8
   %load_store_tmp1 = load i64, ptr %local_1, align 8
   store i64 %load_store_tmp1, ptr %local_4__value, align 8
   %fv.02 = load i64, ptr %local_4__value, align 8
   %insert_03 = insertvalue %struct.Coins__Coin_M11__Eth_ undef, i64 %fv.02, 0
-  store %struct.Coins__Coin_M11__Eth_ %insert_03, ptr %local_5, align 8
+  %insert_14 = insertvalue %struct.Coins__Coin_M11__Eth_ %insert_03, i8 0, 1
+  store %struct.Coins__Coin_M11__Eth_ %insert_14, ptr %local_5, align 8
   %rv.0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_3, align 8
   %rv.1 = load %struct.Coins__Coin_M11__Eth_, ptr %local_5, align 8
-  %insert_04 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
-  %insert_1 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_04, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
-  ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
+  %insert_05 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } undef, %struct.Coins__Coin_M11__USDC_ %rv.0, 0
+  %insert_16 = insertvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_05, %struct.Coins__Coin_M11__Eth_ %rv.1, 1
+  ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_16
 }
 
 define private %struct.Coins__Coin_M11__USDC_ @M11__mint_usdc(i64 %0) {
@@ -114,7 +116,8 @@ entry:
   store i64 %load_store_tmp, ptr %local_1__value, align 8
   %fv.0 = load i64, ptr %local_1__value, align 8
   %insert_0 = insertvalue %struct.Coins__Coin_M11__USDC_ undef, i64 %fv.0, 0
-  store %struct.Coins__Coin_M11__USDC_ %insert_0, ptr %local_2, align 8
+  %insert_1 = insertvalue %struct.Coins__Coin_M11__USDC_ %insert_0, i8 0, 1
+  store %struct.Coins__Coin_M11__USDC_ %insert_1, ptr %local_2, align 8
   %retval = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 8
   ret %struct.Coins__Coin_M11__USDC_ %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -20,14 +20,16 @@ entry:
   store i1 false, ptr %local_2__dummy_field, align 1
   %fv.0 = load i1, ptr %local_2__dummy_field, align 1
   %insert_0 = insertvalue %struct.M__EmptyStruct undef, i1 %fv.0, 0
-  store %struct.M__EmptyStruct %insert_0, ptr %local_3__field3, align 1
+  %insert_1 = insertvalue %struct.M__EmptyStruct %insert_0, i8 0, 1
+  store %struct.M__EmptyStruct %insert_1, ptr %local_3__field3, align 1
   %fv.01 = load i32, ptr %local_0__field1, align 4
   %fv.1 = load i1, ptr %local_1__field2, align 1
   %fv.2 = load %struct.M__EmptyStruct, ptr %local_3__field3, align 1
   %insert_02 = insertvalue %struct.M__MyStruct undef, i32 %fv.01, 0
-  %insert_1 = insertvalue %struct.M__MyStruct %insert_02, i1 %fv.1, 1
-  %insert_2 = insertvalue %struct.M__MyStruct %insert_1, %struct.M__EmptyStruct %fv.2, 2
-  store %struct.M__MyStruct %insert_2, ptr %local_4, align 4
+  %insert_13 = insertvalue %struct.M__MyStruct %insert_02, i1 %fv.1, 1
+  %insert_2 = insertvalue %struct.M__MyStruct %insert_13, %struct.M__EmptyStruct %fv.2, 2
+  %insert_3 = insertvalue %struct.M__MyStruct %insert_2, i8 0, 3
+  store %struct.M__MyStruct %insert_3, ptr %local_4, align 4
   %retval = load %struct.M__MyStruct, ptr %local_4, align 4
   ret %struct.M__MyStruct %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -104,14 +104,16 @@ entry:
   store i64 32, ptr %local_4__x, align 8
   %fv.0 = load i64, ptr %local_4__x, align 8
   %insert_0 = insertvalue %struct.Country__Dunno undef, i64 %fv.0, 0
-  store %struct.Country__Dunno %insert_0, ptr %local_5__phony, align 8
+  %insert_1 = insertvalue %struct.Country__Dunno %insert_0, i8 0, 1
+  store %struct.Country__Dunno %insert_1, ptr %local_5__phony, align 8
   %fv.02 = load i8, ptr %local_2__id, align 1
   %fv.1 = load i64, ptr %local_3__population, align 8
   %fv.2 = load %struct.Country__Dunno, ptr %local_5__phony, align 8
   %insert_03 = insertvalue %struct.Country__Country undef, i8 %fv.02, 0
-  %insert_1 = insertvalue %struct.Country__Country %insert_03, i64 %fv.1, 1
-  %insert_2 = insertvalue %struct.Country__Country %insert_1, %struct.Country__Dunno %fv.2, 2
-  store %struct.Country__Country %insert_2, ptr %local_6, align 8
+  %insert_14 = insertvalue %struct.Country__Country %insert_03, i64 %fv.1, 1
+  %insert_2 = insertvalue %struct.Country__Country %insert_14, %struct.Country__Dunno %fv.2, 2
+  %insert_3 = insertvalue %struct.Country__Country %insert_2, i8 0, 3
+  store %struct.Country__Country %insert_3, ptr %local_6, align 8
   %retval = load %struct.Country__Country, ptr %local_6, align 8
   ret %struct.Country__Country %retval
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/stdlib-bcs.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/stdlib-bcs.move
@@ -1,4 +1,4 @@
-// signers 0xcafe
+// signers 0xcafe,0x1,0x2
 
 module 0x10::bcs {
   native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
@@ -167,6 +167,15 @@ module 0x10::tests {
     assert!(v == vv, 11);
   }
 
+  public fun test_vec_signer(s1: signer, s2: signer) {
+    let v: vector<signer> = vector::empty();
+    vector::push_back(&mut v, s1);
+    vector::push_back(&mut v, s2);
+    let vs: vector<u8> = bcs::to_bytes(&v);
+    let vv: vector<signer> = bcs::test_from_bytes(&vs);
+    assert!(v == vv, 11);
+  }
+
   public fun test_vec_vec_bool() {
     let v: vector<vector<bool>> = vector::empty();
     {
@@ -195,15 +204,15 @@ module 0x10::tests {
     vector::push_back(&mut v, TestVecStruct { a: 3, b: 4 });
     let vs: vector<u8> = bcs::to_bytes(&v);
     let vv: vector<TestVecStruct> = bcs::test_from_bytes(&vs);
-    // fixme this asserts in the compiler
-    //assert!(&v == &vv, 11);
+    assert!(&v == &vv, 11);
+    assert!(v == vv, 12);
   }
 }
 
 script {
   use 0x10::tests;
 
-  fun main(s: signer) {
+  fun main(s: signer, s1: signer, s2: signer) {
     tests::test_bool();
     tests::test_u8();
     tests::test_u16();
@@ -222,8 +231,8 @@ script {
     tests::test_vec_u128();
     tests::test_vec_u256();
     tests::test_vec_address();
-    //tests::test_vec_signer(); // fixme
+    tests::test_vec_signer(s1, s2);
     tests::test_vec_vec_bool();
-    //tests::test_vec_struct(); // fixme
+    tests::test_vec_struct();
   }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-cmp.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-cmp.move
@@ -180,37 +180,55 @@ module 0x300::cmp_struct_tests {
     public fun doit() {
         let v0a = A1 { f1: 0xffffffffeeeeeeee };
         let v0b = A1 { f1: 0xffffffffeeeeeeee };
+        assert!(&v0a == &v0b, 1);
         assert!(v0a == v0b, 1);
 
         assert!(A1 { f1: 22 } != A1 { f1: 23}, 2);
 
         let v1a = A2 { f1: V::singleton(123) };
         let v1b = A2 { f1: V::singleton(123) };
+        assert!(&v1a == &v1b, 3);
         assert!(v1a == v1b, 3);
 
         let v2a = A3 { f1: 0x5a, f2: 0xcafe };
         let v2b = A3 { f1: 0x5a, f2: 0xcafe };
+        assert!(&v2a == &v2b, 4);
         assert!(v2a == v2b, 4);
 
         let v3a = A3 { f1: 0x55, f2: 0xcafe };
         let v3b = A3 { f1: 0x5a, f2: 0xcafe };
+        assert!(&v3a != &v3b, 5);
         assert!(v3a != v3b, 5);
 
         let v4a = A4 { f1: 0, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 };
         let v4b = A4 { f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 };
+        assert!(&v4a != &v4b, 6);
         assert!(v4a != v4b, 6);
 
         let v5a = A4 { f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 };
         let v5b = A4 { f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6 };
+        assert!(&v5a == &v5b, 7);
         assert!(v5a == v5b, 7);
 
         let v6a = A5 { f1: true, f2: V::singleton(0xf00dcafe) };
         let v6b = A5 { f1: true, f2: V::singleton(0xf00dcafe) };
+        assert!(&v6a == &v6b, 8);
         assert!(v6a == v6b, 8);
 
         let v7a = A5 { f1: false, f2: V::singleton(0xf00dcaff) };
         let v7b = A5 { f1: true, f2: V::singleton(0xf00dcafe) };
+        assert!(&v7a != &v7b, 9);
         assert!(v7a != v7b, 9);
+
+        let v8a = A6 { f1: @0x55aa00f0e1, f2: true };
+        let v8b = A6 { f1: @0x55aa00f0e1, f2: true };
+        assert!(&v8a == &v8b, 10);
+        assert!(v8a == v8b, 10);
+
+        let v9a = A6 { f1: @0x55aa00f0e1, f2: true };
+        let v9b = A6 { f1: @0x55aa00f0e0, f2: true };
+        assert!(&v9a != &v9b, 11);
+        assert!(v9a != v9b, 11);
     }
 }
 


### PR DESCRIPTION
This patch implements new routine `move-native::rt::move_rt_struct_cmp_eq` to perform deep comparisons on Move structs.

Also finished `move-native::rt::move_rt_vec_cmp_eq` by adding support for Signer elements and Struct elements (using above routine).

Previously, as a temporary measure, the compiler generated explicit LLVM IR to do struct compares. Update compiler to call new runtime routine `move_ty_struct_cmp_eq` instead.

With the new runtime support, vector-of-struct bcs serialization now works. Uncommented failing test `tests::test_vec_struct` and uncommented asserts. Also added `tests::test_vec_signer(s1, s2)` to test vector<signer> serialization. All tests now pass.

Add more struct comparison test coverage in `struct-cmp.move` now that the runtime is complete and the compiler now supports both struct and &struct comparisons.

Added `vector<signer>` testing in `vec.move` to cover above.