### PR TITLE
Yet another attempt to fix CI handling of comment text

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -32,8 +32,10 @@ jobs:
         if: ${{ steps.check_auth.outputs.pass == 1 }}
         id: parse_command
         run: |
-          body='${{ github.event.comment.body }}'
-          body=${body//[$'\r'$'\n' $'`']/}
+          body=$(cat <<-"EOF" | head -n 1 | sed -e "s#[ \`\(\)\'\"\$]##g"
+          ${{ github.event.comment.body }}
+          EOF
+          )
           echo "command=$body" >> "$GITHUB_OUTPUT"
 
       - if: startsWith(steps.parse_command.outputs.command, '!')


### PR DESCRIPTION
This change attempts to prevent any subcommand expansions when body of a comment is echoed.