### PR TITLE
ci: add an audit step before the release

### DIFF
--- a/.github/workflows/release_asset.yml
+++ b/.github/workflows/release_asset.yml
@@ -8,8 +8,18 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+
 jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          ./scripts/cargo_audit.sh
+
   build:
+    needs:
+      - audit
     name: Build release asset
     continue-on-error: true
     strategy:

--- a/scripts/cargo_audit.sh
+++ b/scripts/cargo_audit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cargo_audit_ignores=(
+   RUSTSEC-2021-0073
+   RUSTSEC-2021-0072
+   RUSTSEC-2020-0071
+)
+
+cmd="cargo audit"
+
+cmd+="$(printf " --ignore %s" "${cargo_audit_ignores[@]}")"
+
+$cmd


### PR DESCRIPTION
## Motivation

close #269 

## Summary of Changes

- add a script for audit stuff
- add an audit step before we releasing

(when this one get merged, we will be blocked on the audit issue in the next release if we don't fix them first)