### PR TITLE
ci: add pr links automatically

### DIFF
--- a/.github/workflows/add-pr-link.yml
+++ b/.github/workflows/add-pr-link.yml
@@ -1,0 +1,36 @@
+name: Add PR Links
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - shell: bash
+        run: |
+          gh pr checkout "$PR_NUMBER"
+
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git commit --allow-empty -m "AUTO GENERATED (#$PR_NUMBER)"
+
+          cat <<'EOF' > /tmp/mv-commit-to-head.sh
+            #!/usr/bin/env bash
+            sed -i '/AUTO GENERATED/!H;/AUTO GENERATED/{x;H};$!d;$x' $1
+          EOF
+          chmod +x /tmp/mv-commit-to-head.sh
+
+          the_first_commit_of_pr=$(gh pr view --json commits "$PR_NUMBER" | jq '.commits[0].oid' | tr -d '"')
+          GIT_SEQUENCE_EDITOR="/tmp/mv-commit-to-head.sh" git rebase -i ${the_first_commit_of_pr}^
+
+          git push -f
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

a improvement for https://github.com/solana-labs/move/issues/51. try to make the process become automatic. this new action will be triggered when someone create a PR. it will 

1. commit a empty change with the PR number.
2. move the commit as the first commit of the PR. (via rebase)
3. push -f

if we don't like it, we can change this process to either
- only append the pr message to the last commit of a PR.
- the same process as this one but happen in the last commit instead of the head commit
- other possibilities ...
<details><summary>Use Cases</summary>

### When a PR has been created
![Screenshot 2023-08-29 at 4 06 06 PM](https://github.com/solana-labs/move/assets/8209234/31dbb263-0984-493e-a650-295ab436f0c3)

### When the action successes
![Screenshot 2023-08-29 at 4 07 09 PM](https://github.com/solana-labs/move/assets/8209234/a0ea3de1-f6e7-4cf3-9659-b5692fcc8590)

the demo PR: https://github.com/yihau/solana-move/pull/27
</details> 
