### PR TITLE
Add move-native to workspace, fix formatting etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "language/move-ir-compiler/move-ir-to-bytecode/syntax",
     "language/move-ir-compiler/transactional-tests",
     "language/move-model",
+    "language/move-native",
     "language/move-prover",
     "language/move-prover/boogie-backend",
     "language/move-prover/bytecode",
@@ -99,11 +100,6 @@ default-members = [
     "language/tools/move-coverage",
     "language/tools/move-mv-llvm-compiler",
     "language/tools/move-unit-test",
-]
-
-exclude = [
-    # this is a no-std staticlib that does not build for the host platform
-    "language/move-native",
 ]
 
 # Dependencies that should be kept in sync through the whole workspace

--- a/language/move-native/Cargo.toml
+++ b/language/move-native/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 
-[workspace]
-members = ["."]
-
+# When compiled as a Solana runtime, this crate is compiled
+# as a staticlib, though it is not declared as such here.
+# See the crate documentation on `no-std` compatibility for explanation.
 [lib]
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 solana = []

--- a/language/move-native/src/conv.rs
+++ b/language/move-native/src/conv.rs
@@ -4,9 +4,11 @@
 
 use crate::rt_types::*;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::{Deref, DerefMut};
+use core::{
+    marker::PhantomData,
+    mem,
+    ops::{Deref, DerefMut},
+};
 
 /// This is a placeholder for the unstable `ptr::invalid_mut`.
 ///
@@ -77,9 +79,7 @@ pub fn rust_vec_to_move_vec<T>(mut rv: Vec<T>) -> MoveUntypedVector {
     mv
 }
 
-pub unsafe fn borrow_move_vec_as_rust_vec<T>(
-    mv: &MoveUntypedVector,
-) -> MoveBorrowedRustVec<'_, T> {
+pub unsafe fn borrow_move_vec_as_rust_vec<T>(mv: &MoveUntypedVector) -> MoveBorrowedRustVec<'_, T> {
     let rv = Vec::from_raw_parts(
         mv.ptr as *mut T,
         usize::try_from(mv.length).expect("overflow"),
@@ -264,9 +264,7 @@ pub unsafe fn raw_borrow_move_value_as_rust_value(
             let move_ref = mem::transmute(value);
             RawBorrowedTypedMoveValue::Vector(element_type, move_ref)
         }
-        TypeDesc::Struct => {
-            RawBorrowedTypedMoveValue::Struct(*type_, value)
-        }
+        TypeDesc::Struct => RawBorrowedTypedMoveValue::Struct(*type_, value),
         TypeDesc::Reference => {
             let element_type = *(*type_.type_info).reference.element_type;
             let move_ref = mem::transmute(value);
@@ -308,64 +306,40 @@ pub enum TypedMoveBorrowedRustVecMut<'mv> {
     // todo
 }
 
-#[rustfmt::skip]
 pub unsafe fn borrow_typed_move_vec_as_rust_vec<'mv>(
     type_: &'mv MoveType,
     mv: &'mv MoveUntypedVector,
 ) -> TypedMoveBorrowedRustVec<'mv> {
     match type_.type_desc {
-        TypeDesc::Bool => {
-            TypedMoveBorrowedRustVec::Bool(borrow_move_vec_as_rust_vec::<bool>(mv))
-        }
-        TypeDesc::U8 => {
-            TypedMoveBorrowedRustVec::U8(borrow_move_vec_as_rust_vec::<u8>(mv))
-        }
-        TypeDesc::U16 => {
-            TypedMoveBorrowedRustVec::U16(borrow_move_vec_as_rust_vec::<u16>(mv))
-        }
-        TypeDesc::U32 => {
-            TypedMoveBorrowedRustVec::U32(borrow_move_vec_as_rust_vec::<u32>(mv))
-        }
-        TypeDesc::U64 => {
-            TypedMoveBorrowedRustVec::U64(borrow_move_vec_as_rust_vec::<u64>(mv))
-        }
-        TypeDesc::U128 => {
-            TypedMoveBorrowedRustVec::U128(borrow_move_vec_as_rust_vec::<u128>(mv))
-        }
-        TypeDesc::U256 => {
-            TypedMoveBorrowedRustVec::U256(borrow_move_vec_as_rust_vec::<U256>(mv))
-        }
+        TypeDesc::Bool => TypedMoveBorrowedRustVec::Bool(borrow_move_vec_as_rust_vec::<bool>(mv)),
+        TypeDesc::U8 => TypedMoveBorrowedRustVec::U8(borrow_move_vec_as_rust_vec::<u8>(mv)),
+        TypeDesc::U16 => TypedMoveBorrowedRustVec::U16(borrow_move_vec_as_rust_vec::<u16>(mv)),
+        TypeDesc::U32 => TypedMoveBorrowedRustVec::U32(borrow_move_vec_as_rust_vec::<u32>(mv)),
+        TypeDesc::U64 => TypedMoveBorrowedRustVec::U64(borrow_move_vec_as_rust_vec::<u64>(mv)),
+        TypeDesc::U128 => TypedMoveBorrowedRustVec::U128(borrow_move_vec_as_rust_vec::<u128>(mv)),
+        TypeDesc::U256 => TypedMoveBorrowedRustVec::U256(borrow_move_vec_as_rust_vec::<U256>(mv)),
         TypeDesc::Address => {
             TypedMoveBorrowedRustVec::Address(borrow_move_vec_as_rust_vec::<MoveAddress>(mv))
         }
         TypeDesc::Signer => {
             TypedMoveBorrowedRustVec::Signer(borrow_move_vec_as_rust_vec::<MoveSigner>(mv))
         }
-        TypeDesc::Vector => {
-            TypedMoveBorrowedRustVec::Vector(
-                *(*type_.type_info).vector.element_type,
-                borrow_move_vec_as_rust_vec::<MoveUntypedVector>(mv),
-            )
-        }
-        TypeDesc::Struct => {
-            TypedMoveBorrowedRustVec::Struct(
-                MoveBorrowedRustVecOfStruct {
-                    inner: mv,
-                    name: type_.name,
-                    type_: &(*type_.type_info).struct_,
-                }
-            )
-        }
-        TypeDesc::Reference => {
-            TypedMoveBorrowedRustVec::Reference(
-                *(*type_.type_info).reference.element_type,
-                borrow_move_vec_as_rust_vec::<MoveUntypedReference>(mv),
-            )
-        }
+        TypeDesc::Vector => TypedMoveBorrowedRustVec::Vector(
+            *(*type_.type_info).vector.element_type,
+            borrow_move_vec_as_rust_vec::<MoveUntypedVector>(mv),
+        ),
+        TypeDesc::Struct => TypedMoveBorrowedRustVec::Struct(MoveBorrowedRustVecOfStruct {
+            inner: mv,
+            name: type_.name,
+            type_: &(*type_.type_info).struct_,
+        }),
+        TypeDesc::Reference => TypedMoveBorrowedRustVec::Reference(
+            *(*type_.type_info).reference.element_type,
+            borrow_move_vec_as_rust_vec::<MoveUntypedReference>(mv),
+        ),
     }
 }
 
-#[rustfmt::skip]
 pub unsafe fn borrow_typed_move_vec_as_rust_vec_mut<'mv>(
     type_: &'mv MoveType,
     mv: &'mv mut MoveUntypedVector,
@@ -374,9 +348,7 @@ pub unsafe fn borrow_typed_move_vec_as_rust_vec_mut<'mv>(
         TypeDesc::Bool => {
             TypedMoveBorrowedRustVecMut::Bool(borrow_move_vec_as_rust_vec_mut::<bool>(mv))
         }
-        TypeDesc::U8 => {
-            TypedMoveBorrowedRustVecMut::U8(borrow_move_vec_as_rust_vec_mut::<u8>(mv))
-        }
+        TypeDesc::U8 => TypedMoveBorrowedRustVecMut::U8(borrow_move_vec_as_rust_vec_mut::<u8>(mv)),
         TypeDesc::U16 => {
             TypedMoveBorrowedRustVecMut::U16(borrow_move_vec_as_rust_vec_mut::<u16>(mv))
         }
@@ -398,27 +370,19 @@ pub unsafe fn borrow_typed_move_vec_as_rust_vec_mut<'mv>(
         TypeDesc::Signer => {
             TypedMoveBorrowedRustVecMut::Signer(borrow_move_vec_as_rust_vec_mut::<MoveSigner>(mv))
         }
-        TypeDesc::Vector => {
-            TypedMoveBorrowedRustVecMut::Vector(
-                *(*type_.type_info).vector.element_type,
-                borrow_move_vec_as_rust_vec_mut::<MoveUntypedVector>(mv),
-            )
-        }
-        TypeDesc::Struct => {
-            TypedMoveBorrowedRustVecMut::Struct(
-                MoveBorrowedRustVecOfStructMut {
-                    inner: mv,
-                    name: type_.name,
-                    type_: &(*type_.type_info).struct_,
-                }
-            )
-        }
-        TypeDesc::Reference => {
-            TypedMoveBorrowedRustVecMut::Reference(
-                *(*type_.type_info).reference.element_type,
-                borrow_move_vec_as_rust_vec_mut::<MoveUntypedReference>(mv),
-            )
-        }
+        TypeDesc::Vector => TypedMoveBorrowedRustVecMut::Vector(
+            *(*type_.type_info).vector.element_type,
+            borrow_move_vec_as_rust_vec_mut::<MoveUntypedVector>(mv),
+        ),
+        TypeDesc::Struct => TypedMoveBorrowedRustVecMut::Struct(MoveBorrowedRustVecOfStructMut {
+            inner: mv,
+            name: type_.name,
+            type_: &(*type_.type_info).struct_,
+        }),
+        TypeDesc::Reference => TypedMoveBorrowedRustVecMut::Reference(
+            *(*type_.type_info).reference.element_type,
+            borrow_move_vec_as_rust_vec_mut::<MoveUntypedReference>(mv),
+        ),
     }
 }
 

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -101,6 +101,16 @@
 //! module. For Solana specifically, we will probably link to `solana_program`,
 //! which links to `std.
 //!
+//! When compiled as a Move runtime, and not for e.g. a host or testing,
+//! this library is compiled as a "staticlib" crate type, which results
+//! in an archive library that does not contain the Rust standard library.
+//!
+//! The crate's manifest though does not declare it as a staticlib.
+//! If it did, then workspace operations like `cargo check` would attempt
+//! to build it as a staticlib for the host, and this library does not declare
+//! the lang-items necessary to build a staticlib for the host.
+//! Instead, the build process for rbpf runs `cargo rustc --crate-type staticlib`.
+//!
 //!
 //! # Platform compatibility
 //!

--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -235,7 +235,6 @@
 //! - `move-core-types::value`
 
 #![no_std]
-
 // NB Solana's Rust seems to allow use of unstable features.
 // This wouldn't normally be allowed.
 #![cfg_attr(feature = "solana", feature(default_alloc_error_handler))]
@@ -244,9 +243,7 @@ extern crate alloc;
 
 /// Types literally shared with the compiler through crate linkage.
 pub mod shared {
-    pub use crate::rt_types::TypeDesc;
-    pub use crate::rt_types::MOVE_UNTYPED_VEC_DESC_SIZE;
-    pub use crate::rt_types::MOVE_TYPE_DESC_SIZE;
+    pub use crate::rt_types::{TypeDesc, MOVE_TYPE_DESC_SIZE, MOVE_UNTYPED_VEC_DESC_SIZE};
 }
 
 /// Types known to the compiler.

--- a/language/move-native/src/rt.rs
+++ b/language/move-native/src/rt.rs
@@ -21,12 +21,20 @@ unsafe extern "C" fn vec_empty(type_ve: &MoveType) -> MoveUntypedVector {
 }
 
 #[export_name = "move_rt_vec_copy"]
-unsafe extern "C" fn vec_copy(type_ve: &MoveType, dstv: &mut MoveUntypedVector, srcv: &MoveUntypedVector) {
+unsafe extern "C" fn vec_copy(
+    type_ve: &MoveType,
+    dstv: &mut MoveUntypedVector,
+    srcv: &MoveUntypedVector,
+) {
     crate::vector::copy(type_ve, dstv, srcv)
 }
 
 #[export_name = "move_rt_vec_cmp_eq"]
-unsafe extern "C" fn vec_cmp_eq(type_ve: &MoveType, v1: &MoveUntypedVector, v2: &MoveUntypedVector) -> bool {
+unsafe extern "C" fn vec_cmp_eq(
+    type_ve: &MoveType,
+    v1: &MoveUntypedVector,
+    v2: &MoveUntypedVector,
+) -> bool {
     crate::vector::cmp_eq(type_ve, v1, v2)
 }
 

--- a/language/move-native/src/rt_types.rs
+++ b/language/move-native/src/rt_types.rs
@@ -68,7 +68,7 @@ pub const MOVE_TYPE_DESC_SIZE: u64 = core::mem::size_of::<MoveType>() as u64;
 
 // Needed to make the MoveType, which contains raw pointers,
 // Sync, so that it can be stored in statics for test cases.
-unsafe impl Sync for MoveType { }
+unsafe impl Sync for MoveType {}
 
 impl core::fmt::Debug for MoveType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -186,8 +186,7 @@ pub struct ReferenceTypeInfo {
 pub struct AnyValue(u8);
 
 #[repr(transparent)]
-#[derive(Debug, PartialEq)]
-#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(Debug, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct MoveSigner(pub MoveAddress);
 
 /// A Move address.
@@ -197,8 +196,7 @@ pub struct MoveSigner(pub MoveAddress);
 ///
 /// Bytes are in little-endian order.
 #[repr(transparent)]
-#[derive(PartialEq)]
-#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct MoveAddress(pub [u8; target_defs::ACCOUNT_ADDRESS_LENGTH]);
 
 impl core::fmt::Debug for MoveAddress {
@@ -232,8 +230,7 @@ pub struct MoveAsciiString {
 #[derive(Debug)]
 pub struct MoveUntypedReference(pub *const AnyValue);
 
-#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Copy, Clone, PartialEq)]
 #[repr(transparent)]
 pub struct U256(pub [u128; 2]);
 

--- a/language/move-native/src/rt_types.rs
+++ b/language/move-native/src/rt_types.rs
@@ -91,7 +91,7 @@ pub struct StaticTypeName {
 }
 
 impl StaticTypeName {
-    pub unsafe fn as_ascii_str<'a>(&'a self) -> &'a str {
+    pub unsafe fn as_ascii_str(&self) -> &str {
         core::str::from_utf8_unchecked(core::slice::from_raw_parts(
             self.ptr,
             usize::try_from(self.len).expect("overflow"),

--- a/language/move-native/src/serialization.rs
+++ b/language/move-native/src/serialization.rs
@@ -177,7 +177,7 @@ unsafe fn serialize_vector(type_elt: &MoveType, v: &MoveUntypedVector, buf: &mut
 }
 
 unsafe fn deserialize_vector(type_elt: &MoveType, bytes: &mut &[u8]) -> MoveUntypedVector {
-    let mut mv: MoveUntypedVector = crate::vector::empty(&type_elt);
+    let mut mv: MoveUntypedVector = crate::vector::empty(type_elt);
     let mut rv = borrow_typed_move_vec_as_rust_vec_mut(type_elt, &mut mv);
     match &mut rv {
         TypedMoveBorrowedRustVecMut::Bool(v) => {
@@ -212,7 +212,7 @@ unsafe fn deserialize_vector(type_elt: &MoveType, bytes: &mut &[u8]) -> MoveUnty
             let len: usize = len as usize;
             v.reserve_exact(len);
             for _ in 0..len {
-                let eltv = deserialize_vector(&inner_elt_type, bytes);
+                let eltv = deserialize_vector(inner_elt_type, bytes);
                 v.push(eltv);
             }
         }

--- a/language/move-native/src/serialization.rs
+++ b/language/move-native/src/serialization.rs
@@ -2,11 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::conv::*;
-use crate::rt_types::*;
-use core::ptr;
-use borsh::{BorshSerialize, BorshDeserialize};
+use crate::{conv::*, rt_types::*};
 use alloc::vec::Vec;
+use borsh::{BorshDeserialize, BorshSerialize};
+use core::ptr;
 
 fn borsh_to_buf<T: BorshSerialize>(v: &T, buf: &mut Vec<u8>) {
     borsh::to_writer(buf, v).expect("serialization failure")
@@ -129,33 +128,15 @@ unsafe fn deserialize_from_slice(type_v: &MoveType, bytes: &mut &[u8], v: *mut A
 unsafe fn serialize_vector(type_elt: &MoveType, v: &MoveUntypedVector, buf: &mut Vec<u8>) {
     let v = borrow_typed_move_vec_as_rust_vec(type_elt, v);
     match v {
-        TypedMoveBorrowedRustVec::Bool(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U8(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U16(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U32(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U64(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U128(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::U256(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::Address(v) => {
-            borsh_to_buf(&*v, buf)
-        }
-        TypedMoveBorrowedRustVec::Signer(v) => {
-            borsh_to_buf(&*v, buf)
-        }
+        TypedMoveBorrowedRustVec::Bool(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U8(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U16(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U32(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U64(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U128(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::U256(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::Address(v) => borsh_to_buf(&*v, buf),
+        TypedMoveBorrowedRustVec::Signer(v) => borsh_to_buf(&*v, buf),
         TypedMoveBorrowedRustVec::Vector(t, v) => {
             let len: u32 = v.len().try_into().expect("overlong vector");
             borsh_to_buf(&len, buf);

--- a/language/move-native/src/std.rs
+++ b/language/move-native/src/std.rs
@@ -74,9 +74,7 @@ mod hash {
         let rust_vec = move_byte_vec_to_rust_vec(ptr);
 
         let hash_vec = Sha256::digest(rust_vec.as_slice()).to_vec();
-        let move_vec = rust_vec_to_move_byte_vec(hash_vec);
-
-        move_vec
+        rust_vec_to_move_byte_vec(hash_vec)
     }
 
     #[export_name = "move_native_hash_sha3_256"]
@@ -84,9 +82,7 @@ mod hash {
         let rust_vec = move_byte_vec_to_rust_vec(ptr);
 
         let hash_vec = Sha3_256::digest(rust_vec.as_slice()).to_vec();
-        let move_vec = rust_vec_to_move_byte_vec(hash_vec);
-
-        move_vec
+        rust_vec_to_move_byte_vec(hash_vec)
     }
 }
 
@@ -109,10 +105,7 @@ pub(crate) mod string {
         let rust_vec = borrow_move_byte_vec_as_rust_vec(v);
         let res = str::from_utf8(&rust_vec);
 
-        match res {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        res.is_ok()
     }
 
     #[export_name = "move_native_string_internal_is_char_boundary"]

--- a/language/move-native/src/std.rs
+++ b/language/move-native/src/std.rs
@@ -24,16 +24,18 @@ mod bcs {
     ///
     /// This is not actually in move std, but is used for testing.
     #[export_name = "move_native_bcs_test_from_bytes"]
-    unsafe extern "C" fn test_from_bytes(type_v: &MoveType, bytes: &MoveByteVector, v: *mut AnyValue) {
+    unsafe extern "C" fn test_from_bytes(
+        type_v: &MoveType,
+        bytes: &MoveByteVector,
+        v: *mut AnyValue,
+    ) {
         crate::serialization::deserialize(type_v, bytes, v)
     }
 }
 
 // nursery
 mod debug {
-    use crate::conv::*;
-    use crate::rt_types::*;
-    use crate::target_defs;
+    use crate::{conv::*, rt_types::*, target_defs};
     use alloc::format;
 
     #[export_name = "move_native_debug_print"]
@@ -64,8 +66,10 @@ mod event {
 }
 
 mod hash {
-    use crate::conv::{move_byte_vec_to_rust_vec, rust_vec_to_move_byte_vec};
-    use crate::rt_types::*;
+    use crate::{
+        conv::{move_byte_vec_to_rust_vec, rust_vec_to_move_byte_vec},
+        rt_types::*,
+    };
     use sha2::{Digest, Sha256};
     use sha3::Sha3_256;
 
@@ -96,8 +100,7 @@ mod signer {
 }
 
 pub(crate) mod string {
-    use crate::conv::*;
-    use crate::rt_types::*;
+    use crate::{conv::*, rt_types::*};
     use core::str;
 
     #[export_name = "move_native_string_internal_check_utf8"]
@@ -146,13 +149,12 @@ pub(crate) mod string {
             Some(i) => i,
             None => s_rust_str.len(),
         })
-            .expect("u64")
+        .expect("u64")
     }
 }
 
 mod type_name {
-    use crate::conv::*;
-    use crate::rt_types::*;
+    use crate::{conv::*, rt_types::*};
 
     #[export_name = "move_native_type_name_get"]
     unsafe extern "C" fn get(type_: &MoveType) -> TypeName {
@@ -217,7 +219,7 @@ mod vector {
     unsafe extern "C" fn push_back(
         type_ve: &MoveType,
         v: &mut MoveUntypedVector,
-        e: *mut AnyValue
+        e: *mut AnyValue,
     ) {
         crate::vector::push_back(type_ve, v, e)
     }
@@ -226,17 +228,13 @@ mod vector {
     unsafe extern "C" fn borrow_mut<'v>(
         type_ve: &'v MoveType,
         v: &'v mut MoveUntypedVector,
-        i: u64
+        i: u64,
     ) -> &'v mut AnyValue {
         crate::vector::borrow_mut(type_ve, v, i)
     }
 
     #[export_name = "move_native_vector_pop_back"]
-    unsafe extern "C" fn pop_back(
-        type_ve: &MoveType,
-        v: &mut MoveUntypedVector,
-        r: *mut AnyValue,
-    ) {
+    unsafe extern "C" fn pop_back(type_ve: &MoveType, v: &mut MoveUntypedVector, r: *mut AnyValue) {
         crate::vector::pop_back(type_ve, v, r)
     }
 

--- a/language/move-native/src/structs.rs
+++ b/language/move-native/src/structs.rs
@@ -37,38 +37,42 @@ pub unsafe fn walk_fields_mut<'mv>(
 }
 
 pub unsafe fn cmp_eq(type_ve: &MoveType, s1: &AnyValue, s2: &AnyValue) -> bool {
-    use crate::conv::{BorrowedTypedMoveValue as BTMV, borrow_move_value_as_rust_value};
+    use crate::conv::{borrow_move_value_as_rust_value, BorrowedTypedMoveValue as BTMV};
 
     let st_info = (*(type_ve.type_info)).struct_;
     let fields1 = walk_fields(&st_info, s1);
     let fields2 = walk_fields(&st_info, s2);
-    for ((fld_ty1, fld_ref1, _fld_name1), (fld_ty2, fld_ref2, _fld_name2)) in Iterator::zip(fields1, fields2) {
+    for ((fld_ty1, fld_ref1, _fld_name1), (fld_ty2, fld_ref2, _fld_name2)) in
+        Iterator::zip(fields1, fields2)
+    {
         let rv1 = borrow_move_value_as_rust_value(fld_ty1, fld_ref1);
         let rv2 = borrow_move_value_as_rust_value(fld_ty2, fld_ref2);
 
         let is_eq = match (rv1, rv2) {
-            (BTMV::Bool(val1), BTMV::Bool(val2)) => { val1 == val2  }
-            (BTMV::U8(val1), BTMV::U8(val2)) => { val1 == val2  }
-            (BTMV::U16(val1), BTMV::U16(val2)) => { val1 == val2  }
-            (BTMV::U32(val1), BTMV::U32(val2)) => { val1 == val2  }
-            (BTMV::U64(val1), BTMV::U64(val2)) => { val1 == val2  }
-            (BTMV::U128(val1), BTMV::U128(val2)) => { val1 == val2  }
-            (BTMV::U256(val1), BTMV::U256(val2)) => { val1 == val2  }
-            (BTMV::Address(val1), BTMV::Address(val2)) => { val1 == val2  }
-            (BTMV::Signer(val1), BTMV::Signer(val2)) => { val1 == val2  }
+            (BTMV::Bool(val1), BTMV::Bool(val2)) => val1 == val2,
+            (BTMV::U8(val1), BTMV::U8(val2)) => val1 == val2,
+            (BTMV::U16(val1), BTMV::U16(val2)) => val1 == val2,
+            (BTMV::U32(val1), BTMV::U32(val2)) => val1 == val2,
+            (BTMV::U64(val1), BTMV::U64(val2)) => val1 == val2,
+            (BTMV::U128(val1), BTMV::U128(val2)) => val1 == val2,
+            (BTMV::U256(val1), BTMV::U256(val2)) => val1 == val2,
+            (BTMV::Address(val1), BTMV::Address(val2)) => val1 == val2,
+            (BTMV::Signer(val1), BTMV::Signer(val2)) => val1 == val2,
             (BTMV::Vector(t1, utv1), BTMV::Vector(_t2, utv2)) => {
                 crate::vector::cmp_eq(&t1, utv1, utv2)
             }
-            (BTMV::Struct(t1, anyv1), BTMV::Struct(_t2, anyv2)) => {
-                cmp_eq(&t1, anyv1, anyv2)
-            }
+            (BTMV::Struct(t1, anyv1), BTMV::Struct(_t2, anyv2)) => cmp_eq(&t1, anyv1, anyv2),
             (BTMV::Reference(_, _), BTMV::Reference(_, _)) => {
                 unreachable!("reference in struct field impossible")
             }
-            _ => { unreachable!("struct_cmp_eq unexpected value combination") }
+            _ => {
+                unreachable!("struct_cmp_eq unexpected value combination")
+            }
         };
 
-        if !is_eq { return false }
+        if !is_eq {
+            return false;
+        }
     }
     true
 }

--- a/language/move-native/src/target_defs.rs
+++ b/language/move-native/src/target_defs.rs
@@ -40,9 +40,7 @@ mod impls {
 
     pub fn abort(code: u64) -> ! {
         unsafe {
-            syscalls::sol_log_64_(
-                code, code, code, code, code,
-            );
+            syscalls::sol_log_64_(code, code, code, code, code);
             syscalls::abort()
         }
     }
@@ -57,10 +55,11 @@ mod impls {
     }
 
     mod globals {
-        use alloc::alloc::{GlobalAlloc, Layout};
-        use alloc::format;
-        use core::mem::size_of;
-        use core::ptr::null_mut;
+        use alloc::{
+            alloc::{GlobalAlloc, Layout},
+            format,
+        };
+        use core::{mem::size_of, ptr::null_mut};
 
         const PANIC_ABORT_CODE: u64 = 101;
 

--- a/language/move-native/src/tests.rs
+++ b/language/move-native/src/tests.rs
@@ -3,13 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::conv::*;
-use crate::rt_types::*;
-use crate::std::string::*;
-use crate::vector;
+use crate::{conv::*, rt_types::*, std::string::*, target_defs::ACCOUNT_ADDRESS_LENGTH, vector};
 use alloc::{string::String, vec};
 use core::mem;
-use crate::target_defs::ACCOUNT_ADDRESS_LENGTH;
 
 #[test]
 fn test_string_check_utf8() {
@@ -223,7 +219,10 @@ fn test_vec_with_signer() {
 
     unsafe { vector::pop_back(&ELEMENT_TYPE, &mut move_vec, popped_element_ptr) };
     assert_eq!(move_vec.length, 0);
-    assert_eq!(popped_element, MoveSigner(MoveAddress([u8::MIN; ACCOUNT_ADDRESS_LENGTH])));
+    assert_eq!(
+        popped_element,
+        MoveSigner(MoveAddress([u8::MIN; ACCOUNT_ADDRESS_LENGTH]))
+    );
 
     unsafe { vector::destroy_empty(&ELEMENT_TYPE, move_vec) }
 }

--- a/language/move-native/src/tests.rs
+++ b/language/move-native/src/tests.rs
@@ -160,9 +160,6 @@ fn test_vec_with_vector() {
         vector::push_back(&OUTER_ELEMENT_TYPE, &mut move_vec, new_element_vec_ptr);
         assert_eq!(move_vec.length, 1);
 
-        // remove this moved value from current scope
-        drop(new_element_vec);
-
         let mut popped_element = vector::empty(&INNER_ELEMENT_TYPE);
         let popped_element_ptr = &mut popped_element as *mut _ as *mut AnyValue;
 

--- a/language/move-native/src/vector.rs
+++ b/language/move-native/src/vector.rs
@@ -9,7 +9,7 @@ use core::{mem, ptr};
 use core::ops::Deref;
 
 pub fn empty(type_r: &MoveType) -> MoveUntypedVector {
-    let move_vec = match type_r.type_desc {
+    match type_r.type_desc {
         TypeDesc::Bool => rust_vec_to_move_vec::<bool>(Vec::new()),
         TypeDesc::U8 => rust_vec_to_move_vec::<u8>(Vec::new()),
         TypeDesc::U16 => rust_vec_to_move_vec::<u16>(Vec::new()),
@@ -69,9 +69,7 @@ pub fn empty(type_r: &MoveType) -> MoveUntypedVector {
             }
         },
         TypeDesc::Reference => rust_vec_to_move_vec::<MoveUntypedReference>(Vec::new()),
-    };
-
-    move_vec
+    }
 }
 
 pub unsafe fn destroy_empty(type_ve: &MoveType, v: MoveUntypedVector) {
@@ -122,8 +120,6 @@ pub unsafe fn destroy_empty(type_ve: &MoveType, v: MoveUntypedVector) {
                     .expect("bad size or alignment");
                 alloc::alloc::dealloc(v.ptr, layout);
             }
-
-            drop(v);
         }
         TypeDesc::Reference => drop(move_vec_to_rust_vec::<MoveUntypedReference>(v)),
     }
@@ -424,7 +420,7 @@ pub unsafe fn cmp_eq(type_ve: &MoveType, v1: &MoveUntypedVector, v2: &MoveUntype
 }
 
 impl<'mv> MoveBorrowedRustVecOfStruct<'mv> {
-    pub unsafe fn iter<'s>(&'s self) -> impl Iterator<Item = &'s AnyValue> {
+    pub unsafe fn iter(&self) -> impl Iterator<Item = &AnyValue> {
         let struct_size = usize::try_from(self.type_.size).expect("overflow");
         let vec_len = usize::try_from(self.inner.length).expect("overflow");
         (0..vec_len).map(move |i| {
@@ -432,8 +428,7 @@ impl<'mv> MoveBorrowedRustVecOfStruct<'mv> {
             let offset = i.checked_mul(struct_size).expect("overflow");
             let offset = isize::try_from(offset).expect("overflow");
             let element_ptr = base_ptr.offset(offset);
-            let element_ref = &*(element_ptr as *const AnyValue);
-            element_ref
+            &*(element_ptr as *const AnyValue)
         })
     }
 
@@ -449,8 +444,7 @@ impl<'mv> MoveBorrowedRustVecOfStruct<'mv> {
         let offset = i.checked_mul(struct_size).expect("overflow");
         let offset = isize::try_from(offset).expect("overflow");
         let element_ptr = base_ptr.offset(offset);
-        let element_ref = &*(element_ptr as *const AnyValue);
-        element_ref
+        &*(element_ptr as *const AnyValue)
     }
 }
 
@@ -467,8 +461,7 @@ impl<'mv> MoveBorrowedRustVecOfStructMut<'mv> {
         let offset = i.checked_mul(struct_size).expect("overflow");
         let offset = isize::try_from(offset).expect("overflow");
         let element_ptr = base_ptr.offset(offset);
-        let element_ref = &mut *(element_ptr as *mut AnyValue);
-        element_ref
+        &mut *(element_ptr as *mut AnyValue)
     }
 
     /// Get a pointer to a possibly-uninitialized element.
@@ -484,8 +477,7 @@ impl<'mv> MoveBorrowedRustVecOfStructMut<'mv> {
         let offset = i.checked_mul(struct_size).expect("overflow");
         let offset = isize::try_from(offset).expect("overflow");
         let element_ptr = base_ptr.offset(offset);
-        let element_ptr = element_ptr as *mut AnyValue;
-        element_ptr
+        element_ptr as *mut AnyValue
     }
 
     pub unsafe fn set_length(&mut self, len: usize) {

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests.rs
@@ -145,9 +145,12 @@ fn get_runtime(sbf_tools: &PlatformTools) -> anyhow::Result<Runtime> {
             .to_string_lossy()
             .to_string();
 
-        // release mode required to eliminate large stack frames
+        // Using `cargo rustc` to compile move-native as a staticlib.
+        // See move-native documentation on `no-std` compatibilty for explanation.
+        // Release mode is required to eliminate large stack frames.
         let res = sbf_tools.run_cargo(&[
-            "build",
+            "rustc",
+            "--crate-type=staticlib",
             "-p",
             "move-native",
             "--target",

--- a/x.toml
+++ b/x.toml
@@ -201,10 +201,3 @@ mark-changed = ["move-analyzer"]
 # x controls the build process, so if it changes, build everything.
 on-affected = ["x"]
 mark-changed = "all"
-
-[[determinator.path-rule]]
-# Ignore files in move-native (for now)
-# todo (brson) I don't understand what this actually does but it's required to pass `cargo x lint`
-# move-native is not part of the workspace
-globs = ["language/move-native/**/*"]
-mark-changed = []


### PR DESCRIPTION
This makes `cargo xfmt` and `cargo xclippy` work with move-native by adding move-native to the workspace. `cargo xlint` already applies to move-native. CI will now run these on move-native.

The reason move-native was not part of the workspace is because it is compiled as a staticlib. Previously this caused workspace operations like `cargo check` to attempt to compile move-native as a staticlib for the host platform. Staticlibs are expected to contain necessary lang-items like panic handlers and allocators, but move-native does not try to declare these for platforms other than solana, and this caused the build to fail.

This resolves that problem by _not_ declaring move-native a staticlib in its manifest. Now normal build operations just build it as a rlib, which is allowed to not contain those lang items since it must be linked to other rlibs to be used. As a result of this, to compile move-native correctly for solana one must use a lesser-known command:

`cargo rustc --crate-type=staticlib`

and this is what `rbpf-tests` does.

One might try to instead declare the correct lang-items when compiled for various host platforms, but I am not aware of a way to do so _only_ when compiling a staticlib, and not an rlib. And I see it as an uglier solution even if it is possible.

Closes https://github.com/solana-labs/move/issues/237