### PR TITLE
Fix translation of generic structs instantiated with nested struct type parameters

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/Move.toml
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "struct-nested"
+version = "1.0.0"
+
+[addresses]
+struct_nested = "0xdcba"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib", addr_subst = { "std" = "0x1" } }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/input.json
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        9, 0, 0, 0, 0, 0, 0, 0,
+        109, 97, 105, 110, 95, 95, 98, 97, 114]
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/sources/main.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/struct-nested/sources/main.move
@@ -1,0 +1,52 @@
+// input ../input.json
+
+module struct_nested::main {
+    struct Box<T> has copy, drop, store { a: T }
+    struct Box3<T> has copy, drop, store { b: Box<Box<T>> }
+    struct Box7<T> has copy, drop, store { c: Box3<Box3<T>> }
+    struct Box15<T> has copy, drop, store { d: Box7<Box7<T>> }
+    struct Box31<T> has copy, drop, store { e: Box15<Box15<T>> }
+    struct Box63<T> has copy, drop, store { f: Box31<Box31<T>> }
+    struct Box127<T> has copy, drop, store { g: Box63<Box63<T>> }
+
+    fun box3<T>(x: T): Box3<T> {
+        Box3 { b: Box { a: Box { a: x } } }
+    }
+    fun box7<T>(x: T): Box7<T> {
+        Box7 { c: box3(box3(x)) }
+    }
+
+    fun box15<T>(x: T): Box15<T> {
+        Box15 { d: box7(box7(x)) }
+    }
+
+    fun box31<T>(x: T): Box31<T> {
+        Box31 { e: box15(box15(x)) }
+    }
+
+    fun box63<T>(x: T): Box63<T> {
+        Box63 { f: box31(box31(x)) }
+    }
+
+    fun box127<T>(x: T): Box127<T> {
+        Box127 { g: box63(box63(x)) }
+    }
+
+    public entry fun foo() {
+        let _x = box127(true);
+        // compiler front-end crashes on this long sequence of struct field access
+        /*
+        assert!(x.g.f.e.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a
+                     .e.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a
+                   .f.e.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a
+                     .e.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a,
+                0,
+        );
+        */
+    }
+
+    public entry fun bar() {
+        let x = box31(true);
+        assert!(x.e.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a.d.c.b.a.a.b.a.a.c.b.a.a.b.a.a, 0);
+    }
+}


### PR DESCRIPTION
## Motivation

Instantiations of structs like

```
    struct Box<T> has copy, drop, store { x: T }
    struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
    struct Box7<T> has copy, drop, store { x: Box3<Box3<T>> }
    struct Box15<T> has copy, drop, store { x: Box7<Box7<T>> }
    struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
    struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
    struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
```

were not handled correctly. This requires recursive processing of struct instantiations down to the struct that doesn't depend on struct type parameters, and also up again to declare properly all structs in a chain of instantiations. Some instantiations are not found until functions declarations are being generated. This PR changes handling of type parameterized structs to be continued also after function declarations have started being generated by the translator.

Resolves #312 