### PR TITLE
Add dependency diagnostics

### DIFF
--- a/language/tools/move-mv-llvm-compiler/src/cli.rs
+++ b/language/tools/move-mv-llvm-compiler/src/cli.rs
@@ -84,6 +84,10 @@ pub struct Args {
     /// Path to GraphViz output files (defaults to current working directory).
     #[clap(long = "dot-out-dir", default_value = "")]
     pub dot_file_path: String,
+
+    /// Print more diagnostics in compilation
+    #[clap(long = "diagnostics")]
+    pub diagnostics: bool,
 }
 
 use anyhow::{bail, Result};

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -218,13 +218,22 @@ fn main() -> anyhow::Result<()> {
         );
         let global_cx = GlobalContext::new(&global_env, tgt_platform, &llmachine);
 
-        for mod_id in global_env
+        let modules = global_env
             .get_modules()
             .collect::<Vec<_>>()
             .iter() // now the last is the first - use this in case of deserialization
             .rev()
             .map(|m| m.get_id())
-        {
+            .collect::<Vec<_>>();
+        if args.diagnostics {
+            println!("Order of Modules in compilation");
+            for mod_id in modules.clone() {
+                let module = global_env.get_module(mod_id);
+                let modname = module.llvm_module_name();
+                println!("{}", modname);
+            }
+        }
+        for mod_id in modules {
             let module = global_env.get_module(mod_id);
             let modname = module.llvm_module_name();
             let mut llmod = global_cx.llvm_cx.create_module(&modname);
@@ -234,8 +243,16 @@ fn main() -> anyhow::Result<()> {
                 test_signers: args.test_signers.clone(),
                 ..MoveToSolanaOptions::default()
             };
+            if args.diagnostics {
+                let disasm = module.disassemble();
+                println!("Module {} bytecode {}", modname, disasm);
+            }
             let mod_cx = global_cx.create_module_context(mod_id, &llmod, &options);
             mod_cx.translate();
+            if args.diagnostics {
+                println!("Module {} Solana llvm ir", modname);
+                llmod.dump();
+            }
             if !args.obj {
                 let mut output_file = output_file_path.to_owned();
                 // If '-c' option is set, then -o is the directory to output the compiled modules,

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> anyhow::Result<()> {
                 stdlib,
                 args.dev,
                 args.test,
+                args.diagnostics,
             )?;
         }
 


### PR DESCRIPTION
It is useful for both: compiler development and user debugging.
On option --diagnostics it will produce information about the resolution of dependency set in -p option, also the names, addresses and list of files to compile in the package.
It is an example:

```
Package Dependency Graph pointed by .
ResolutionGraph {
    root_package_path: ".",
    build_options: BuildConfig {
        dev_mode: true,
        test_mode: true,
        generate_docs: false,
        generate_abis: false,
        install_dir: None,
        force_recompilation: false,
        lock_file: None,
        additional_named_addresses: {},
        architecture: Some(
            Move,
        ),
        fetch_deps_only: true,
        skip_fetch_latest_git_deps: true,
        bytecode_version: None,
    },
    root_package: SourceManifest {
        package: PackageInfo {
            name: "my_option_tests",
            version: (
                1,
                5,
                0,
            ),
            authors: [],
            license: None,
            custom_properties: {},
        },
        addresses: Some(
            {
                "std": Some(
                    0x0000000000000000000000000000000000000000000000000000000000000001,
                ),
            },
        ),
        dev_address_assignments: None,
        build: None,
        dependencies: {
            "MoveStdlib": Dependency {
                kind: Local(
                    "../../../move-stdlib/",
                ),
                subst: None,
                version: None,
                digest: None,
            },
        },
        dev_dependencies: {},
    },
    graph: {
        "my_option_tests": [
            (
                "MoveStdlib",
                Outgoing,
            ),
        ],
        "MoveStdlib": [
            (
                "my_option_tests",
                Incoming,
            ),
        ],
    },
    package_table: {
        "MoveStdlib": ResolutionPackage {
            resolution_graph_index: "MoveStdlib",
            source_package: SourceManifest {
                package: PackageInfo {
                    name: "MoveStdlib",
                    version: (
                        1,
                        5,
                        0,
                    ),
                    authors: [],
                    license: None,
                    custom_properties: {},
                },
                addresses: Some(
                    {
                        "std": None,
                    },
                ),
                dev_address_assignments: Some(
                    {
                        "std": 0x0000000000000000000000000000000000000000000000000000000000000001,
                    },
                ),
                build: None,
                dependencies: {},
                dev_dependencies: {},
            },
            package_path: "./../../../move-stdlib/",
            renaming: {},
            resolution_table: {
                "std": 0x0000000000000000000000000000000000000000000000000000000000000001,
            },
            source_digest: "A2FC5BD6D84CA5BEC65DFA3D7FE20E7FB3A29E2AE459B62725CAD8B0252030EB",
        },
        "my_option_tests": ResolutionPackage {
            resolution_graph_index: "my_option_tests",
            source_package: SourceManifest {
                package: PackageInfo {
                    name: "my_option_tests",
                    version: (
                        1,
                        5,
                        0,
                    ),
                    authors: [],
                    license: None,
                    custom_properties: {},
                },
                addresses: Some(
                    {
                        "std": Some(
                            0x0000000000000000000000000000000000000000000000000000000000000001,
                        ),
                    },
                ),
                dev_address_assignments: None,
                build: None,
                dependencies: {
                    "MoveStdlib": Dependency {
                        kind: Local(
                            "../../../move-stdlib/",
                        ),
                        subst: None,
                        version: None,
                        digest: None,
                    },
                },
                dev_dependencies: {},
            },
            package_path: ".",
            renaming: {},
            resolution_table: {
                "std": 0x0000000000000000000000000000000000000000000000000000000000000001,
            },
            source_digest: "8AD9E0DB810A70D670400AC8C50E1D3673D04E595A435946495A50932D869EA8",
        },
    },
}
Dependency and Names
DependencyAndAccountAddress {
    compilation_dependency: [
        "./sources/my_option_tests.move",
        "./../../../move-stdlib/sources/ascii.move",
        "./../../../move-stdlib/sources/vector.move",
        "./../../../move-stdlib/sources/bcs.move",
        "./../../../move-stdlib/sources/type_name.move",
        "./../../../move-stdlib/sources/signer.move",
        "./../../../move-stdlib/sources/unit_test.move",
        "./../../../move-stdlib/sources/fixed_point32.move",
        "./../../../move-stdlib/sources/hash.move",
        "./../../../move-stdlib/sources/error.move",
        "./../../../move-stdlib/sources/bit_vector.move",
        "./../../../move-stdlib/sources/option.move",
        "./../../../move-stdlib/sources/string.move",
    ],
    account_addresses: [
        (
            "std",
            0x0000000000000000000000000000000000000000000000000000000000000001,
        ),
    ],
}
```

