### PR TITLE
ci: get Github Action only reply to the PR comments that start with !

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -28,7 +28,16 @@ jobs:
             echo "pass=1" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/github-script@v6
+      - name: parse command
+        if: ${{ steps.check_auth.outputs.pass == 1 }}
+        id: parse_command
+        run: |
+          body="${{ github.event.comment.body }}"
+          body=${body//[$'\r'$'\n' ]/}
+          echo "command=$body" >> "$GITHUB_OUTPUT"
+
+      - if: startsWith(steps.parse_command.outputs.command, '!')
+        uses: actions/github-script@v6
         with:
           script: |
             github.rest.reactions.createForIssueComment({
@@ -37,14 +46,6 @@ jobs:
               comment_id: ${{ github.event.comment.id }},
               content: 'eyes',
             })
-
-      - name: parse command
-        if: ${{ steps.check_auth.outputs.pass == 1 }}
-        id: parse_command
-        run: |
-          body="${{ github.event.comment.body }}"
-          body=${body//[$'\r'$'\n' ]/}
-          echo "command=$body" >> "$GITHUB_OUTPUT"
 
   help:
     needs: entrypoint


### PR DESCRIPTION
## Motivation

#283 makes Github Action too enthusiastic about replying. I think we only need it to reply to those messages which looks like a command.

## Changes

1. switch `parse command` step and `reply` step
2. add `if: startsWith(steps.parse_command.outputs.command, '!')` to `reply` step