### PR TITLE
Remove -L shortform for stdlib

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/cli.rs
+++ b/language/tools/move-mv-llvm-compiler/src/cli.rs
@@ -40,7 +40,7 @@ pub struct Args {
     pub compile: Option<String>,
 
     /// Use stdlib.
-    #[clap(short = 'L', long = "stdlib")]
+    #[clap(long = "stdlib")]
     pub stdlib: bool,
 
     /// Compile in test mode.

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests.rs
@@ -73,7 +73,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
         &harness_paths,
         &test_plan,
         vec![
-            &"-L".to_string(),
+            &"--stdlib".to_string(),
             &"--test".to_string(),
             &"--dev".to_string(),
         ],


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/move/issues/270