### PR TITLE
Add mv2llvm.sh

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tools/mv2llvm.sh
+++ b/language/tools/move-mv-llvm-compiler/tools/mv2llvm.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+### Use this script to run all .mv files in a given directory thru `move-mv-llvm-compiler``.
+###
+### It is particularly convenient in combination with aptos compiler, for example the following line will
+### call aptos move compiler (which supports move iterator, lambda and inline) and compile all files in the directory
+### provided in `--package-dir` and will produce the bytecode (.mv files) in the directory provided in --output-dir:
+### ./aptos move compile --package-dir  /home/sol/work/git/aptos/aptos-core/aptos-move/framework/move-stdlib --output-dir /tmp/aptos-stdlib
+###
+### Then run this script as
+### mv2llvm.sh --dir /tmp/aptos-stdlib/build/MoveStdlib/bytecode_modules --mv2llvm [path to move-mv-llvm-compiler]
+### Look for produced .ll files in the directory `/tmp/aptos-stdlib/build`.
+
+usage() {
+    echo "Usage: $0 --dir [directory with .mv files] --mv2llvm [path to move_mv_llvm_compiler] -arg1 ... --arg_n val_n [extra parameters of compilation]"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dir)
+            shift
+            directory="$1"
+            ;;
+        --mv2llvm)
+            shift
+            move_mv_llvm_compiler="$1"
+            ;;
+        -*)
+            arg_name="${1#-}"  # Remove leading dash
+            shift
+            arg_value="$1"
+            args["$arg_name"]="$arg_value"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$directory" ]] || [[ -z "$move_mv_llvm_compiler" ]]; then
+    usage
+fi
+
+# Remove trailing slash from directory name if exists
+directory="${directory%/}"
+
+# Create the build directory
+build_dir="$directory/build"
+mkdir -p "$build_dir"
+
+# Iterate over files in the directory
+for file in "$directory"/*; do
+    if [ -f "$file" ]; then
+        file_name=$(basename "$file")
+        file_ext="${file_name##*.}"
+
+        # Skip non-mv files
+        if [[ "$file_ext" != "mv" ]]; then
+            continue
+        fi
+
+        # Build arguments for move_mv_llvm_compiler
+        move_mv_llvm_compiler_args=("-b" "$file")
+        for arg_name in "${!args[@]}"; do
+            move_mv_llvm_compiler_args+=("--$arg_name" "${args[$arg_name]}")
+        done
+
+        # Build output file name with .ll extension
+        output_file="$build_dir/${file_name%.mv}.ll"
+
+        # Execute move_mv_llvm_compiler
+        echo ""
+        echo ""
+        echo "Compiling: ${move_mv_llvm_compiler_args[*]} --> $output_file"
+        RUST_BACKTRACE=1 "$move_mv_llvm_compiler" "${move_mv_llvm_compiler_args[@]}" -S -o "$output_file"
+    fi
+done

--- a/language/tools/move-mv-llvm-compiler/tools/mv2llvm.sh
+++ b/language/tools/move-mv-llvm-compiler/tools/mv2llvm.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
+# SPDX-License-Identifier: Apache-2.0
 
 ### Use this script to run all .mv files in a given directory thru `move-mv-llvm-compiler``.
 ###


### PR DESCRIPTION
From script description:
```
### Use this script to run all .mv files in a given directory thru `move-mv-llvm-compiler``.
###
### It is particularly convenient in combination with aptos compiler, for example the following line will
### call aptos move compiler (which supports move iterator, lambda and inline) and compile all files in the directory
### provided in `--package-dir` and will produce the bytecode (.mv files) in the directory provided in --output-dir:
### ./aptos move compile --package-dir  /home/sol/work/git/aptos/aptos-core/aptos-move/framework/move-stdlib --output-dir /tmp/aptos-stdlib
###
### Then run this script as
### mv2llvm.sh --dir /tmp/aptos-stdlib/build/MoveStdlib/bytecode_modules --mv2llvm [path to move-mv-llvm-compiler]
### Look for produced .ll files in the directory `/tmp/aptos-stdlib/build`.
```
In particular I got some results on Aptos stdlib:
```
sol@dev-equinix-new-york-2:~/work/git/aptos/aptos-core/target/debug:main u=$ ll ~/tmp/aptos-stdlib/build/MoveStdlib/bytecode_modules/
total 56
drwxr-xr-x 3 sol users 4096 Aug 22 22:20 ./
drwxr-xr-x 5 sol users 4096 Aug 22 22:09 ../
-rw-r--r-- 1 sol users  454 Aug 22 22:09 acl.mv
-rw-r--r-- 1 sol users   92 Aug 22 22:09 bcs.mv
-rw-r--r-- 1 sol users  817 Aug 22 22:09 bit_vector.mv
drwxr-xr-x 2 sol users 4096 Aug 22 22:20 build/
-rw-r--r-- 1 sol users  626 Aug 22 22:09 error.mv
-rw-r--r-- 1 sol users 2205 Aug 22 22:09 features.mv
-rw-r--r-- 1 sol users  904 Aug 22 22:09 fixed_point32.mv
-rw-r--r-- 1 sol users  106 Aug 22 22:09 hash.mv
-rw-r--r-- 1 sol users 1194 Aug 22 22:09 option.mv
-rw-r--r-- 1 sol users  130 Aug 22 22:09 signer.mv
-rw-r--r-- 1 sol users  923 Aug 22 22:09 string.mv
-rw-r--r-- 1 sol users 1513 Aug 22 22:09 vector.mv
sol@dev-equinix-new-york-2:~/work/git/aptos/aptos-core/target/debug:main u=$ ll ~/tmp/aptos-stdlib/build/MoveStdlib/bytecode_modules/build/
total 80
drwxr-xr-x 2 sol users  4096 Aug 22 22:20 ./
drwxr-xr-x 3 sol users  4096 Aug 22 22:20 ../
-rw-r--r-- 1 sol users   244 Aug 22 22:24 bcs.ll
-rw-r--r-- 1 sol users  9598 Aug 22 22:24 error.ll
-rw-r--r-- 1 sol users 42174 Aug 22 22:24 fixed_point32.ll
-rw-r--r-- 1 sol users   300 Aug 22 22:24 hash.ll
-rw-r--r-- 1 sol users  1038 Aug 22 22:24 signer.ll
-rw-r--r-- 1 sol users   640 Aug 22 22:24 vector.ll
```

Out of 11 .mv inputs move-mv-llvm-compiler successfully processed 6.
5 inputs failed, future analysis is required.
