### PR TITLE
Update dependency on outdated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4990,9 +4990,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -7931,7 +7931,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 


### PR DESCRIPTION
## Motivation

Rust compiler reports an outdated dependency

```
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
```

This PR resolves the warning by updating the nom crate to a more recent version, compatible with other dependencies.

## Test Plan

The existing tests should pass.