### PR TITLE
[WIP] ci: add pr links automatically

### DIFF
--- a/.github/workflows/add-pr-link.yml
+++ b/.github/workflows/add-pr-link.yml
@@ -1,0 +1,23 @@
+name: Add PR Links
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - shell: bash
+        run: |
+          pr_num="${{ github.event.pull_request.number }}"
+          gh pr checkout "$pr_num"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit --allow-empty -m "AUTO-GENERATED (#$pr_num)"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

add pr links automatically

## Test Plan

a demo PR: https://github.com/yihau/solana-move/pull/5

when a PR has been opened, this pipeline will commit a link to the PR.
