### PR TITLE
Refactor rtty context to include a ref to global env instead module

### DIFF
--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -131,7 +131,7 @@ impl<'up> GlobalContext<'up> {
         llmod: &'this llvm::Module,
         options: &'this Options,
     ) -> ModuleContext<'up, 'this> {
-        let rtty_cx = RttyContext::new(self.env.get_module(id), &self.llvm_cx, llmod);
+        let rtty_cx = RttyContext::new(self.env, &self.llvm_cx, llmod);
         ModuleContext {
             env: self.env.get_module(id),
             llvm_cx: &self.llvm_cx,


### PR DESCRIPTION
## Motivation

`RttyContex` uses module environment only to get a reference to global environment. Instead of constructing an `RttyContext` with a reference to module environment, construct it to include a reference to global environment directly. This eliminates dependency on `ModuleEnv` in `RttyContext` and makes it possible to be used when no `ModuleEnv` exists, for example to generate a completely new LLVM module from scratch without an existing Move Model Module. This is needed to generate entrypoint glue code as a separate LLVM module. 

## Test Plan

Non-functional change, no new tests added.