### PR TITLE
ci: extract check logic to an individual job

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -6,11 +6,11 @@ on:
       - created
 
 jobs:
-  entrypoint:
-    if: ${{ github.event.issue.pull_request }}
+  check:
+    if: ${{ github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '!') }}
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.parse_command.outputs.command }}
+      pass: ${{ steps.check_auth.outputs.pass }}
     steps:
       - name: check auth
         id: check_auth
@@ -28,8 +28,14 @@ jobs:
             echo "pass=1" >> "$GITHUB_OUTPUT"
           fi
 
+  entrypoint:
+    needs: check
+    if: ${{ needs.check.outputs.pass == 1 }}
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.parse_command.outputs.command }}
+    steps:
       - name: parse command
-        if: ${{ steps.check_auth.outputs.pass == 1 }}
         id: parse_command
         run: |
           body=$(cat <<-"EOF" | head -n 1 | sed -e "s#[ \`\(\)\'\"\$]##g"
@@ -38,8 +44,7 @@ jobs:
           )
           echo "command=$body" >> "$GITHUB_OUTPUT"
 
-      - if: startsWith(steps.parse_command.outputs.command, '!')
-        uses: actions/github-script@v6
+      - uses: actions/github-script@v6
         with:
           script: |
             github.rest.reactions.createForIssueComment({


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/move/pull/327#issuecomment-1705412044

the action is too active to parse those `comments` instead of `commands`

#### Summary of Changes

add an extract job, check, before entrypoint. it is used to check format and auth

##### demo pr: https://github.com/yihau/solana-move/pull/30
there are 4 comments in the PR. it means there are 4 corresponding actions.

1. https://github.com/yihau/solana-move/actions/runs/6082440542 (skip due to format)
2. https://github.com/yihau/solana-move/actions/runs/6082442835 (skip due to auth)
3. https://github.com/yihau/solana-move/actions/runs/6082443717 (skip due to format)
4. https://github.com/yihau/solana-move/actions/runs/6082444366 (success)

the action only run when 1) the command is using command format and 2) it is created from a qualified user

##### demo issue: https://github.com/yihau/solana-move/issues/31

https://github.com/yihau/solana-move/actions/runs/6082472902 (skip due to it is an issue comment)