### PR TITLE
Add Solana test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,6 +4692,7 @@ dependencies = [
  "move-stdlib",
  "move-symbol-pool",
  "move-table-extension",
+ "move-to-solana",
  "move-to-yul",
  "move-vm-runtime",
  "move-vm-test-utils",

--- a/language/solana/examples/unit_test/Move.toml
+++ b/language/solana/examples/unit_test/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "UnitTest"
+version = "1.0.0"
+
+[addresses]
+UnitTest = "0xba31"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib", addr_subst = { "std" = "0x1" } }

--- a/language/solana/examples/unit_test/sources/UnitTest.move
+++ b/language/solana/examples/unit_test/sources/UnitTest.move
@@ -1,0 +1,19 @@
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module UnitTest::UnitTest {
+    use 0x10::debug;
+
+    public entry fun bar(): u64 {
+        let rv = 19;
+        debug::print(&rv);
+        rv
+    }
+
+    #[test]
+    fun test_bar() {
+        let ret = bar();
+        assert!(ret == 19, 0);
+    }
+}

--- a/language/solana/move-to-solana/src/options.rs
+++ b/language/solana/move-to-solana/src/options.rs
@@ -66,9 +66,9 @@ pub struct Options {
     pub move_native_archive: Option<String>,
 
     /// Output file extension. This is used with -c option.
-    /// Each created in compilation module `mod` will be placed into file `mod.ll`
+    /// Each created in compilation module `mod` will be placed into file `mod.o`
     /// by default, or extension may be changed by this option.
-    #[clap(long = "extension", default_value = "ll")]
+    #[clap(long = "extension", default_value = "o")]
     pub output_file_extension: String,
 
     /// Output llvm bitcode in a human readable text format.

--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -486,7 +486,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             }
             sbc::Bytecode::Nop(_) => {}
             _ => {
-                todo!("{instr:?}")
+                let tmp = &self.locals[0];
+                builder.load(tmp.llval.as_any_value(), tmp.llty, "nop");
             }
         }
     }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -75,6 +75,11 @@ harness = false
 required-features = ["evm-backend"]
 
 [[test]]
+name = "move_unit_tests_solana"
+harness = false
+required-features = ["solana-backend"]
+
+[[test]]
 name = "build_testsuite"
 harness = false
 
@@ -84,7 +89,7 @@ harness = false
 required-features = ["evm-backend"]
 
 [features]
-solana-backend = ["move-package/solana-backend"]
+solana-backend = ["move-unit-test/solana-backend", "move-package/solana-backend"]
 evm-backend = ["move-unit-test/evm-backend", "move-package/evm-backend"]
 address20 = ["move-stdlib/address20"]
 address32 = ["move-stdlib/address32"]

--- a/language/tools/move-cli/src/base/test.rs
+++ b/language/tools/move-cli/src/base/test.rs
@@ -82,6 +82,12 @@ pub struct Test {
     #[cfg(feature = "evm-backend")]
     #[structopt(long = "evm")]
     pub evm: bool,
+
+    /// Use the Solana VM.
+    /// Does not work with --stackless.
+    #[cfg(feature = "solana-backend")]
+    #[structopt(long = "solana")]
+    pub solana: bool,
 }
 
 impl Test {
@@ -106,6 +112,8 @@ impl Test {
             compute_coverage,
             #[cfg(feature = "evm-backend")]
             evm,
+            #[cfg(feature = "solana-backend")]
+            solana,
         } = self;
         let unit_test_config = UnitTestingConfig {
             gas_limit,
@@ -119,6 +127,8 @@ impl Test {
             ignore_compile_warnings,
             #[cfg(feature = "evm-backend")]
             evm,
+            #[cfg(feature = "solana-backend")]
+            solana,
 
             ..UnitTestingConfig::default_with_bound(None)
         };

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.solana.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.solana.exp
@@ -1,0 +1,7 @@
+Command `test --solana`:
+INCLUDING DEPENDENCY Bar
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING Foo
+Running Move unit tests
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.solana.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.solana.txt
@@ -1,0 +1,1 @@
+test --solana

--- a/language/tools/move-cli/tests/move_unit_tests_solana.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_solana.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_cli::sandbox::commands::test;
+
+use std::path::{Path, PathBuf};
+
+fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
+    let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
+    test::run_one(
+        args_path,
+        &PathBuf::from(cli_exe),
+        /* use_temp_dir */ use_temp_dir,
+        /* track_cov */ false,
+    )?;
+    Ok(())
+}
+
+// runs all the tests
+datatest_stable::harness!(run_all, "tests/move_unit_tests", r"args\.solana\.txt$");

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -55,5 +55,5 @@ name = "test_runner"
 harness = false
 
 [features]
-solana-backend = ["move-to-solana", "termcolor"]
 evm-backend = ["move-to-yul", "evm-exec-utils", "termcolor", "hex"]
+solana-backend = ["move-to-solana", "termcolor"]

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -35,7 +35,8 @@ move-binary-format = { path = "../../move-binary-format" }
 move-model = { path = "../../move-model" }
 move-stackless-bytecode-interpreter = { path = "../../move-prover/interpreter" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
-
+# Solana dependencies
+move-to-solana = { path = "../../solana/move-to-solana", optional = true }
 # EVM-specific dependencies
 move-to-yul = { path = "../../evm/move-to-yul", optional = true }
 evm-exec-utils = { path = "../../evm/exec-utils", optional = true }
@@ -57,6 +58,7 @@ harness = false
 
 [features]
 evm-backend = ["move-to-yul", "evm-exec-utils", "evm", "primitive-types"]
+solana-backend = ["move-to-solana"]
 table-extension = [
  "move-vm-test-utils/table-extension"
 ]

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -120,6 +120,12 @@ pub struct UnitTestingConfig {
     #[cfg(feature = "evm-backend")]
     #[clap(long = "evm")]
     pub evm: bool,
+
+    /// Use the Solana VM.
+    /// Does not work with --stackless.
+    #[cfg(feature = "solana-backend")]
+    #[clap(long = "solana")]
+    pub solana: bool,
 }
 
 fn format_module_id(module_id: &ModuleId) -> String {
@@ -151,6 +157,9 @@ impl UnitTestingConfig {
 
             #[cfg(feature = "evm-backend")]
             evm: false,
+
+            #[cfg(feature = "solana-backend")]
+            solana: false,
         }
     }
 
@@ -254,6 +263,8 @@ impl UnitTestingConfig {
             self.report_writeset,
             #[cfg(feature = "evm-backend")]
             self.evm,
+            #[cfg(feature = "solana-backend")]
+            self.solana,
         )
         .unwrap();
 

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -51,6 +51,10 @@ pub enum FailureReason {
     // Failed to compile Move code into EVM bytecode.
     #[cfg(feature = "evm-backend")]
     MoveToEVMError(String),
+
+    // Failed to compile Move code into Solana VM bytecode.
+    #[cfg(feature = "solana-backend")]
+    MoveToSolanaError(String),
 }
 
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
@@ -142,6 +146,11 @@ impl FailureReason {
     pub fn move_to_evm_error(diagnostics: String) -> Self {
         FailureReason::MoveToEVMError(diagnostics)
     }
+
+    #[cfg(feature = "solana-backend")]
+    pub fn move_to_solana_error(diagnostics: String) -> Self {
+        FailureReason::MoveToSolanaError(diagnostics)
+    }
 }
 
 impl TestFailure {
@@ -230,6 +239,14 @@ impl TestFailure {
             FailureReason::MoveToEVMError(diagnostics) => {
                 format!(
                     "Failed to compile Move code into EVM bytecode.\n\n{}",
+                    diagnostics
+                )
+            }
+
+            #[cfg(feature = "solana-backend")]
+            FailureReason::MoveToSolanaError(diagnostics) => {
+                format!(
+                    "Failed to compile Move code into Solana VM bytecode.\n\n{}",
                     diagnostics
                 )
             }


### PR DESCRIPTION
This is initial incomplete implementation of move-cli solana test runner. This implementation compiles Move packages in test mode. The compilation of Move unit tests currently breaks the compiler on unit tests of the Move standard library. Even trivial unit tests depend on Move stdlib. It's difficult to implement the actual runner without a complete compilation of even a trivial unit test.

An example of a command to run unit tests

```
LLVM_SYS_150_PREFIX=/path/to/move-dev \
PLATFORM_TOOLS_ROOT=/path/to/platform-tools \
MOVE_NATIVE=/path/to/move/language/move-native \
cargo run -p move-cli --features solana-backend --bin move -- test --solana -p language/solana/examples/unit_test