### PR TITLE
Print the full command line invocation when test fails

### DIFF
--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -386,7 +386,9 @@ pub fn run_move_build_full(
     let output = cmd.output()?;
     if !output.status.success() {
         anyhow::bail!(
-            "move-build failed. stderr:\n\n{}",
+            "move-build failed.\ncommand:\n\n{:?}\n\nstdout:\n{}\n\nstderr:\n{}",
+            cmd,
+            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
     }
@@ -418,7 +420,9 @@ pub fn run_move_to_llvm_build(
 
     if !output.status.success() {
         anyhow::bail!(
-            "move-build failed. stderr:\n\n{}",
+            "move-llvm-build failed.\ncommand:\n\n{:?}\n\nstdout:\n{}\n\nstderr:\n{}",
+            cmd,
+            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
     }
@@ -447,7 +451,9 @@ pub fn run_move_build_to_solana(
 
     if !output.status.success() {
         anyhow::bail!(
-            "move build failed. stderr:\n\n{}",
+            "move-solana-build failed.\ncommand:\n\n{:?}\n\nstdout:\n{}\n\nstderr:\n{}",
+            cmd,
+            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
     }


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/move/issues/276

Example:
Now this command can be run directly on terminal to iterate fast on the specific test case.

```
Error: move-solana-build failed.
command:

MOVE_NATIVE="/run/media/adityak/tb_half/move/language/tools/move-mv-llvm-compiler/../../../language/move-native" "/run/media/adityak/tb_half/move/target/debug/move" "build" "--arch" "solana" "-p" "/run/media/adityak/tb_half/move/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/basic"

stdout:

stderr:
COMPILING MoveStdlib, basic to SOLANA
Move source code errors Failed to compile Move into SOLANA ERROR
error: unexpected token
  ┌─ ./sources/basic.move:2:1
  │
2 │ asdfas
  │ ^^^^^^ Invalid code unit. Expected 'address', 'module', or 'script'. Got 'asdfas'


Error: Move source code errors
```