### PR TITLE
Add stdlib tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ target-out-docker
 **/move-mv-llvm-compiler/**/move-ir-tests/**/*.mv
 **/move-mv-llvm-compiler/**/move-ir-tests/**/*.actual.ll
 **/move-mv-llvm-compiler/**/move-to-llvm-tests/**/*.ll.actual
+**/move-mv-llvm-compiler/**/stdlib-tests/**/*.ll.actual
+**/move-mv-llvm-compiler/**/stdlib-with-p-option-tests/**/*.ll.actual
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.mv
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.o
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.so

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -74,3 +74,12 @@ harness = false
 [[test]]
 name = "move-to-llvm-tests"
 harness = false
+
+[[test]]
+name = "stdlib-tests"
+harness = false
+
+[[test]]
+name = "stdlib-with-p-option-tests"
+harness = false
+

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -82,4 +82,3 @@ harness = false
 [[test]]
 name = "stdlib-with-p-option-tests"
 harness = false
-

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests of compilation from .move to LLVM IR.
+//! Tests of compilation from .move to LLVM IR with resolution against Move stdlib.
 //!
 //! # Usage
 //!
@@ -15,26 +15,26 @@
 //! Running the tests:
 //!
 //! ```
-//! cargo test -p move-mv-llvm-compiler --test move_to_llvm_tests
+//! cargo test -p move-mv-llvm-compiler --test stdlib-tests
 //! ```
 //!
 //! Running a specific test:
 //!
 //! ```
-//! cargo test -p move-mv-llvm-compiler --test move_to_llvm_tests -- struct01.move
+//! cargo test -p move-mv-llvm-compiler --test stdlib-tests -- hash_tests.move
 //! ```
 //!
 //! Promoting all results to expected results:
 //!
 //! ```
-//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test move_to_llvm_tests
+//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test stdlib-tests
 //! ```
 //!
 //! # Details
 //!
 //! They do the following:
 //!
-//! - Create a test for every .move file in move_to_llvm_tests/
+//! - Create a test for every .move file in stdlib-tests/
 //! - Run `move-mv-llvm-compiler` to compile Move source to LLVM IR.
 //! - Compare the actual IR to an existing expected IR.
 //!
@@ -51,7 +51,7 @@ use std::path::Path;
 mod test_common;
 use test_common as tc;
 
-pub const TEST_DIR: &str = "tests/move-to-llvm-tests";
+pub const TEST_DIR: &str = "tests/stdlib-tests";
 
 datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
 
@@ -69,7 +69,15 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    tc::run_move_to_llvm_build(&harness_paths, &test_plan, vec![])?;
+    tc::run_move_to_llvm_build(
+        &harness_paths,
+        &test_plan,
+        vec![
+            &"-L".to_string(),
+            &"--test".to_string(),
+            &"--dev".to_string(),
+        ],
+    )?;
 
     tc::compare_results(&test_plan)?;
 

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash.ll.expected
@@ -1,0 +1,32 @@
+; ModuleID = '0x1__hash'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private void @hash__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+declare { ptr, i64, i64 } @move_native_hash_sha3_256(ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash_tests.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash_tests.ll.expected
@@ -1,0 +1,131 @@
+; ModuleID = '0x1__hash_tests'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@vec_literal = internal constant [3 x i8] c"abc"
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 3, i64 3 }
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal.1 = internal constant [32 x i8] c"\BAx\16\BF\8F\01\CF\EAAA@\DE]\AE\22#\B0\03a\A3\96\17z\9C\B4\10\FFa\F2\00\15\AD"
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 32, i64 32 }
+@vec_literal.3 = internal constant [3 x i8] c"abc"
+@vdesc.4 = internal constant { ptr, i64, i64 } { ptr @vec_literal.3, i64 3, i64 3 }
+@vec_literal.5 = internal constant [32 x i8] c":\98]\A7O\E2%\B2\04\\\17-k\D3\90\BD\85_\08n>\9DR[F\BF\E2E\11C\152"
+@vdesc.6 = internal constant { ptr, i64, i64 } { ptr @vec_literal.5, i64 32, i64 32 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private void @hash_tests__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define private void @hash_tests__sha2_256_expected_hash() {
+entry:
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_hash_sha2_256(ptr %local_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.2)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_1, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_0 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+define private void @hash_tests__sha3_256_expected_hash() {
+entry:
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.4)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_hash_sha3_256(ptr %local_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.6)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_1, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_0 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_hash_sha3_256(ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+declare i1 @move_rt_vec_cmp_eq(ptr nonnull readonly dereferenceable(32), ptr nonnull readonly dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__unit_test.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__unit_test.ll.expected
@@ -1,0 +1,28 @@
+; ModuleID = '0x1__unit_test'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define private void @unit_test__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests.move
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests.move
@@ -1,0 +1,18 @@
+#[test_only]
+module std::hash_tests {
+    use std::hash;
+
+    #[test]
+    fun sha2_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert!(hash::sha2_256(input) == expected_output, 0);
+    }
+
+    #[test]
+    fun sha3_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        assert!(hash::sha3_256(input) == expected_output, 0);
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash.ll.expected
@@ -1,0 +1,32 @@
+; ModuleID = '0x1__hash'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private void @hash__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+declare { ptr, i64, i64 } @move_native_hash_sha3_256(ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash_tests.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash_tests.ll.expected
@@ -1,0 +1,131 @@
+; ModuleID = '0x1__hash_tests'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@vec_literal = internal constant [3 x i8] c"abc"
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 3, i64 3 }
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal.1 = internal constant [32 x i8] c"\BAx\16\BF\8F\01\CF\EAAA@\DE]\AE\22#\B0\03a\A3\96\17z\9C\B4\10\FFa\F2\00\15\AD"
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 32, i64 32 }
+@vec_literal.3 = internal constant [3 x i8] c"abc"
+@vdesc.4 = internal constant { ptr, i64, i64 } { ptr @vec_literal.3, i64 3, i64 3 }
+@vec_literal.5 = internal constant [32 x i8] c":\98]\A7O\E2%\B2\04\\\17-k\D3\90\BD\85_\08n>\9DR[F\BF\E2E\11C\152"
+@vdesc.6 = internal constant { ptr, i64, i64 } { ptr @vec_literal.5, i64 32, i64 32 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define private void @hash_tests__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define private void @hash_tests__sha2_256_expected_hash() {
+entry:
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_hash_sha2_256(ptr %local_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.2)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_1, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_0 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+define private void @hash_tests__sha3_256_expected_hash() {
+entry:
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.4)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_hash_sha3_256(ptr %local_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.6)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_1, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_0 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_hash_sha3_256(ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+declare i1 @move_rt_vec_cmp_eq(ptr nonnull readonly dereferenceable(32), ptr nonnull readonly dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { cold noreturn }

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__unit_test.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__unit_test.ll.expected
@@ -1,0 +1,28 @@
+; ModuleID = '0x1__unit_test'
+source_filename = " This is host specific and removed from comparison "
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define private void @unit_test__unit_test_poison() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests.move
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests.move
@@ -1,0 +1,18 @@
+#[test_only]
+module std::hash_tests {
+    use std::hash;
+
+    #[test]
+    fun sha2_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert!(hash::sha2_256(input) == expected_output, 0);
+    }
+
+    #[test]
+    fun sha3_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        assert!(hash::sha3_256(input) == expected_output, 0);
+    }
+}


### PR DESCRIPTION
Testing **-L** (compile with stdlib) and **-p** (compile with package) options.

Notice that 
option **-p abs-path-to-stdlib** is equal to simple option **-L**. 
