### PR TITLE
ci: specify url and ref for add-pr-link push command

### DIFF
--- a/.github/workflows/add-pr-link.yml
+++ b/.github/workflows/add-pr-link.yml
@@ -30,7 +30,7 @@ jobs:
           the_first_commit_of_pr=$(gh pr view --json commits "$PR_NUMBER" | jq '.commits[0].oid' | tr -d '"')
           GIT_SEQUENCE_EDITOR="/tmp/mv-commit-to-head.sh" git rebase -i ${the_first_commit_of_pr}^
 
-          git push -f
+          git push -f ${{ github.event.pull_request.head.repo.clone_url }} HEAD:${{ github.event.pull_request.head.ref }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/move/pull/327#issuecomment-1705333709

when a PR is using the default branch, it will get us confused between base branch name and head branch name.

#### Summary of Changes

specify url and ref for the push command!

demo PRs => https://github.com/yihau/solana-move/pull/28 https://github.com/yihau/solana-move/pull/29