### PR TITLE
Remove cfg attribute for feature that became stable

### DIFF
--- a/language/move-native/src/lib.rs
+++ b/language/move-native/src/lib.rs
@@ -241,9 +241,6 @@
 //! - `move-core-types::value`
 
 #![no_std]
-// NB Solana's Rust seems to allow use of unstable features.
-// This wouldn't normally be allowed.
-#![cfg_attr(feature = "solana", feature(default_alloc_error_handler))]
 
 extern crate alloc;
 


### PR DESCRIPTION
Since we upgraded rust compiler the feature `default_alloc_error_handler` has became stable and doesn't require a cfg attribute to be enabled.