### PR TITLE
Clarify why mem::forget is called in MoveBorrowedRustVec::drop

### DIFF
--- a/language/move-native/src/conv.rs
+++ b/language/move-native/src/conv.rs
@@ -119,6 +119,17 @@ pub struct MoveBorrowedRustVecMut<'mv, T> {
 impl<'mv, T> Drop for MoveBorrowedRustVec<'mv, T> {
     fn drop(&mut self) {
         let rv = mem::take(&mut self.inner);
+
+        /* mem::forget takes rv by value so it is no longer in scope to be
+        passed to any other function.  We call forget here because
+        rv is type Vec, which owns its interior buffer pointer, but
+        this Vec was temporarily fabricated from a MoveUntypedVector,
+        which actually owns that buffer. So forgetting the Vec quietly
+        destroys it without running the Vec destructor - so that the
+        original MoveUntypedVector can continue owning that buffer.
+        The only reason to call mem::forget is to not run a
+        destructor. */
+
         mem::forget(rv);
     }
 }

--- a/language/move-native/src/rt.rs
+++ b/language/move-native/src/rt.rs
@@ -54,7 +54,9 @@ pub const MAX_PERMITTED_DATA_INCREASE: usize = 1_024 * 10;
 /// `assert_eq(std::mem::align_of::<u128>(), 8)` is true for BPF but not for some host machines
 pub const BPF_ALIGN_OF_U128: usize = 8;
 
-/// Deserialize the input arguments
+/// Deserialize the input arguments in encoded in borsh
+/// https://github.com/solana-labs/solana/blob/master/sdk/program/src/lib.rs
+/// https://github.com/solana-labs/solana/blob/master/sdk/program/src/instruction.rs: new_with_borsh
 ///
 /// Input arguments consist of three items
 /// - program_id -- a 32 byte Pubkey of the deployed module in Solana ledger,


### PR DESCRIPTION
Copied the comments from: https://github.com/solana-labs/move/pull/244/files#r1271079816