### PR TITLE
Fix stdlib unit test that depend on address length and vector representation

### DIFF
--- a/language/move-stdlib/tests/bcs_tests.move
+++ b/language/move-stdlib/tests/bcs_tests.move
@@ -13,7 +13,7 @@ module std::bcs_tests {
     #[test]
     fun bcs_address() {
         let addr = @0x89b9f9d1fadc027cf9532d6f99041522;
-        let expected_output = x"89b9f9d1fadc027cf9532d6f99041522";
+        let expected_output = x"221504996f2d53f97c02dcfad1f9b98900000000000000000000000000000000";
         assert!(bcs::to_bytes(&addr) == expected_output, 0);
     }
 
@@ -62,7 +62,7 @@ module std::bcs_tests {
     #[test]
     fun bcs_vec_u8() {
         let v = x"0f";
-        let expected_output = x"010f";
+        let expected_output = x"010000000f";
         assert!(bcs::to_bytes(&v) == expected_output, 0);
     }
 

--- a/language/move-stdlib/tests/type_name_tests.move
+++ b/language/move-stdlib/tests/type_name_tests.move
@@ -21,27 +21,27 @@ module 0xA::type_name_tests {
         assert!(into_string(get<vector<u8>>()) == string(b"vector<u8>"), 0)
     }
 
-    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
+    // Note: these tests assume a 32 byte address length, and will fail on platforms where addresses are 20 or 16 bytes
     #[test]
     fun test_structs() {
-        assert!(into_string(get<TestStruct>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestStruct"), 0);
-        assert!(into_string(get<std::ascii::String>()) == string(b"00000000000000000000000000000001::ascii::String"), 0);
-        assert!(into_string(get<std::option::Option<u64>>()) == string(b"00000000000000000000000000000001::option::Option<u64>"), 0);
-        assert!(into_string(get<std::string::String>()) == string(b"00000000000000000000000000000001::string::String"), 0);
+        assert!(into_string(get<TestStruct>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestStruct"), 0);
+        assert!(into_string(get<std::ascii::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::ascii::String"), 0);
+        assert!(into_string(get<std::option::Option<u64>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u64>"), 0);
+        assert!(into_string(get<std::string::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::string::String"), 0);
     }
 
-    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
+    // Note: these tests assume a 32 byte address length, and will fail on platforms where addresses are 20 or 16 bytes
     #[test]
     fun test_generics() {
-        assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestGenerics<00000000000000000000000000000001::string::String>"), 0);
-        assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<0000000000000000000000000000000a::type_name_tests::TestGenerics<u64>>"), 0);
-        assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"00000000000000000000000000000001::option::Option<0000000000000000000000000000000a::type_name_tests::TestGenerics<u8>>"), 0);
+        assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<0000000000000000000000000000000000000000000000000000000000000001::string::String>"), 0);
+        assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u64>>"), 0);
+        assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u8>>"), 0);
     }
 
-    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
+    // Note: these tests assume a 32 byte address length, and will fail on platforms where addresses are 20 or 16 bytes
     #[test]
     fun test_multi_generics() {
-        assert!(into_string(get<TestMultiGenerics<bool, u64, u128>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,u64,u128>"), 0);
-        assert!(into_string(get<TestMultiGenerics<bool, vector<u64>, TestGenerics<u128>>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,vector<u64>,0000000000000000000000000000000a::type_name_tests::TestGenerics<u128>>"), 0);
+        assert!(into_string(get<TestMultiGenerics<bool, u64, u128>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,u64,u128>"), 0);
+        assert!(into_string(get<TestMultiGenerics<bool, vector<u64>, TestGenerics<u128>>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,vector<u64>,000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u128>>"), 0);
     }
 }


### PR DESCRIPTION
## Motivation

These Move stdlib unit tests depend on the length of Address, Endianness and Vector value representation.
The expected results in these tests do not match the actual results produced by Move to Solana compiler.

This PR adjusts the expected results to match what is expected on Solana from the operations performed in the tests.

## Test Plan

These are fixes to tests themselves.

Resolves #329
