### PR TITLE
Add an example of Move package with a generic entry function

### DIFF
--- a/language/solana/examples/entry/Move.toml
+++ b/language/solana/examples/entry/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "entry"
+version = "1.0.0"
+
+[addresses]
+entry = "0xeeee"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib", addr_subst = { "std" = "0x1" } }

--- a/language/solana/examples/entry/sources/entry.move
+++ b/language/solana/examples/entry/sources/entry.move
@@ -1,0 +1,24 @@
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module 0xc::token {
+    struct Token has store {
+        owner: address
+    }
+}
+
+module 0xe::entry_bar {
+    use 0x10::debug;
+
+    struct Coin<T> has key {
+        token: T,
+        value: u64,
+    }
+
+    public entry fun bar<T: store>(coin: &Coin<T>): u64 {
+        let rv = coin.value;
+        debug::print(&rv);
+        rv
+    }
+}


### PR DESCRIPTION
## Motivation

Eventually, support for generic entry function will be added. This PR adds a simple example of Move package containing a generic entry function that may be parameterized by a struct type at run-time.

## Test Plan

This PR contains a test of functionality to be added in the future.