### PR TITLE
Enable remaining move-cli build tests for Solana backend

### DIFF
--- a/language/tools/move-cli/tests/build_tests/dependency_chain/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/dependency_chain/args.solana.exp
@@ -1,0 +1,2 @@
+Command `build -v --arch solana`:
+COMPILING A, Bar, Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/dependency_chain/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/dependency_chain/args.solana.txt
@@ -1,0 +1,1 @@
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/dev_address/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/dev_address/args.solana.exp
@@ -1,0 +1,2 @@
+Command `build -v -d --arch solana`:
+COMPILING A to SOLANA

--- a/language/tools/move-cli/tests/build_tests/dev_address/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/dev_address/args.solana.txt
@@ -1,0 +1,1 @@
+build -v -d --arch solana

--- a/language/tools/move-cli/tests/build_tests/empty_module_no_deps/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/empty_module_no_deps/args.solana.exp
@@ -1,0 +1,2 @@
+Command `build -v --arch solana`:
+COMPILING A to SOLANA

--- a/language/tools/move-cli/tests/build_tests/empty_module_no_deps/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/empty_module_no_deps/args.solana.txt
@@ -1,0 +1,1 @@
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.solana.exp
@@ -1,0 +1,19 @@
+Command `build -v --arch solana`:
+COMPILING build_include_exclude_stdlib to SOLANA
+Move source code errors Failed to compile Move into SOLANA ERROR
+[0m[1m[38;5;9merror[0m[1m: unbound module[0m
+  [0m[34m┌─[0m ./sources/UseSigner.move:3:7
+  [0m[34m│[0m
+[0m[34m3[0m [0m[34m│[0m   use [0m[31mstd::signer[0m;
+  [0m[34m│[0m       [0m[31m^^^^^^^^^^^[0m [0m[31mInvalid 'use'. Unbound module: '(std=0x1)::signer'[0m
+
+[0m[1m[38;5;9merror[0m[1m: unbound module[0m
+  [0m[34m┌─[0m ./sources/UseSigner.move:6:5
+  [0m[34m│[0m
+[0m[34m6[0m [0m[34m│[0m     [0m[31msigner[0m::address_of(account)
+  [0m[34m│[0m     [0m[31m^^^^^^[0m [0m[31mUnbound module alias 'signer'[0m
+
+
+Error: Move source code errors
+Command `-d -v build --arch solana`:
+COMPILING MoveStdlib, build_include_exclude_stdlib to SOLANA

--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.solana.txt
@@ -1,0 +1,2 @@
+build -v --arch solana
+-d -v build --arch solana

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.solana.exp
@@ -1,0 +1,5 @@
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+External Command `touch sources/Bar.move`:
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.solana.txt
@@ -1,0 +1,3 @@
+build -v --arch solana
+> touch sources/Bar.move
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.solana.exp
@@ -1,0 +1,8 @@
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+External Command `rm build/solana/Foo/0x1__Foo.o`:
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+External Command `rm build/solana/Foo.so`:
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.solana.txt
@@ -1,0 +1,5 @@
+build -v --arch solana
+> rm build/solana/Foo/0x1__Foo.o
+build -v --arch solana
+> rm build/solana/Foo.so
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.solana.exp
@@ -1,0 +1,5 @@
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+External Command `touch Move.toml`:
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.solana.txt
@@ -1,0 +1,3 @@
+build -v --arch solana
+> touch Move.toml
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.solana.exp
@@ -1,0 +1,5 @@
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+External Command `touch sources/Foo.move`:
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.solana.txt
@@ -1,0 +1,3 @@
+build -v --arch solana
+> touch sources/Foo.move
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.solana.exp
@@ -1,0 +1,4 @@
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA
+Command `build -v --arch solana`:
+COMPILING Foo to SOLANA

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.solana.txt
@@ -1,0 +1,2 @@
+build -v --arch solana
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/unbound_address/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_address/args.solana.exp
@@ -1,0 +1,8 @@
+Command `build -v --arch solana`:
+Error: Unresolved addresses found: [
+Named address 'A' in package 'A'
+]
+To fix this, add an entry for each unresolved address to the [addresses] section of ./Move.toml: e.g.,
+[addresses]
+Std = "0x1"
+Alternatively, you can also define [dev-addresses] and call with the -d flag

--- a/language/tools/move-cli/tests/build_tests/unbound_address/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/unbound_address/args.solana.txt
@@ -1,0 +1,1 @@
+build -v --arch solana

--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.solana.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.solana.exp
@@ -1,0 +1,7 @@
+Command `build -v --arch solana`:
+Error: Failed to resolve dependencies for package 'A'
+
+Caused by:
+    0: Parsing manifest for 'Foo'
+    1: Unable to find package manifest for 'Foo' at "./foo/Move.toml"
+    2: No such file or directory (os error 2)

--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.solana.txt
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.solana.txt
@@ -1,0 +1,1 @@
+build -v --arch solana


### PR DESCRIPTION
## Motivation

More testing


## Test Plan

Enabled move-cli build tests for Solana backend.