### PR TITLE
Added compile options -L -p --test --dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,6 +4249,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
+ "move-cli",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
@@ -4256,11 +4257,15 @@ dependencies = [
  "move-ir-types",
  "move-model",
  "move-native",
+ "move-package",
  "move-stackless-bytecode",
+ "move-stdlib",
+ "move-symbol-pool",
  "num 0.4.0",
  "num-traits 0.2.14",
  "once_cell",
  "parking_lot 0.11.1",
+ "regex",
  "semver 1.0.17",
  "serde 1.0.163",
  "serde_json",
@@ -4270,6 +4275,7 @@ dependencies = [
  "solana-sdk",
  "solana_rbpf",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -16,7 +16,8 @@ log = "0.4.14"
 chrono = "0.4"
 once_cell = "1.10"
 parking_lot = "0.11"
-
+toml = "0.5.8"
+regex = "1.1.9"
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-command-line-common = { path = "../../move-command-line-common" }
@@ -28,7 +29,10 @@ move-compiler = { path = "../../move-compiler" }
 move-model = { path = "../../move-model" }
 move-native = { path = "../../move-native" }
 move-stackless-bytecode = { path = "../../move-prover/bytecode" }
-
+move-stdlib = { path = "../../move-stdlib" }
+move-symbol-pool = { path = "../../move-symbol-pool" }
+move-cli = { path = "../../tools/move-cli" }
+move-package = { path = "../../tools/move-package" }
 clap = { version = "3.1.8", features = ["derive"] }
 #inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0"] }
 semver = "1.0.13"

--- a/language/tools/move-mv-llvm-compiler/src/cli.rs
+++ b/language/tools/move-mv-llvm-compiler/src/cli.rs
@@ -39,6 +39,17 @@ pub struct Args {
     #[clap(short = 'c', long = "compile")]
     pub compile: Option<String>,
 
+    /// Use stdlib.
+    #[clap(short = 'L', long = "stdlib")]
+    pub stdlib: bool,
+
+    /// Compile in test mode.
+    #[clap(long = "test")]
+    pub test: bool,
+
+    /// Compile in dev mode.
+    #[clap(long = "dev")]
+    pub dev: bool,
     /// Output file extension. This is used with -c option.
     /// Each created in compilation module `mod` will be placed into file `mod.ll`
     /// by default, or extension may be changed by this option.

--- a/language/tools/move-mv-llvm-compiler/src/lib.rs
+++ b/language/tools/move-mv-llvm-compiler/src/lib.rs
@@ -7,5 +7,6 @@ pub mod cstr;
 pub mod disassembler;
 pub mod errors;
 pub mod move_bpf_module;
+pub mod package;
 pub mod stackless;
 pub mod support;

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -7,7 +7,7 @@
 //#![forbid(unsafe_code)]
 
 use anyhow::Context;
-use anyhow::{bail, Result};
+use anyhow::bail;
 use clap::Parser;
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use llvm_sys::{core::LLVMContextCreate, prelude::LLVMModuleRef};
@@ -19,15 +19,12 @@ use move_bytecode_source_map::{mapping::SourceMapping, utils::source_map_from_fi
 use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
-use move_compiler::shared;
 use move_compiler::shared::PackagePaths;
 use move_compiler::Flags;
 use move_ir_types::location::Spanned;
 use move_model::options::ModelBuilderOptions;
 use move_model::run_model_builder_with_options_and_compilation_flags;
 use move_model::{model::GlobalEnv, run_bytecode_model_builder, run_model_builder};
-use move_mv_llvm_compiler::stackless::extensions::ModuleEnvExt;
-use move_mv_llvm_compiler::stackless::write_object_file;
 use move_mv_llvm_compiler::{cli::Args, disassembler::Disassembler};
 use move_symbol_pool::Symbol as SymbolPool;
 use std::{fs, path::Path};
@@ -35,19 +32,10 @@ use std::{fs, path::Path};
 use move_compiler::shared::NumericalAddress;
 use move_stdlib::{move_stdlib_files, move_stdlib_named_addresses};
 
-use crate::Architecture::Move;
-use move_package::{Architecture, BuildConfig};
-
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use move_package::source_package::layout::SourcePackageLayout;
-use move_package::{
-    resolution,
-    source_package::{manifest_parser, parsed_manifest::SourceManifest},
-};
+use move_mv_llvm_compiler::package::resolve_dependency;
 
-use move_mv_llvm_compiler::package::{resolve_dependency, DependencyAndAccountAddress};
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -7,6 +7,7 @@
 //#![forbid(unsafe_code)]
 
 use anyhow::Context;
+use anyhow::{bail, Result};
 use clap::Parser;
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use llvm_sys::{core::LLVMContextCreate, prelude::LLVMModuleRef};
@@ -18,11 +19,35 @@ use move_bytecode_source_map::{mapping::SourceMapping, utils::source_map_from_fi
 use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
+use move_compiler::shared;
 use move_compiler::shared::PackagePaths;
+use move_compiler::Flags;
 use move_ir_types::location::Spanned;
+use move_model::options::ModelBuilderOptions;
+use move_model::run_model_builder_with_options_and_compilation_flags;
 use move_model::{model::GlobalEnv, run_bytecode_model_builder, run_model_builder};
+use move_mv_llvm_compiler::stackless::extensions::ModuleEnvExt;
+use move_mv_llvm_compiler::stackless::write_object_file;
 use move_mv_llvm_compiler::{cli::Args, disassembler::Disassembler};
+use move_symbol_pool::Symbol as SymbolPool;
 use std::{fs, path::Path};
+
+use move_compiler::shared::NumericalAddress;
+use move_stdlib::{move_stdlib_files, move_stdlib_named_addresses};
+
+use crate::Architecture::Move;
+use move_package::{Architecture, BuildConfig};
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use move_package::source_package::layout::SourcePackageLayout;
+use move_package::{
+    resolution,
+    source_package::{manifest_parser, parsed_manifest::SourceManifest},
+};
+
+use move_mv_llvm_compiler::package::{resolve_dependency, DependencyAndAccountAddress};
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -33,6 +58,7 @@ fn main() -> anyhow::Result<()> {
 
     let compilation = args.compile.is_some();
     let deserialization = args.bytecode_file_path.is_some();
+    let stdlib = args.stdlib;
 
     if compilation && deserialization {
         anyhow::bail!("can't do both: compile from source and deserialize from .mv");
@@ -42,16 +68,89 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("must set either compile or deserialize option");
     }
 
+    if let Some(ref x) = args.move_package_path {
+        let p = PathBuf::from(x);
+        resolve_dependency(p, args.dev, args.test);
+    }
+
     let global_env: GlobalEnv;
     if compilation {
-        let path = args.compile.as_ref().unwrap().to_owned();
-        let targets = vec![PackagePaths {
-            name: None,
-            paths: vec![path],
-            named_address_map: std::collections::BTreeMap::<String, _>::new(),
-        }];
+        let mut deps = vec![];
+        let mut named_address_map = std::collections::BTreeMap::<String, _>::new();
 
-        global_env = run_model_builder(targets, vec![])?;
+        if stdlib {
+            named_address_map = move_stdlib_named_addresses();
+            named_address_map.insert(
+                "std".to_string(),
+                NumericalAddress::parse_str("0x1").unwrap(),
+            );
+
+            let compiler_dependency = move_stdlib_files();
+
+            deps.push(PackagePaths {
+                name: None,
+                paths: compiler_dependency.clone(),
+                named_address_map: named_address_map.clone(),
+            });
+        }
+
+        let target_path: String = args.compile.as_ref().unwrap().to_owned();
+
+        if let Some(ref move_package_path_maybe) = args.move_package_path {
+            let move_package_path: PathBuf = PathBuf::from(move_package_path_maybe);
+            let res = resolve_dependency(move_package_path, args.dev, args.test);
+            if res.is_ok() {
+                let compiler_dependency: Vec<String> = res
+                    .as_ref()
+                    .unwrap()
+                    .compiler_dependency
+                    .to_owned()
+                    .into_iter()
+                    .filter(|s| *s != target_path)
+                    .collect();
+
+                let account_addresses = res.unwrap().to_owned().account_addresses;
+
+                // Note: could use a simple chaining iterator like
+                // named_address_map.extend(account_addresses.iter().map(|(sym, acc)|
+                //     (sym.as_str().to_string(), NumericalAddress::parse_str(&acc.to_string()).unwrap())).into_iter());
+                // but need to check for possible reassignment, so making this in old fashion loop:
+                for (symbol, account_address) in account_addresses {
+                    let name = symbol.as_str().to_string();
+                    let address =
+                        NumericalAddress::parse_str(&account_address.to_string()).unwrap();
+                    if let Some(value) = named_address_map.get(&name) {
+                        if *value != address {
+                            bail!("{} already has assigned address {}, cannot reassign with new address {}. Possibly an error in Move.toml.",
+                            name, address, *value);
+                        }
+                    } else {
+                        named_address_map.insert(name, address);
+                    }
+                }
+
+                deps.push(PackagePaths {
+                    name: None,
+                    paths: compiler_dependency.clone(),
+                    named_address_map: named_address_map.clone(),
+                });
+            }
+        }
+
+        let sources = vec![PackagePaths {
+            name: Some(SymbolPool::from(target_path.clone())), // TODO: is it better than `None`?
+            paths: vec![target_path],
+            named_address_map: named_address_map.clone(),
+        }];
+        let options = ModelBuilderOptions::default();
+        let mut flags = if !args.test {
+            Flags::verification()
+        } else {
+            Flags::testing()
+        };
+
+        global_env =
+            run_model_builder_with_options_and_compilation_flags(sources, deps, options, flags)?;
 
         if global_env.diag_count(Severity::Warning) > 0 {
             let mut writer = Buffer::no_color();
@@ -194,6 +293,10 @@ fn main() -> anyhow::Result<()> {
                         .join(modname);
                     out_path.set_extension(&args.output_file_extension);
                     output_file = out_path.to_str().unwrap().to_string();
+                    match fs::create_dir_all(out_path.parent().expect("Should be a path")) {
+                        Ok(_) => {}
+                        Err(err) => eprintln!("Error creating directory: {}", err),
+                    }
                 }
                 llvm_write_to_file(llmod.as_mut(), args.llvm_ir, &output_file)?;
                 drop(llmod);

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -6,8 +6,7 @@
 
 //#![forbid(unsafe_code)]
 
-use anyhow::Context;
-use anyhow::bail;
+use anyhow::{bail, Context};
 use clap::Parser;
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use llvm_sys::{core::LLVMContextCreate, prelude::LLVMModuleRef};
@@ -19,12 +18,12 @@ use move_bytecode_source_map::{mapping::SourceMapping, utils::source_map_from_fi
 use move_command_line_common::files::{
     MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
-use move_compiler::shared::PackagePaths;
-use move_compiler::Flags;
+use move_compiler::{shared::PackagePaths, Flags};
 use move_ir_types::location::Spanned;
-use move_model::options::ModelBuilderOptions;
-use move_model::run_model_builder_with_options_and_compilation_flags;
-use move_model::{model::GlobalEnv, run_bytecode_model_builder, run_model_builder};
+use move_model::{
+    model::GlobalEnv, options::ModelBuilderOptions, run_bytecode_model_builder, run_model_builder,
+    run_model_builder_with_options_and_compilation_flags,
+};
 use move_mv_llvm_compiler::{cli::Args, disassembler::Disassembler};
 use move_symbol_pool::Symbol as SymbolPool;
 use std::{fs, path::Path};
@@ -35,7 +34,6 @@ use move_stdlib::{move_stdlib_files, move_stdlib_named_addresses};
 use std::path::PathBuf;
 
 use move_mv_llvm_compiler::package::resolve_dependency;
-
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
 
             deps.push(PackagePaths {
                 name: None,
-                paths: compiler_dependency.clone(),
+                paths: compiler_dependency,
                 named_address_map: named_address_map.clone(),
             });
         }
@@ -87,17 +87,17 @@ fn main() -> anyhow::Result<()> {
         if let Some(ref move_package_path_maybe) = args.move_package_path {
             let move_package_path: PathBuf = PathBuf::from(move_package_path_maybe);
             let res = resolve_dependency(move_package_path, args.dev, args.test);
-            if res.is_ok() {
+            if let Ok(..) = res {
                 let compiler_dependency: Vec<String> = res
                     .as_ref()
                     .unwrap()
                     .compiler_dependency
-                    .to_owned()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .filter(|s| *s != target_path)
                     .collect();
 
-                let account_addresses = res.unwrap().to_owned().account_addresses;
+                let account_addresses = res.unwrap().account_addresses;
 
                 // Note: could use a simple chaining iterator like
                 // named_address_map.extend(account_addresses.iter().map(|(sym, acc)|
@@ -119,7 +119,7 @@ fn main() -> anyhow::Result<()> {
 
                 deps.push(PackagePaths {
                     name: None,
-                    paths: compiler_dependency.clone(),
+                    paths: compiler_dependency,
                     named_address_map: named_address_map.clone(),
                 });
             }

--- a/language/tools/move-mv-llvm-compiler/src/package.rs
+++ b/language/tools/move-mv-llvm-compiler/src/package.rs
@@ -1,0 +1,295 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::bail;
+use anyhow::{anyhow, Context, Result};
+use move_cli::base::reroot_path;
+use move_command_line_common::env::MOVE_HOME;
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
+use regex;
+use std::collections::BTreeMap;
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use {
+    move_package::source_package::{
+        layout::SourcePackageLayout,
+        manifest_parser,
+        manifest_parser::{parse_move_manifest_string, parse_source_manifest},
+        parsed_manifest::{
+            CustomDepInfo, Dependencies, Dependency, DependencyKind, GitInfo, PackageName,
+            SourceManifest,
+        },
+    },
+    move_package::{Architecture, BuildConfig},
+};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DependencyInfo {
+    pub source_manifest: SourceManifest,
+    pub path: PathBuf,
+}
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DependencyAndAccountAddress {
+    pub compiler_dependency: Vec<String>,
+    pub account_addresses: Vec<(Symbol, AccountAddress)>,
+}
+
+/// It reads Move manifest file (Move.toml), defined by `-p dir` option.
+/// Dependency in this files should be relative paths `rel` and will be adjoined to path in `dir`,
+/// then all *.move files in `dir/rel` and `dir/rel/sources` will be compiled together with source in `-c source`.
+/// This function also assigns numerical addresses to all names listed in the manifest.
+pub fn resolve_dependency(
+    target_path: PathBuf,
+    dev: bool,
+    test: bool,
+) -> anyhow::Result<DependencyAndAccountAddress> {
+    let build_config = BuildConfig {
+        dev_mode: dev,
+        test_mode: test,
+        generate_docs: false,
+        generate_abis: false,
+        install_dir: None, // Option<PathBuf>
+        force_recompilation: false,
+        lock_file: None, // Option<PathBuf>
+        additional_named_addresses: BTreeMap::new(),
+        architecture: Some(Architecture::Move),
+        fetch_deps_only: true,
+        skip_fetch_latest_git_deps: true,
+        bytecode_version: None, // Option<u32>
+    };
+
+    let rerooted_path = reroot_path(Some(target_path))?;
+
+    let dep_info = download_deps_for_package(&build_config, &rerooted_path)?;
+
+    let mut compiler_dependency: Vec<String> = vec![];
+    let mut account_addresses = Vec::<(Symbol, AccountAddress)>::new();
+
+    for dep in dep_info {
+        let manifest = dep.source_manifest;
+
+        // Collect named addresses.
+        let acc_addr = if !build_config.dev_mode {
+            manifest
+                .addresses
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|(sym, op)| op.map(|v| (sym, v)))
+                .collect::<Vec<_>>()
+        } else {
+            manifest
+                .dev_address_assignments
+                .unwrap_or_default()
+                .into_iter()
+                .collect::<Vec<(Symbol, AccountAddress)>>()
+        };
+
+        account_addresses.extend(&acc_addr);
+
+        // Collect compiler_dependency
+        let path = dep.path;
+        if !path.exists() {
+            bail!("No such file or directory '{}'", path.to_string_lossy())
+        }
+
+        compiler_dependency.extend(move_dep_files(path));
+        continue;
+    }
+
+    let dep_and_names = DependencyAndAccountAddress {
+        compiler_dependency,
+        account_addresses,
+    };
+    return Ok(dep_and_names);
+}
+
+use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
+// Const below defined in `move-stdlib` but only as private.
+// Since it is "standard" for stdlib, we follow the same scheme.
+const MODULES_DIR: &str = "sources";
+fn move_dep_files(path: PathBuf) -> Vec<String> {
+    let mut dir = path;
+    dir.push(MODULES_DIR.to_string());
+    find_filenames(&[dir], |p| extension_equals(p, MOVE_EXTENSION)).unwrap()
+}
+
+fn download_deps_for_package(
+    build_config: &BuildConfig,
+    path: &Path,
+) -> anyhow::Result<Vec<DependencyInfo>> {
+    let path = SourcePackageLayout::try_find_root(path)?;
+    let toml_manifest = parse_toml_manifest(path.join(SourcePackageLayout::Manifest.path()))?;
+    let manifest: SourceManifest = manifest_parser::parse_source_manifest(toml_manifest)?;
+
+    let mut processed_deps: HashSet<String> = HashSet::new();
+    let mut deps_for_pack: Vec<DependencyInfo> = vec![];
+
+    download_dependency_repos(
+        &manifest,
+        &build_config,
+        path,
+        &mut processed_deps,
+        &mut deps_for_pack,
+    )?;
+    return Ok(deps_for_pack);
+}
+
+fn parse_toml_manifest(path: PathBuf) -> anyhow::Result<toml::Value> {
+    let manifest_string = std::fs::read_to_string(path)?;
+    manifest_parser::parse_move_manifest_string(manifest_string)
+}
+
+pub fn download_dependency_repos(
+    manifest: &SourceManifest,
+    build_config: &BuildConfig,
+    root_path: PathBuf,
+    processed_deps: &mut HashSet<String>,
+    deps_for_pack: &mut Vec<DependencyInfo>,
+) -> anyhow::Result<()> {
+    let manifest_name = manifest.package.name.as_str().to_string();
+    if !processed_deps.insert(manifest_name.clone()) {
+        println!("Dependency {} has been processed before", &manifest_name);
+        return Ok(());
+    }
+
+    deps_for_pack.push(DependencyInfo {
+        source_manifest: manifest.clone(),
+        path: root_path.clone(),
+    });
+
+    // include dev dependencies if in dev mode
+    let empty_deps;
+    let additional_deps = if build_config.dev_mode {
+        &manifest.dev_dependencies
+    } else {
+        empty_deps = Dependencies::new();
+        &empty_deps
+    };
+
+    for (dep_name, dep) in manifest.dependencies.iter().chain(additional_deps.iter()) {
+        download_and_update_if_remote(*dep_name, dep, build_config.skip_fetch_latest_git_deps)?;
+        let (dep_manifest, root_path_from_manifest) =
+            parse_package_manifest(dep, dep_name, root_path.clone())
+                .with_context(|| format!("While processing dependency '{}'", *dep_name))?;
+
+        download_dependency_repos(
+            &dep_manifest,
+            build_config,
+            root_path_from_manifest.clone(),
+            processed_deps,
+            deps_for_pack,
+        )?;
+    }
+    Ok(())
+}
+
+fn parse_package_manifest(
+    dep: &Dependency,
+    dep_name: &PackageName,
+    mut root_path: PathBuf,
+) -> Result<(SourceManifest, PathBuf)> {
+    root_path.push(local_path(&dep.kind));
+    let manifest_path = root_path.join(SourcePackageLayout::Manifest.path());
+
+    let contents = fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "Unable to find package manifest for '{}' at {:?}",
+            dep_name, manifest_path,
+        )
+    })?;
+
+    let manifest_toml = parse_move_manifest_string(contents)?;
+    let source_package = parse_source_manifest(manifest_toml)?;
+    Ok((source_package, root_path))
+}
+
+// Note: for full dependency processing see same function in move-package
+fn download_and_update_if_remote(
+    _dep_name: PackageName,
+    dep: &Dependency,
+    _skip_fetch_latest_git_deps: bool,
+) -> Result<()> {
+    match &dep.kind {
+        DependencyKind::Local(_) => Ok(()),
+        _ => Err(anyhow::anyhow!(
+            "Only local dependency allowed in manifest (.toml) file"
+        )),
+    }
+}
+
+// The local location of the repository containing the dependency of kind `kind` (and potentially
+// other, related dependencies).
+fn repository_path(kind: &DependencyKind) -> PathBuf {
+    match kind {
+        DependencyKind::Local(path) => path.clone(),
+
+        // Note: non-local was restricted in `download_and_update_if_remote`,
+        // but we keep the full functionality here, since it is an independent function.
+
+        // Downloaded packages are of the form <sanitized_git_url>_<rev_name>
+        DependencyKind::Git(GitInfo {
+            git_url,
+            git_rev,
+            subdir: _,
+        }) => [
+            &*MOVE_HOME,
+            &format!(
+                "{}_{}",
+                url_to_file_name(git_url.as_str()),
+                git_rev.replace('/', "__"),
+            ),
+        ]
+        .iter()
+        .collect(),
+
+        // Downloaded packages are of the form <sanitized_node_url>_<address>_<package>
+        DependencyKind::Custom(CustomDepInfo {
+            node_url,
+            package_address,
+            package_name,
+            subdir: _,
+        }) => [
+            &*MOVE_HOME,
+            &format!(
+                "{}_{}_{}",
+                url_to_file_name(node_url.as_str()),
+                package_address.as_str(),
+                package_name.as_str(),
+            ),
+        ]
+        .iter()
+        .collect(),
+    }
+}
+
+// The path that the dependency of kind `kind` is found at locally, after it is fetched.
+fn local_path(kind: &DependencyKind) -> PathBuf {
+    let mut repo_path = repository_path(kind);
+
+    if let DependencyKind::Git(GitInfo { subdir, .. })
+    | DependencyKind::Custom(CustomDepInfo { subdir, .. }) = kind
+    {
+        repo_path.push(subdir);
+    }
+
+    repo_path
+}
+
+fn url_to_file_name(url: &str) -> String {
+    regex::Regex::new(r"/|:|\.|@")
+        .unwrap()
+        .replace_all(url, "_")
+        .to_string()
+}
+
+pub fn path_to_string(path: &Path) -> anyhow::Result<String> {
+    match path.to_str() {
+        Some(p) => Ok(p.to_string()),
+        None => Err(anyhow!("non-Unicode file name")),
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/src/package.rs
+++ b/language/tools/move-mv-llvm-compiler/src/package.rs
@@ -105,7 +105,7 @@ pub fn resolve_dependency(
         compiler_dependency,
         account_addresses,
     };
-    return Ok(dep_and_names);
+    Ok(dep_and_names)
 }
 
 use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
@@ -114,7 +114,7 @@ use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXT
 const MODULES_DIR: &str = "sources";
 fn move_dep_files(path: PathBuf) -> Vec<String> {
     let mut dir = path;
-    dir.push(MODULES_DIR.to_string());
+    dir.push(MODULES_DIR);
     find_filenames(&[dir], |p| extension_equals(p, MOVE_EXTENSION)).unwrap()
 }
 
@@ -131,12 +131,12 @@ fn download_deps_for_package(
 
     download_dependency_repos(
         &manifest,
-        &build_config,
+        build_config,
         path,
         &mut processed_deps,
         &mut deps_for_pack,
     )?;
-    return Ok(deps_for_pack);
+    Ok(deps_for_pack)
 }
 
 fn parse_toml_manifest(path: PathBuf) -> anyhow::Result<toml::Value> {

--- a/language/tools/move-mv-llvm-compiler/src/package.rs
+++ b/language/tools/move-mv-llvm-compiler/src/package.rs
@@ -2,21 +2,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::bail;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use move_cli::base::reroot_path;
 use move_command_line_common::env::MOVE_HOME;
 use move_core_types::account_address::AccountAddress;
-use move_symbol_pool::Symbol;
-use regex;
-use std::collections::BTreeMap;
-use std::{
-    collections::HashSet,
-    fs,
-    path::{Path, PathBuf},
-};
-use {
-    move_package::source_package::{
+use move_package::{
+    source_package::{
         layout::SourcePackageLayout,
         manifest_parser,
         manifest_parser::{parse_move_manifest_string, parse_source_manifest},
@@ -25,7 +16,14 @@ use {
             SourceManifest,
         },
     },
-    move_package::{Architecture, BuildConfig},
+    Architecture, BuildConfig,
+};
+use move_symbol_pool::Symbol;
+use regex;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
Added compilation (from .move source) options:
- **-L** - to compile together with all .move files in stdlib. This will also assign numeric address to "std".
- **-p package** - to include **Move.toml** as a manifest in directory **package**. Notice that **-p path_to_stdlib** is equal to simple **-L**. 
-  Keep in mind you may want to use **--dev** or **--test**, since some Move.toml files define numeric addresses only in this case.

Explanation of the algorithm
When processing **-p package** option the **Move.toml** file in **package** directory will be read and each dependency (defined here as relative **path**) will be adjoined to create a directory **dir = package/path**., then all *.move files from **dir** and **dir/sources** will be added as sources to compilation.
Also all statements in the Move manifest like
```Move
"std" = 0x1
``` 
will be treated as assignment of the numeric address. But keep in mind they may be under **test** or **dev** clause.
This algorithm is very likely not a requirement of the Move language, but I see that in many examples of Move.toml the relative paths from the current Move.toml are used.
Another possibility would be to define an environment variable **MOVE_TOML_ROOT** and then define all dependencies relatively to it.

Example:
```
>move-mv-llvm-compiler --compile /tmp/1/build/test_struct/bytecode_modules/M7.move  -p /home/sol/work/git/move/language/extensions/move-table-extension/Move.toml  -S  --test --dev  -o /home/sol/tmp/M7.1


>ll  /home/sol/tmp/M7.1
drwxr-xr-x  2 sol users 4096 Aug  1 05:37 ./
drwxr-xr-x 14 sol users 4096 Aug  1 04:28 ../
-rw-r--r--  1 sol users 2790 Aug  1 05:37 0x100__M7.ll
-rw-r--r--  1 sol users 1250 Aug  1 05:37 0x1__unit_test.ll


>less /home/sol/work/git/move/language/extensions/move-table-extension/Move.toml 
[package]
name = "MoveTableExtension"
version = "1.0.0"

[addresses]
extensions = "_"

[dev-addresses]
std = "0x1"
extensions = "0x2"

[dependencies]
MoveStdlib = { local = "../../move-stdlib" }
MoveNursery = { local = "../../move-stdlib/nursery" }

```

