### PR TITLE
Fix handling of entry functions with void return value by entrypoint

### DIFF
--- a/language/solana/move-to-solana/src/stackless/module_context.rs
+++ b/language/solana/move-to-solana/src/stackless/module_context.rs
@@ -1191,7 +1191,14 @@ impl<'mm, 'up> ModuleContext<'mm, 'up> {
             let ll_fun = self.fn_decls.get(&fn_name).unwrap();
             let params = self.emit_entry_arguments(&fun, &insn_data_ptr, &offset.as_any_value());
             let ret = self.llvm_builder.call(*ll_fun, &params);
-            self.llvm_builder.store(ret, retval);
+            if fun.get_return_count() > 0 {
+                self.llvm_builder.store(ret, retval);
+            } else {
+                self.llvm_builder.store(
+                    llvm::Constant::int(self.llvm_cx.int_type(64), U256::zero()).as_any_value(),
+                    retval,
+                );
+            }
             self.llvm_builder.build_br(exit_bb);
             self.llvm_builder.position_at_end(else_bb);
         }

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/Move.toml
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "void-entry"
+version = "1.0.0"
+
+[addresses]
+void_entry = "0xabcd"

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/input.json
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        9, 0, 0, 0, 0, 0, 0, 0,
+        109, 97, 105, 110, 95, 95, 98, 97, 114]
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/sources/main.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/void-entry/sources/main.move
@@ -1,0 +1,15 @@
+// input ../input.json
+// log 19
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module void_entry::main {
+    use 0x10::debug;
+
+    public entry fun bar() {
+        let rv = 19;
+        debug::print(&rv);
+    }
+}


### PR DESCRIPTION

## Motivation

Solana entrypoint is expected to return a value. For Move entry functions that return no value generate a return code 0.

## Test Plan

Added a runnable test Move package with an entry function returning no value.