### PR TITLE
Remove backquotes from comment body in github wf

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -32,8 +32,8 @@ jobs:
         if: ${{ steps.check_auth.outputs.pass == 1 }}
         id: parse_command
         run: |
-          body="${{ github.event.comment.body }}"
-          body=${body//[$'\r'$'\n' ]/}
+          body='${{ github.event.comment.body }}'
+          body=${body//[$'\r'$'\n' $'`']/}
           echo "command=$body" >> "$GITHUB_OUTPUT"
 
       - if: startsWith(steps.parse_command.outputs.command, '!')


### PR DESCRIPTION
The backquotes get expanded in echo command, or more likely before that when variable containing the comment text is assigned, and trigger subshell execution on the content in backquotes. This leads to an error in workflow execution and email report being sent to the author of the comment.
