### PR TITLE
Update symbol naming scheme to avoid long and duplicate names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "cipher 0.2.5",
  "ctr 0.6.0",
  "ghash",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
  "cipher 0.3.0",
  "ctr 0.8.0",
  "polyval 0.5.3",
- "subtle",
+ "subtle 2.4.1",
  "zeroize",
 ]
 
@@ -732,6 +732,21 @@ dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
  "constant_time_eq 0.1.5",
+]
+
+[[package]]
+name = "blake3"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq 0.1.5",
+ "crypto-mac 0.7.0",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -1650,12 +1665,22 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array 0.12.4",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.7",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -1665,7 +1690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array 0.14.7",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -1759,7 +1784,7 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.5.1",
  "serde 1.0.188",
- "subtle",
+ "subtle 2.4.1",
  "zeroize",
 ]
 
@@ -1773,7 +1798,7 @@ dependencies = [
  "digest 0.9.0",
  "fiat-crypto",
  "rand_core 0.6.4",
- "subtle",
+ "subtle 2.4.1",
  "zeroize",
 ]
 
@@ -2025,7 +2050,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -3593,7 +3618,7 @@ checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -4640,6 +4665,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "blake3 0.1.5",
  "bs58 0.5.0",
  "chrono",
  "clap 3.1.8",
@@ -7052,7 +7078,7 @@ version = "1.17.0"
 source = "git+https://github.com/solana-labs/solana?rev=5d1538013206c1afe6f9d3c8a1a870cb0bfa9dcd#5d1538013206c1afe6f9d3c8a1a870cb0bfa9dcd"
 dependencies = [
  "ahash 0.8.3",
- "blake3",
+ "blake3 1.4.1",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
  "bv",
@@ -7071,7 +7097,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "solana-frozen-abi-macro",
- "subtle",
+ "subtle 2.4.1",
  "thiserror",
 ]
 
@@ -7132,7 +7158,7 @@ dependencies = [
  "base64 0.21.3",
  "bincode",
  "bitflags 2.4.0",
- "blake3",
+ "blake3 1.4.1",
  "borsh 0.10.3",
  "borsh 0.9.3",
  "bs58 0.4.0",
@@ -7288,7 +7314,7 @@ dependencies = [
  "sha3 0.9.1",
  "solana-program",
  "solana-sdk",
- "subtle",
+ "subtle 2.4.1",
  "thiserror",
  "zeroize",
 ]
@@ -7423,6 +7449,12 @@ dependencies = [
  "quote 1.0.32",
  "syn 1.0.99",
 ]
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -7931,7 +7963,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -8085,7 +8117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.7",
- "subtle",
+ "subtle 2.4.1",
 ]
 
 [[package]]

--- a/language/solana/move-to-solana/Cargo.toml
+++ b/language/solana/move-to-solana/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 atty = "0.2.14"
+blake3 = "0.1.5"
 bs58 = "0.5.0"
 chrono = "0.4"
 clap = { version = "3.1.8", features = ["derive"] }

--- a/language/solana/move-to-solana/src/stackless/entrypoint.rs
+++ b/language/solana/move-to-solana/src/stackless/entrypoint.rs
@@ -217,7 +217,7 @@ impl<'mm, 'up> EntrypointGenerator<'mm, 'up> {
         // name to the name passed in the instruction_data, and call
         // the matching entry function.
         for fun in entry_functions {
-            let entry = self.generate_global_str_slice(fun.llvm_symbol_name(&[]).as_str());
+            let entry = self.generate_global_str_slice(fun.llvm_symbol_name_entrypoint().as_str());
 
             let func_name_ptr = self.llvm_builder.getelementptr(
                 entry.as_any_value(),

--- a/language/solana/move-to-solana/src/stackless/extensions.rs
+++ b/language/solana/move-to-solana/src/stackless/extensions.rs
@@ -21,17 +21,99 @@ pub impl<'a> ModuleEnvExt for mm::ModuleEnv<'a> {
 #[extension_trait]
 pub impl<'a> FunctionEnvExt for mm::FunctionEnv<'a> {
     fn llvm_symbol_name(&self, tyvec: &[mty::Type]) -> String {
-        let mut name = self.get_full_name_str();
+        let name = self.get_full_name_str();
         if name == "<SELF>::<SELF>" {
             // fixme move-model names script fns "<SELF>".
             // we might want to preserve the actual names
             "main".to_string()
         } else {
-            for ty in tyvec {
-                name += &format!("_{}", ty.display(&self.get_type_display_ctx()))
-            }
-            name.replace([':', '<', '>'], "_").replace(", ", "_")
+            self.llvm_symbol_name_full(tyvec)
         }
+    }
+
+    /// Generate a symbol name that is less than 64 bytes long.
+    ///
+    /// The rbpf VM supports symbol names up to 64 bytes in length
+    /// (defined by SYMBOL_NAME_LENGTH_MAXIMUM within rbpf),
+    /// the last byte of which is 0, so we have 63 bytes to work with.
+    /// We also need to ensure that names are unique with no collisions
+    /// across modules.
+    ///
+    /// The scheme is:
+    ///
+    /// - 16 bytes - The low 8 bytes of the module address, hex encoded.
+    /// -  1 byte  - "_"
+    /// - 15 bytes - The first 15 bytes (or fewer) of the module name.
+    /// -  1 byte  - "_"
+    /// - 15 bytes - The first 15 bytes (or fewer) of the function name.
+    /// -  1 byte  - "_"
+    /// - 14 bytes - The type hash (below).
+    ///
+    /// It sacrifices three bytes to separator characters for readability.
+    ///
+    /// ## The type hash
+    ///
+    /// The type hash attempts to ensure uniqueness. It includes the full
+    /// module address, module name, function name, and type parameters.
+    /// Because there are only N bytes available for the encoded hash, it
+    /// is not particularly strong, but we probably don't need to worry about
+    /// adversarial scenarios with symbol naming. We use base58 encoding to get
+    /// the most bits out of the hash while using only alphanumerics.
+    fn llvm_symbol_name_full(&self, tyvec: &[mty::Type]) -> String {
+        let module_env = &self.module_env;
+        let module_address = module_env.self_address().to_canonical_string();
+        let module_name = module_env
+            .get_name()
+            .display(module_env.symbol_pool())
+            .to_string();
+        let function_name = self.get_name_str();
+        let type_names = tyvec
+            .iter()
+            .map(|ty| ty.display(&self.get_type_display_ctx()).to_string());
+
+        const MODULE_ADDRESS_LEN: usize = 16;
+        const MODULE_NAME_LEN: usize = 15;
+        const FUNCTION_NAME_LEN: usize = 15;
+        const HASH_LEN: usize = 14;
+
+        let formatted_module_address =
+            &module_address[(module_address.len() - MODULE_ADDRESS_LEN)..];
+        let formatted_module_name = &module_name[..MODULE_NAME_LEN.min(module_name.len())];
+        let formatted_function_name = &function_name[..FUNCTION_NAME_LEN.min(function_name.len())];
+
+        let hash: String = {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(module_address.as_bytes());
+            hasher.update(module_name.as_bytes());
+            hasher.update(b"."); // This avoids the ambiguity of sequentially hashing two user-controlled names.
+            hasher.update(function_name.as_bytes());
+
+            // Hash the types. This is just hashing the display names, which will be less
+            // efficient and precise than hashing some kind of type id (perhaps the `TypeTag`).
+            // To guarantee uniqueness these type names probably should have their module address etc.
+            // hashed as well, which wouldn't be necessary if hashing a globally-unique type id.
+            for ty in type_names {
+                hasher.update(b".");
+                hasher.update(ty.as_bytes());
+            }
+
+            let hash = hasher.finalize();
+            let mut hash_base58 = bs58::encode(hash.as_bytes()).into_string();
+            hash_base58.truncate(HASH_LEN);
+            hash_base58
+        };
+
+        let symbol = format!(
+            "{formatted_module_address}_{formatted_module_name}_{formatted_function_name}_{hash}"
+        );
+        assert!(symbol.len() < 64);
+
+        symbol
+    }
+
+    /// Entry points follow their own naming convention
+    fn llvm_symbol_name_entrypoint(&self) -> String {
+        self.get_full_name_str().replace(':', "_")
     }
 
     /// Native functions follow their own naming convention

--- a/language/tools/move-mv-llvm-compiler/tests/cli-tests/basic-coin-build/0x1__signer.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/cli-tests/basic-coin-build/0x1__signer.ll.expected
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define [32 x i8] @signer__address_of(ptr nonnull readonly %0) {
+define [32 x i8] @"0000000000000001_signer_address_of_HobbRqPY4HqJJ6"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/abort-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @Test__test() {
+define private void @"0000000000000100_Test_test_FfymrXLxVKvhRk"() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/acct-address01-build/modules/0_M3.expected.ll
@@ -7,7 +7,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i1 @M3__eq_address([32 x i8] %0, [32 x i8] %1) {
+define i1 @"0000000000000100_M3_eq_address_RDPBXNLr9nyQX8"([32 x i8] %0, [32 x i8] %1) {
 entry:
   %local_0 = alloca [32 x i8], align 1
   %local_1 = alloca [32 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i1 %retval
 }
 
-define [32 x i8] @M3__fixed_address() {
+define [32 x i8] @"0000000000000100_M3_fixed_address_AXsxXXZpHkUKQ3"() {
 entry:
   %local_0 = alloca [32 x i8], align 1
   %0 = load [32 x i8], ptr @acct.addr, align 1
@@ -32,7 +32,7 @@ entry:
   ret [32 x i8] %retval
 }
 
-define i1 @M3__ne_address([32 x i8] %0, [32 x i8] %1) {
+define i1 @"0000000000000100_M3_ne_address_7hMDYRZvi8hjUg"([32 x i8] %0, [32 x i8] %1) {
 entry:
   %local_0 = alloca [32 x i8], align 1
   %local_1 = alloca [32 x i8], align 1
@@ -48,7 +48,7 @@ entry:
   ret i1 %retval
 }
 
-define ptr @M3__ret_address_ref(ptr nonnull readonly %0) {
+define ptr @"0000000000000100_M3_ret_address_ref_mH7xfp9W2TDBYv"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -59,7 +59,7 @@ entry:
   ret ptr %retval
 }
 
-define [32 x i8] @M3__use_address_ref(ptr nonnull readonly %0) {
+define [32 x i8] @"0000000000000100_M3_use_address_ref_9jcTfHHsGoQPVk"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -74,7 +74,7 @@ entry:
   ret [32 x i8] %retval
 }
 
-define [32 x i8] @M3__use_address_val([32 x i8] %0) {
+define [32 x i8] @"0000000000000100_M3_use_address_val_EytLbxU1j6cfLn"([32 x i8] %0) {
 entry:
   %local_0 = alloca [32 x i8], align 1
   %local_1 = alloca [32 x i8], align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/assert-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @Test__test() {
+define private void @"0000000000000100_Test_test_FfymrXLxVKvhRk"() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 10, ptr %local_0, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/bitwise-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i8 @Test__test_and(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_and_DFphxaoqiXYNDV"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -26,7 +26,7 @@ entry:
   ret i8 %retval
 }
 
-define private i8 @Test__test_or(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_or_ABgsHoLgySjeMj"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -47,7 +47,7 @@ entry:
   ret i8 %retval
 }
 
-define private i128 @Test__test_shl128(i128 %0, i8 %1) {
+define private i128 @"0000000000000100_Test_test_shl128_FjsWYtVAK5ZT52"(i128 %0, i8 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i8, align 1
@@ -77,7 +77,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i32 @Test__test_shl32(i32 %0, i8 %1) {
+define private i32 @"0000000000000100_Test_test_shl32_BY8MnnQVbnAiqd"(i32 %0, i8 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i8, align 1
@@ -107,7 +107,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i64 @Test__test_shl64(i64 %0, i8 %1) {
+define private i64 @"0000000000000100_Test_test_shl64_6uBaAfC6RR7X2A"(i64 %0, i8 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1
@@ -137,7 +137,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i8 @Test__test_shl8(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_shl8_GAUo4HFL6n4cUQ"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -166,7 +166,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__test_shr128(i128 %0, i8 %1) {
+define private i128 @"0000000000000100_Test_test_shr128_6Uq2b5WWBuctcq"(i128 %0, i8 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i8, align 1
@@ -196,7 +196,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i32 @Test__test_shr32(i32 %0, i8 %1) {
+define private i32 @"0000000000000100_Test_test_shr32_FpQwVwgHroD4FB"(i32 %0, i8 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i8, align 1
@@ -226,7 +226,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i64 @Test__test_shr64(i64 %0, i8 %1) {
+define private i64 @"0000000000000100_Test_test_shr64_DBFfqGmnEJWtN8"(i64 %0, i8 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1
@@ -256,7 +256,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i8 @Test__test_shr8(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_shr8_5uSFM3pVunbF5g"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -285,7 +285,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i8 @Test__test_xor(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_xor_4csxK8UYp6BVr8"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/call-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i8 @Test__get_sub(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_get_sub_13wN27GrZPghd6"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private void @Test__test() {
+define private void @"0000000000000100_Test_test_FfymrXLxVKvhRk"() {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -48,7 +48,7 @@ entry:
   store i8 3, ptr %local_2, align 1
   %call_arg_0 = load i8, ptr %local_1, align 1
   %call_arg_1 = load i8, ptr %local_2, align 1
-  %retval = call i8 @Test__get_sub(i8 %call_arg_0, i8 %call_arg_1)
+  %retval = call i8 @"0000000000000100_Test_get_sub_13wN27GrZPghd6"(i8 %call_arg_0, i8 %call_arg_1)
   store i8 %retval, ptr %local_3, align 1
   %load_store_tmp = load i8, ptr %local_3, align 1
   store i8 %load_store_tmp, ptr %local_0, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/cast-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i32 @Test__cast_u32(i8 %0) {
+define private i32 @"0000000000000100_Test_cast_u32_HTSGZTK3vZ9o3P"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -20,7 +20,7 @@ entry:
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u64(i8 %0) {
+define private i64 @"0000000000000100_Test_cast_u64_mv2mrQJuzMJGw2"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -35,7 +35,7 @@ entry:
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u8(i32 %0) {
+define private i8 @"0000000000000100_Test_cast_u8_AvxxS7Jvff27Kr"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/casting-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i128 @Test__cast_u128_as_u128(i128 %0) {
+define private i128 @"0000000000000100_Test_cast_u128_as_u1_EosMbgKgb89mtR"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -19,7 +19,7 @@ entry:
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u128_as_u16(i128 %0) {
+define private i16 @"0000000000000100_Test_cast_u128_as_u1_DKvxE3D2MTsJDM"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -42,7 +42,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u128_as_u256(i128 %0) {
+define private i256 @"0000000000000100_Test_cast_u128_as_u2_3USaYBXhLMZNZi"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -57,7 +57,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u128_as_u32(i128 %0) {
+define private i32 @"0000000000000100_Test_cast_u128_as_u3_FZpzfHEvyFzXAF"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -80,7 +80,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u128_as_u64(i128 %0) {
+define private i64 @"0000000000000100_Test_cast_u128_as_u6_GxMXTS12zJWHeE"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -103,7 +103,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u128_as_u8(i128 %0) {
+define private i8 @"0000000000000100_Test_cast_u128_as_u8_3Kanynuh6xkmq4"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -126,7 +126,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__cast_u16_as_u128(i16 %0) {
+define private i128 @"0000000000000100_Test_cast_u16_as_u12_48vvYCk9oyAVii"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -141,7 +141,7 @@ entry:
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u16_as_u16(i16 %0) {
+define private i16 @"0000000000000100_Test_cast_u16_as_u16_Ggg6LSEKHK9isj"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -155,7 +155,7 @@ entry:
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u16_as_u256(i16 %0) {
+define private i256 @"0000000000000100_Test_cast_u16_as_u25_5f1LCGcZBMnPmg"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -170,7 +170,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u16_as_u32(i16 %0) {
+define private i32 @"0000000000000100_Test_cast_u16_as_u32_HskuQVc3bds5ee"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -185,7 +185,7 @@ entry:
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u16_as_u64(i16 %0) {
+define private i64 @"0000000000000100_Test_cast_u16_as_u64_5o1aSw6vxP18zv"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -200,7 +200,7 @@ entry:
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u16_as_u8(i16 %0) {
+define private i8 @"0000000000000100_Test_cast_u16_as_u8_E6h4ahDP7DeDTS"(i16 %0) {
 entry:
   %local_0 = alloca i16, align 2
   %local_1 = alloca i16, align 2
@@ -223,7 +223,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__cast_u256_as_u128(i256 %0) {
+define private i128 @"0000000000000100_Test_cast_u256_as_u1_H1vE9mLtb7F11J"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -246,7 +246,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u256_as_u16(i256 %0) {
+define private i16 @"0000000000000100_Test_cast_u256_as_u1_2VpzeTuQbUiRFz"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -269,7 +269,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u256_as_u256(i256 %0) {
+define private i256 @"0000000000000100_Test_cast_u256_as_u2_J6eBUVWyksaSbN"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -283,7 +283,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u256_as_u32(i256 %0) {
+define private i32 @"0000000000000100_Test_cast_u256_as_u3_H67HkVhmACKjFV"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -306,7 +306,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u256_as_u64(i256 %0) {
+define private i64 @"0000000000000100_Test_cast_u256_as_u6_9ShSGoBZXMB5rk"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -329,7 +329,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u256_as_u8(i256 %0) {
+define private i8 @"0000000000000100_Test_cast_u256_as_u8_83PatQdaFB94BM"(i256 %0) {
 entry:
   %local_0 = alloca i256, align 8
   %local_1 = alloca i256, align 8
@@ -352,7 +352,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__cast_u32_as_u128(i32 %0) {
+define private i128 @"0000000000000100_Test_cast_u32_as_u12_12PvDPRobNZEgk"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -367,7 +367,7 @@ entry:
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u32_as_u16(i32 %0) {
+define private i16 @"0000000000000100_Test_cast_u32_as_u16_6omAdQfymrkdLg"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -390,7 +390,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u32_as_u256(i32 %0) {
+define private i256 @"0000000000000100_Test_cast_u32_as_u25_B1Usr4HNUQpNGW"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -405,7 +405,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u32_as_u32(i32 %0) {
+define private i32 @"0000000000000100_Test_cast_u32_as_u32_EcgAh6KgPGSVQF"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -419,7 +419,7 @@ entry:
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u32_as_u64(i32 %0) {
+define private i64 @"0000000000000100_Test_cast_u32_as_u64_5cLe7X4v97JAod"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -434,7 +434,7 @@ entry:
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u32_as_u8(i32 %0) {
+define private i8 @"0000000000000100_Test_cast_u32_as_u8_621Fe4uwzZKLc6"(i32 %0) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -457,7 +457,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__cast_u64_as_u128(i64 %0) {
+define private i128 @"0000000000000100_Test_cast_u64_as_u12_Cr9Fp8Rz9e9Lug"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -472,7 +472,7 @@ entry:
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u64_as_u16(i64 %0) {
+define private i16 @"0000000000000100_Test_cast_u64_as_u16_2v27U4cWf4GFgB"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -495,7 +495,7 @@ join_bb:                                          ; preds = %entry
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u64_as_u256(i64 %0) {
+define private i256 @"0000000000000100_Test_cast_u64_as_u25_J7dXGFVM1ke1d7"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -510,7 +510,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u64_as_u32(i64 %0) {
+define private i32 @"0000000000000100_Test_cast_u64_as_u32_3ufnzwj8S12nP2"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -533,7 +533,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u64_as_u64(i64 %0) {
+define private i64 @"0000000000000100_Test_cast_u64_as_u64_5J4YBxzZDqdXD1"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -547,7 +547,7 @@ entry:
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u64_as_u8(i64 %0) {
+define private i8 @"0000000000000100_Test_cast_u64_as_u8_ALyQoFsJdn41Vd"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -570,7 +570,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i128 @Test__cast_u8_as_u128(i8 %0) {
+define private i128 @"0000000000000100_Test_cast_u8_as_u128_AJCCPEsVkgqCDf"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -585,7 +585,7 @@ entry:
   ret i128 %retval
 }
 
-define private i16 @Test__cast_u8_as_u16(i8 %0) {
+define private i16 @"0000000000000100_Test_cast_u8_as_u16_5LHZStPc9X5SB5"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -600,7 +600,7 @@ entry:
   ret i16 %retval
 }
 
-define private i256 @Test__cast_u8_as_u256(i8 %0) {
+define private i256 @"0000000000000100_Test_cast_u8_as_u256_Fm3PeifTodqbt5"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -615,7 +615,7 @@ entry:
   ret i256 %retval
 }
 
-define private i32 @Test__cast_u8_as_u32(i8 %0) {
+define private i32 @"0000000000000100_Test_cast_u8_as_u32_3t63QaPFCJ5VRw"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -630,7 +630,7 @@ entry:
   ret i32 %retval
 }
 
-define private i64 @Test__cast_u8_as_u64(i8 %0) {
+define private i64 @"0000000000000100_Test_cast_u8_as_u64_GVubcyHxLKmAwn"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -645,7 +645,7 @@ entry:
   ret i64 %retval
 }
 
-define private i8 @Test__cast_u8_as_u8(i8 %0) {
+define private i8 @"0000000000000100_Test_cast_u8_as_u8_CHTbdKkdKa7gKZ"(i8 %0) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/const_u128-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i128 @Test__takes_u128(i128 %0) {
+define private i128 @"0000000000000100_Test_takes_u128_CfVBECU94wasNh"(i128 %0) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -16,7 +16,7 @@ entry:
   ret i128 %retval
 }
 
-define private i128 @Test__test_const_u128() {
+define private i128 @"0000000000000100_Test_test_const_u128_4QDEWdNs8j9Apg"() {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -28,19 +28,19 @@ entry:
   %local_7 = alloca i128, align 8
   store i128 7, ptr %local_0, align 8
   %call_arg_0 = load i128, ptr %local_0, align 8
-  %retval = call i128 @Test__takes_u128(i128 %call_arg_0)
+  %retval = call i128 @"0000000000000100_Test_takes_u128_CfVBECU94wasNh"(i128 %call_arg_0)
   store i128 %retval, ptr %local_1, align 8
   store i128 4294967296, ptr %local_2, align 8
   %call_arg_01 = load i128, ptr %local_2, align 8
-  %retval2 = call i128 @Test__takes_u128(i128 %call_arg_01)
+  %retval2 = call i128 @"0000000000000100_Test_takes_u128_CfVBECU94wasNh"(i128 %call_arg_01)
   store i128 %retval2, ptr %local_3, align 8
   store i128 18446744073709551616, ptr %local_4, align 8
   %call_arg_03 = load i128, ptr %local_4, align 8
-  %retval4 = call i128 @Test__takes_u128(i128 %call_arg_03)
+  %retval4 = call i128 @"0000000000000100_Test_takes_u128_CfVBECU94wasNh"(i128 %call_arg_03)
   store i128 %retval4, ptr %local_5, align 8
   store i128 -170141183460469231731687303715884105728, ptr %local_6, align 8
   %call_arg_05 = load i128, ptr %local_6, align 8
-  %retval6 = call i128 @Test__takes_u128(i128 %call_arg_05)
+  %retval6 = call i128 @"0000000000000100_Test_takes_u128_CfVBECU94wasNh"(i128 %call_arg_05)
   store i128 %retval6, ptr %local_7, align 8
   %retval7 = load i128, ptr %local_7, align 8
   ret i128 %retval7

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/continue-build/modules/0_m.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/continue-build/modules/0_m.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define void @m__a() {
+define void @"0000000000000042_m_a_57P3fP7Rqn6AaT"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -96,7 +96,7 @@ join_bb7:                                         ; preds = %bb_3
   store i64 %add_dst, ptr %local_14, align 8
   %load_store_tmp8 = load i64, ptr %local_14, align 8
   store i64 %load_store_tmp8, ptr %local_0, align 8
-  call void @m__bar()
+  call void @"0000000000000042_m_bar_4HsAdEmqY5xWAy"()
   br label %bb_6
 
 bb_5:                                             ; preds = %bb_4
@@ -140,11 +140,11 @@ join_bb24:                                        ; preds = %join_bb16
 bb_0:                                             ; preds = %bb_6
   store ptr %local_1, ptr %local_21, align 8
   %call_arg_0 = load ptr, ptr %local_21, align 8
-  call void @m__foo(ptr %call_arg_0)
+  call void @"0000000000000042_m_foo_372CFZN6eJ9KQL"(ptr %call_arg_0)
   ret void
 }
 
-define void @m__bar() {
+define void @"0000000000000042_m_bar_4HsAdEmqY5xWAy"() {
 entry:
   %local_0 = alloca i64, align 8
   store i64 0, ptr %local_0, align 8
@@ -153,7 +153,7 @@ entry:
   unreachable
 }
 
-define void @m__foo(ptr nonnull readonly %0) {
+define void @"0000000000000042_m_foo_372CFZN6eJ9KQL"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/eq-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i1 @Test__test(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_FfymrXLxVKvhRk"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g01-build/modules/0_M2.expected.ll
@@ -7,7 +7,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define %struct.M2__Coin_M2__Currency1_ @M2__mint_concrete(i64 %0) {
+define %struct.M2__Coin_M2__Currency1_ @"0000000000000100_M2_mint_concrete_CK5nnKkU3LG9QT"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/g02-build/modules/0_M6.expected.ll
@@ -13,7 +13,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i1 @M6__boo() {
+define private i1 @"0000000000000100_M6_boo_FoY7muUhpv8nVr"() {
 entry:
   %local_0__x = alloca i1, align 1
   %local_1 = alloca %struct.M6__Foo_bool_, align 8
@@ -29,7 +29,7 @@ entry:
   ret i1 %retval
 }
 
-define private { i8, i64 } @M6__goo() {
+define private { i8, i64 } @"0000000000000100_M6_goo_5FCtwPiBP7YsUN"() {
 entry:
   %local_0__x = alloca i8, align 1
   %local_1__y = alloca i64, align 8
@@ -55,7 +55,7 @@ entry:
   ret { i8, i64 } %insert_12
 }
 
-define private i32 @M6__rcv_and_idx(%struct.M6__Baz_address.u32_ %0) {
+define private i32 @"0000000000000100_M6_rcv_and_idx_FwErx2TZaeG1AK"(%struct.M6__Baz_address.u32_ %0) {
 entry:
   %local_0 = alloca %struct.M6__Baz_address.u32_, align 8
   %local_1 = alloca ptr, align 8
@@ -77,7 +77,7 @@ entry:
   ret i32 %retval
 }
 
-define private %struct.M6__Foo_u16_ @M6__snd_rcv(%struct.M6__Foo_u16_ %0) {
+define private %struct.M6__Foo_u16_ @"0000000000000100_M6_snd_rcv_A3p5ByHS3F11Y9"(%struct.M6__Foo_u16_ %0) {
 entry:
   %local_0 = alloca %struct.M6__Foo_u16_, align 8
   %local_1 = alloca %struct.M6__Foo_u16_, align 8
@@ -86,7 +86,7 @@ entry:
   ret %struct.M6__Foo_u16_ %retval
 }
 
-define private { i8, i64 } @M6__zoo() {
+define private { i8, i64 } @"0000000000000100_M6_zoo_5hjWgvSKxHmhsy"() {
 entry:
   %local_0 = alloca %struct.M6__Foo_u64_, align 8
   %local_1__x = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func01-build/modules/0_M2.expected.ll
@@ -8,19 +8,19 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private %struct.M2__Coin_M2__Bitcoin_ @M2__call_mint_generic() {
+define private %struct.M2__Coin_M2__Bitcoin_ @"0000000000000100_M2_call_mint_gener_HTsEQGGmgPyUAU"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %struct.M2__Coin_M2__Bitcoin_, align 8
   store i64 4, ptr %local_0, align 8
   %call_arg_0 = load i64, ptr %local_0, align 8
-  %retval = call %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %call_arg_0)
+  %retval = call %struct.M2__Coin_M2__Bitcoin_ @"0000000000000100_M2_mint_generic_8d7Fo6wG2thH9y"(i64 %call_arg_0)
   store %struct.M2__Coin_M2__Bitcoin_ %retval, ptr %local_1, align 8
   %retval1 = load %struct.M2__Coin_M2__Bitcoin_, ptr %local_1, align 8
   ret %struct.M2__Coin_M2__Bitcoin_ %retval1
 }
 
-define private %struct.M2__Coin_M2__Bitcoin_ @M2__mint_generic_M2__Bitcoin(i64 %0) {
+define private %struct.M2__Coin_M2__Bitcoin_ @"0000000000000100_M2_mint_generic_8d7Fo6wG2thH9y"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8
@@ -35,7 +35,7 @@ entry:
   ret %struct.M2__Coin_M2__Bitcoin_ %retval
 }
 
-define %struct.M2__Coin_M2__Sol_ @M2__mint_concrete(i64 %0) {
+define %struct.M2__Coin_M2__Sol_ @"0000000000000100_M2_mint_concrete_CK5nnKkU3LG9QT"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/generic-func02-build/modules/1_M11.expected.ll
@@ -8,20 +8,20 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i64 @M11__get_value_usdc(%struct.Coins__Coin_M11__USDC_ %0) {
+define private i64 @"0000000000000200_M11_get_value_usdc_Csv35CynoWwEgY"(%struct.Coins__Coin_M11__USDC_ %0) {
 entry:
   %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_2 = alloca i64, align 8
   store %struct.Coins__Coin_M11__USDC_ %0, ptr %local_0, align 8
   %call_arg_0 = load %struct.Coins__Coin_M11__USDC_, ptr %local_0, align 8
-  %retval = call i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %call_arg_0)
+  %retval = call i64 @"0000000000000100_Coins_get_value_gener_37G3KF88HbT289"(%struct.Coins__Coin_M11__USDC_ %call_arg_0)
   store i64 %retval, ptr %local_2, align 8
   %retval1 = load i64, ptr %local_2, align 8
   ret i64 %retval1
 }
 
-define private i64 @Coins__get_value_generic_M11__USDC(%struct.Coins__Coin_M11__USDC_ %0) {
+define private i64 @"0000000000000100_Coins_get_value_gener_37G3KF88HbT289"(%struct.Coins__Coin_M11__USDC_ %0) {
 entry:
   %local_0 = alloca %struct.Coins__Coin_M11__USDC_, align 8
   %local_1 = alloca %struct.Coins__Coin_M11__USDC_, align 8
@@ -34,7 +34,7 @@ entry:
   ret i64 %retval
 }
 
-define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @M11__mint_2coins_usdc_and_eth(i64 %0, i64 %1) {
+define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @"0000000000000200_M11_mint_2coins_usd_HXHCeMeLgQCrzR"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -50,7 +50,7 @@ entry:
   store i64 %load_store_tmp1, ptr %local_3, align 8
   %call_arg_0 = load i64, ptr %local_2, align 8
   %call_arg_1 = load i64, ptr %local_3, align 8
-  %retval = call { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %call_arg_0, i64 %call_arg_1)
+  %retval = call { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @"0000000000000100_Coins_mint_2coins_gen_AtMhpFnbmM1Mqk"(i64 %call_arg_0, i64 %call_arg_1)
   %extract_0 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 0
   %extract_1 = extractvalue { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %retval, 1
   store %struct.Coins__Coin_M11__USDC_ %extract_0, ptr %local_4, align 8
@@ -62,7 +62,7 @@ entry:
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
 }
 
-define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @Coins__mint_2coins_generic_M11__USDC_M11__Eth(i64 %0, i64 %1) {
+define private { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } @"0000000000000100_Coins_mint_2coins_gen_AtMhpFnbmM1Mqk"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -89,7 +89,7 @@ entry:
   ret { %struct.Coins__Coin_M11__USDC_, %struct.Coins__Coin_M11__Eth_ } %insert_1
 }
 
-define private %struct.Coins__Coin_M11__USDC_ @M11__mint_usdc(i64 %0) {
+define private %struct.Coins__Coin_M11__USDC_ @"0000000000000200_M11_mint_usdc_GzVxdamAz5sawd"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -98,13 +98,13 @@ entry:
   %load_store_tmp = load i64, ptr %local_0, align 8
   store i64 %load_store_tmp, ptr %local_1, align 8
   %call_arg_0 = load i64, ptr %local_1, align 8
-  %retval = call %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %call_arg_0)
+  %retval = call %struct.Coins__Coin_M11__USDC_ @"0000000000000100_Coins_mint_generic_GQxHvvaJwHZeyU"(i64 %call_arg_0)
   store %struct.Coins__Coin_M11__USDC_ %retval, ptr %local_2, align 8
   %retval1 = load %struct.Coins__Coin_M11__USDC_, ptr %local_2, align 8
   ret %struct.Coins__Coin_M11__USDC_ %retval1
 }
 
-define private %struct.Coins__Coin_M11__USDC_ @Coins__mint_generic_M11__USDC(i64 %0) {
+define private %struct.Coins__Coin_M11__USDC_ @"0000000000000100_Coins_mint_generic_GQxHvvaJwHZeyU"(i64 %0) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1__value = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/if-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i8 @Test__test(i1 %0) {
+define private i8 @"0000000000000100_Test_test_FfymrXLxVKvhRk"(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/logical-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i1 @Test__test_eq(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_eq_366ARFPhMmSyMo"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -26,7 +26,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_ge(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_ge_DBZC95vesA1jRq"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -47,7 +47,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_gt(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_gt_GWoUX26svUrHhF"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -68,7 +68,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_le(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_le_6NcbrgwUewLK7C"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -89,7 +89,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_logical_and(i1 %0, i1 %1) {
+define private i1 @"0000000000000100_Test_test_logical_an_F8HzjVXWKzWQ5R"(i1 %0, i1 %1) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -110,7 +110,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_logical_or(i1 %0, i1 %1) {
+define private i1 @"0000000000000100_Test_test_logical_or_FAfaDF74bG3FMx"(i1 %0, i1 %1) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -131,7 +131,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_lt(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_lt_BeVM6AhDEfWHuC"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -152,7 +152,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_ne(i8 %0, i8 %1) {
+define private i1 @"0000000000000100_Test_test_ne_CsXpo6DAyKaoT7"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -173,7 +173,7 @@ entry:
   ret i1 %retval
 }
 
-define private i1 @Test__test_not(i1 %0) {
+define private i1 @"0000000000000100_Test_test_not_BhbbUQKrv3NaSc"(i1 %0) {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i128 @Test__test(i128 %0, i128 %1) {
+define private i128 @"0000000000000100_Test_test_FfymrXLxVKvhRk"(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i128 @Test__test_div(i128 %0, i128 %1) {
+define private i128 @"0000000000000100_Test_test_div_CsfLhW9PqfGaCK"(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -63,7 +63,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i128 @Test__test_mod(i128 %0, i128 %1) {
+define private i128 @"0000000000000100_Test_test_mod_9cvjdgT4bUtsBt"(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -92,7 +92,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i128 @Test__test_mul(i128 %0, i128 %1) {
+define private i128 @"0000000000000100_Test_test_mul_BctFaeLnecF8Gw"(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8
@@ -122,7 +122,7 @@ join_bb:                                          ; preds = %entry
   ret i128 %retval
 }
 
-define private i128 @Test__test_sub(i128 %0, i128 %1) {
+define private i128 @"0000000000000100_Test_test_sub_GYyxTcZpGoiPQz"(i128 %0, i128 %1) {
 entry:
   %local_0 = alloca i128, align 8
   %local_1 = alloca i128, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i32 @Test__test(i32 %0, i32 %1) {
+define private i32 @"0000000000000100_Test_test_FfymrXLxVKvhRk"(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i32 @Test__test_div(i32 %0, i32 %1) {
+define private i32 @"0000000000000100_Test_test_div_CsfLhW9PqfGaCK"(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -63,7 +63,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i32 @Test__test_mul_trunc(i32 %0, i32 %1) {
+define private i32 @"0000000000000100_Test_test_mul_trunc_9cVsZJF8wDCbrp"(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4
@@ -93,7 +93,7 @@ join_bb:                                          ; preds = %entry
   ret i32 %retval
 }
 
-define private i32 @Test__test_sub(i32 %0, i32 %1) {
+define private i32 @"0000000000000100_Test_test_sub_GYyxTcZpGoiPQz"(i32 %0, i32 %1) {
 entry:
   %local_0 = alloca i32, align 4
   %local_1 = alloca i32, align 4

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i64 @Test__test(i64 %0, i64 %1) {
+define private i64 @"0000000000000100_Test_test_FfymrXLxVKvhRk"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i64 @Test__test_div(i64 %0, i64 %1) {
+define private i64 @"0000000000000100_Test_test_div_CsfLhW9PqfGaCK"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -63,7 +63,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i64 @Test__test_mul(i64 %0, i64 %1) {
+define private i64 @"0000000000000100_Test_test_mul_BctFaeLnecF8Gw"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
@@ -93,7 +93,7 @@ join_bb:                                          ; preds = %entry
   ret i64 %retval
 }
 
-define private i64 @Test__test_sub(i64 %0, i64 %1) {
+define private i64 @"0000000000000100_Test_test_sub_GYyxTcZpGoiPQz"(i64 %0, i64 %1) {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i8 @Test__test_add(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_add_4oCr6Z6trEYRw5"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -34,7 +34,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i8 @Test__test_div(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_div_CsfLhW9PqfGaCK"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -63,7 +63,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i8 @Test__test_mod(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_mod_9cvjdgT4bUtsBt"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -92,7 +92,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i8 @Test__test_mul(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_mul_BctFaeLnecF8Gw"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -122,7 +122,7 @@ join_bb:                                          ; preds = %entry
   ret i8 %retval
 }
 
-define private i8 @Test__test_sub(i8 %0, i8 %1) {
+define private i8 @"0000000000000100_Test_test_sub_GYyxTcZpGoiPQz"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/0_Test2.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test2__test2(i8 %0, i8 %1) {
+define i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/modules/1_Test1.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test1__test1(i8 %0, i8 %1) {
+define i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -20,10 +20,10 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %call_arg_0 = load i8, ptr %local_2, align 1
   %call_arg_1 = load i8, ptr %local_3, align 1
-  %retval = call i8 @Test2__test2(i8 %call_arg_0, i8 %call_arg_1)
+  %retval = call i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8 %call_arg_0, i8 %call_arg_1)
   store i8 %retval, ptr %local_4, align 1
   %retval2 = load i8, ptr %local_4, align 1
   ret i8 %retval2
 }
 
-declare i8 @Test2__test2(i8, i8)
+declare i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multi-module-build/scripts/main.expected.ll
@@ -14,9 +14,9 @@ entry:
   store i8 2, ptr %local_1, align 1
   %call_arg_0 = load i8, ptr %local_0, align 1
   %call_arg_1 = load i8, ptr %local_1, align 1
-  %retval = call i8 @Test1__test1(i8 %call_arg_0, i8 %call_arg_1)
+  %retval = call i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8 %call_arg_0, i8 %call_arg_1)
   store i8 %retval, ptr %local_2, align 1
   ret void
 }
 
-declare i8 @Test1__test1(i8, i8)
+declare i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/multiple-return-vals-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private { i1, i1 } @Test__ret_2vals() {
+define private { i1, i1 } @"0000000000000100_Test_ret_2vals_4CuQa8nupbuFDS"() {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
@@ -18,7 +18,7 @@ entry:
   ret { i1, i1 } %insert_1
 }
 
-define private { ptr, i8, i128, i32 } @Test__ret_4vals(ptr nonnull readonly %0) {
+define private { ptr, i8, i128, i32 } @"0000000000000100_Test_ret_4vals_DQQWrrMFWmFYXx"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -42,12 +42,12 @@ entry:
   ret { ptr, i8, i128, i32 } %insert_3
 }
 
-define private void @Test__use_2val_call_result() {
+define private void @"0000000000000100_Test_use_2val_call_r_8Cw8LwSQv9c8vG"() {
 entry:
   %local_0 = alloca i1, align 1
   %local_1 = alloca i1, align 1
   %local_2 = alloca i1, align 1
-  %retval = call { i1, i1 } @Test__ret_2vals()
+  %retval = call { i1, i1 } @"0000000000000100_Test_ret_2vals_4CuQa8nupbuFDS"()
   %extract_0 = extractvalue { i1, i1 } %retval, 0
   %extract_1 = extractvalue { i1, i1 } %retval, 1
   store i1 %extract_0, ptr %local_0, align 1
@@ -59,7 +59,7 @@ entry:
   ret void
 }
 
-define private void @Test__use_4val_call_result() {
+define private void @"0000000000000100_Test_use_4val_call_r_DZEUupnqD12oiQ"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca i8, align 1
@@ -80,7 +80,7 @@ entry:
   store i64 %load_store_tmp, ptr %local_0, align 8
   store ptr %local_0, ptr %local_5, align 8
   %call_arg_0 = load ptr, ptr %local_5, align 8
-  %retval = call { ptr, i8, i128, i32 } @Test__ret_4vals(ptr %call_arg_0)
+  %retval = call { ptr, i8, i128, i32 } @"0000000000000100_Test_ret_4vals_DQQWrrMFWmFYXx"(ptr %call_arg_0)
   %extract_0 = extractvalue { ptr, i8, i128, i32 } %retval, 0
   %extract_1 = extractvalue { ptr, i8, i128, i32 } %retval, 1
   %extract_2 = extractvalue { ptr, i8, i128, i32 } %retval, 2

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/return-build/modules/0_Test.expected.ll
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i8 @Test__test() {
+define private i8 @"0000000000000100_Test_test_FfymrXLxVKvhRk"() {
 entry:
   %local_0 = alloca i8, align 1
   store i8 100, ptr %local_0, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct-cmp-build/modules/0_foo.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct-cmp-build/modules/0_foo.expected.ll
@@ -11,7 +11,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private i1 @foo__doit({ ptr, i64, i64 } %0, { ptr, i64, i64 } %1) {
+define private i1 @"0000000000000100_foo_doit_CzRTpuhrrBkxXu"({ ptr, i64, i64 } %0, { ptr, i64, i64 } %1) {
 entry:
   %local_0 = alloca { ptr, i64, i64 }, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct01-build/modules/0_M.expected.ll
@@ -8,7 +8,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define %struct.M__MyStruct @M__boofun() {
+define %struct.M__MyStruct @"0000000000000100_M_boofun_4Lq2jSQu2tgp5C"() {
 entry:
   %local_0__field1 = alloca i32, align 4
   %local_1__field2 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/0_Country.expected.ll
@@ -8,7 +8,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Country__dropit(%struct.Country__Country %0) {
+define i8 @"0000000000000100_Country_dropit_4gerfDdmY6R4Gd"(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca %struct.Country__Country, align 8
@@ -27,7 +27,7 @@ entry:
   ret i8 %retval
 }
 
-define i8 @Country__get_id(ptr nonnull readonly %0) {
+define i8 @"0000000000000100_Country_get_id_8Ghws4vKQMPGTv"(ptr nonnull readonly %0) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca ptr, align 8
@@ -46,7 +46,7 @@ entry:
   ret i8 %retval
 }
 
-define i64 @Country__get_phony_x(%struct.Country__Country %0) {
+define i64 @"0000000000000100_Country_get_phony_x_5NH9foguf4sbTM"(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca ptr, align 8
@@ -68,7 +68,7 @@ entry:
   ret i64 %retval
 }
 
-define i64 @Country__get_pop(%struct.Country__Country %0) {
+define i64 @"0000000000000100_Country_get_pop_4Cs3XUWadjMT5e"(%struct.Country__Country %0) {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca ptr, align 8
@@ -86,7 +86,7 @@ entry:
   ret i64 %retval
 }
 
-define %struct.Country__Country @Country__new_country(i8 %0, i64 %1) {
+define %struct.Country__Country @"0000000000000100_Country_new_country_52Qi8jwYTdUTGJ"(i8 %0, i64 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i64, align 8
@@ -116,7 +116,7 @@ entry:
   ret %struct.Country__Country %retval
 }
 
-define void @Country__set_id(ptr noalias nonnull %0, i8 %1) {
+define void @"0000000000000100_Country_set_id_8yeuwVpdrxBWtK"(ptr noalias nonnull %0, i8 %1) {
 entry:
   %local_0 = alloca ptr, align 8
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/struct02-build/modules/1_UseIt.expected.ll
@@ -8,7 +8,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define void @UseIt__getit() {
+define void @"0000000000000200_UseIt_getit_EyaUGrU5E3rBkM"() {
 entry:
   %local_0 = alloca %struct.Country__Country, align 8
   %local_1 = alloca i8, align 1
@@ -26,36 +26,36 @@ entry:
   store i64 1000000, ptr %local_2, align 8
   %call_arg_0 = load i8, ptr %local_1, align 1
   %call_arg_1 = load i64, ptr %local_2, align 8
-  %retval = call %struct.Country__Country @Country__new_country(i8 %call_arg_0, i64 %call_arg_1)
+  %retval = call %struct.Country__Country @"0000000000000100_Country_new_country_52Qi8jwYTdUTGJ"(i8 %call_arg_0, i64 %call_arg_1)
   store %struct.Country__Country %retval, ptr %local_3, align 8
   %load_store_tmp = load %struct.Country__Country, ptr %local_3, align 8
   store %struct.Country__Country %load_store_tmp, ptr %local_0, align 8
   %load_store_tmp1 = load %struct.Country__Country, ptr %local_0, align 8
   store %struct.Country__Country %load_store_tmp1, ptr %local_4, align 8
   %call_arg_02 = load %struct.Country__Country, ptr %local_4, align 8
-  %retval3 = call i64 @Country__get_pop(%struct.Country__Country %call_arg_02)
+  %retval3 = call i64 @"0000000000000100_Country_get_pop_4Cs3XUWadjMT5e"(%struct.Country__Country %call_arg_02)
   store i64 %retval3, ptr %local_5, align 8
   store ptr %local_0, ptr %local_6, align 8
   %call_arg_04 = load ptr, ptr %local_6, align 8
-  %retval5 = call i8 @Country__get_id(ptr %call_arg_04)
+  %retval5 = call i8 @"0000000000000100_Country_get_id_8Ghws4vKQMPGTv"(ptr %call_arg_04)
   store i8 %retval5, ptr %local_7, align 1
   store ptr %local_0, ptr %local_8, align 8
   store i8 123, ptr %local_9, align 1
   %call_arg_06 = load ptr, ptr %local_8, align 8
   %call_arg_17 = load i8, ptr %local_9, align 1
-  call void @Country__set_id(ptr %call_arg_06, i8 %call_arg_17)
+  call void @"0000000000000100_Country_set_id_8yeuwVpdrxBWtK"(ptr %call_arg_06, i8 %call_arg_17)
   %call_arg_08 = load %struct.Country__Country, ptr %local_0, align 8
-  %retval9 = call i8 @Country__dropit(%struct.Country__Country %call_arg_08)
+  %retval9 = call i8 @"0000000000000100_Country_dropit_4gerfDdmY6R4Gd"(%struct.Country__Country %call_arg_08)
   store i8 %retval9, ptr %local_11, align 1
   ret void
 }
 
-declare %struct.Country__Country @Country__new_country(i8, i64)
+declare %struct.Country__Country @"0000000000000100_Country_new_country_52Qi8jwYTdUTGJ"(i8, i64)
 
-declare i64 @Country__get_pop(%struct.Country__Country)
+declare i64 @"0000000000000100_Country_get_pop_4Cs3XUWadjMT5e"(%struct.Country__Country)
 
-declare i8 @Country__get_id(ptr nonnull readonly)
+declare i8 @"0000000000000100_Country_get_id_8Ghws4vKQMPGTv"(ptr nonnull readonly)
 
-declare void @Country__set_id(ptr noalias nonnull, i8)
+declare void @"0000000000000100_Country_set_id_8yeuwVpdrxBWtK"(ptr noalias nonnull, i8)
 
-declare i8 @Country__dropit(%struct.Country__Country)
+declare i8 @"0000000000000100_Country_dropit_4gerfDdmY6R4Gd"(%struct.Country__Country)

--- a/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/0x100__Test1.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/0x100__Test1.ll.expected
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test1__test1(i8 %0, i8 %1) {
+define i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -20,10 +20,10 @@ entry:
   store i8 %load_store_tmp1, ptr %local_3, align 1
   %call_arg_0 = load i8, ptr %local_2, align 1
   %call_arg_1 = load i8, ptr %local_3, align 1
-  %retval = call i8 @Test2__test2(i8 %call_arg_0, i8 %call_arg_1)
+  %retval = call i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8 %call_arg_0, i8 %call_arg_1)
   store i8 %retval, ptr %local_4, align 1
   %retval2 = load i8, ptr %local_4, align 1
   ret i8 %retval2
 }
 
-declare i8 @Test2__test2(i8, i8)
+declare i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/0x101__Test2.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/0x101__Test2.ll.expected
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define i8 @Test2__test2(i8 %0, i8 %1) {
+define i8 @"0000000000000101_Test2_test2_2uEcxMADSaAiVL"(i8 %0, i8 %1) {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/main.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/multi-module-build/main.ll.expected
@@ -5,7 +5,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define void @main__main() {
+define void @ffffffffffffffff_main_main_3nJ5qedGcCaPAw() {
 entry:
   %local_0 = alloca i8, align 1
   %local_1 = alloca i8, align 1
@@ -14,9 +14,9 @@ entry:
   store i8 2, ptr %local_1, align 1
   %call_arg_0 = load i8, ptr %local_0, align 1
   %call_arg_1 = load i8, ptr %local_1, align 1
-  %retval = call i8 @Test1__test1(i8 %call_arg_0, i8 %call_arg_1)
+  %retval = call i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8 %call_arg_0, i8 %call_arg_1)
   store i8 %retval, ptr %local_2, align 1
   ret void
 }
 
-declare i8 @Test1__test1(i8, i8)
+declare i8 @"0000000000000100_Test1_test1_FSLrpZ9dBeTRcs"(i8, i8)

--- a/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/struct01-build/0x100__M.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/struct01-build/0x100__M.ll.expected
@@ -8,7 +8,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define %struct.M__MyStruct @M__boofun() {
+define %struct.M__MyStruct @"0000000000000100_M_boofun_4Lq2jSQu2tgp5C"() {
 entry:
   %local_0__field1 = alloca i32, align 4
   %local_1__field2 = alloca i1, align 1

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/dupe-fn-name.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/dupe-fn-name.move
@@ -1,0 +1,21 @@
+// Testing that symbols are mangled to avoid basic collisions.
+
+module 0x1::foo {
+  public fun a(): u32 {
+    2
+  }
+}
+
+module 0x2::foo {
+  public fun a(): u32 {
+    2
+  }
+}
+
+script {
+  fun main() {
+    let v1 = 0x1::foo::a();
+    let v2 = 0x1::foo::a();
+    assert!(v1 == v2, 10);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/long-fn-name.move
+++ b/language/tools/move-mv-llvm-compiler/tests/rbpf-tests/long-fn-name.move
@@ -1,0 +1,14 @@
+// Testing that symbols are truncated to a size that passes rbpf's validation.
+
+module 0x1::foo {
+  public fun a_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_(): u32 {
+    2
+  }
+}
+
+script {
+  fun main() {
+    let v = 0x1::foo::a_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_();
+    assert!(v == 2, 10);
+  }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash.ll.expected
@@ -11,7 +11,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @hash__unit_test_poison() {
+define private void @"0000000000000001_hash_unit_test_poiso_4wx61fBNpDhykC"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash_tests.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__hash_tests.ll.expected
@@ -21,7 +21,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @hash_tests__unit_test_poison() {
+define private void @"0000000000000001_hash_tests_unit_test_poiso_A8wEggpFLSNBH1"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8
@@ -35,7 +35,7 @@ entry:
 
 declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
 
-define private void @hash_tests__sha2_256_expected_hash() {
+define private void @"0000000000000001_hash_tests_sha2_256_expect_4ZUoPHbotbSvVN"() {
 entry:
   %newv1 = alloca { ptr, i64, i64 }, align 8
   %newv = alloca { ptr, i64, i64 }, align 8
@@ -76,7 +76,7 @@ bb_2:                                             ; preds = %bb_1
 
 declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
 
-define private void @hash_tests__sha3_256_expected_hash() {
+define private void @"0000000000000001_hash_tests_sha3_256_expect_4VXixMtNgVhwxY"() {
 entry:
   %newv1 = alloca { ptr, i64, i64 }, align 8
   %newv = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__unit_test.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-tests/hash_tests-build/0x1__unit_test.ll.expected
@@ -13,7 +13,7 @@ declare i32 @memcmp(ptr, ptr, i64)
 
 declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
 
-define private void @unit_test__unit_test_poison() {
+define private void @"0000000000000001_unit_test_unit_test_poiso_4afD3MScT99fc9"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash.ll.expected
@@ -11,7 +11,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @hash__unit_test_poison() {
+define private void @"0000000000000001_hash_unit_test_poiso_4wx61fBNpDhykC"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash_tests.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__hash_tests.ll.expected
@@ -21,7 +21,7 @@ target triple = "sbf-solana-solana"
 
 declare i32 @memcmp(ptr, ptr, i64)
 
-define private void @hash_tests__unit_test_poison() {
+define private void @"0000000000000001_hash_tests_unit_test_poiso_A8wEggpFLSNBH1"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8
@@ -35,7 +35,7 @@ entry:
 
 declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
 
-define private void @hash_tests__sha2_256_expected_hash() {
+define private void @"0000000000000001_hash_tests_sha2_256_expect_4ZUoPHbotbSvVN"() {
 entry:
   %newv1 = alloca { ptr, i64, i64 }, align 8
   %newv = alloca { ptr, i64, i64 }, align 8
@@ -76,7 +76,7 @@ bb_2:                                             ; preds = %bb_1
 
 declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
 
-define private void @hash_tests__sha3_256_expected_hash() {
+define private void @"0000000000000001_hash_tests_sha3_256_expect_4VXixMtNgVhwxY"() {
 entry:
   %newv1 = alloca { ptr, i64, i64 }, align 8
   %newv = alloca { ptr, i64, i64 }, align 8

--- a/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__unit_test.ll.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/stdlib-with-p-option-tests/hash_tests-build/0x1__unit_test.ll.expected
@@ -13,7 +13,7 @@ declare i32 @memcmp(ptr, ptr, i64)
 
 declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
 
-define private void @unit_test__unit_test_poison() {
+define private void @"0000000000000001_unit_test_unit_test_poiso_4afD3MScT99fc9"() {
 entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca { ptr, i64, i64 }, align 8


### PR DESCRIPTION
This fixes two problems with symbol naming.

## Name collisions

Two functions with the same module and function name, but different addresses, will have the same symbol name, and generate a link error. Example

```move
module 0x1::foo {
  public fun a(): u32 {
    2
  }
}

module 0x2::foo {
  public fun a(): u32 {
    2
  }
}
```

## Long symbols

rbpf supports symbol names up to 64 characters (63 + a nil byte). Our current symbol naming will easily generate symbol names that are too long.

---

This patch uses an encoding scheme that guarantees short and unique symbols. That scheme is described fully in the comments.

Here is an example of a symbol generated by this scheme:

```
0000000000000010_tests_test_vec_struct_71fWuFLGmmLpqR
```

It is different from the one suggested in https://github.com/solana-labs/move/issues/378#issuecomment-1728397377 for a few reasons:

- Type params need to be included. Here they are just part of the hash, not part of the readable name.
- I included three visual separators for readability.
- I stuffed every datum into a single hash instead of multiple hashes. The main downside to this is it is not possible to perfectly identify e.g. which module a symbol is from by looking at a dedicated module hash. The upside is that it allows an arbitrary amount of data to be stashed in the one hash (like the type params) without spending bytes on separate hashes.

I also allocated 15 bytes to each of the module name and the function name. I think it is arguable that the module name is less important and often short compared to the function name, and those bytes could be reduced to add bytes elsewhere. e.g. the hash here is significantly truncated, so bytes _could_ be added to it, but I also don't feel strongly that more bytes elsewhere will meaningfully improve this scheme.

Encoding the address and hash into all symbols ensures that all symbols are fairly long, so there could be concern about binary size. The only symbols names that will appear in the final binary though are ones that need to be relocated, which currently seems to include only public functions. If the compilation model changes in the future, e.g. using LTO to combine compilation units (or just compiling all modules as one compilation unit to begin with), we could possibly avoid those relocations, but I am not sure.

All the work needed to generate symbols here is arguably inefficient and could be cached for later lookups, but with our small workloads I am not thinking it matters. In casual testing rbf-tests takes approximately the same time to execute after this patch.

This uses blake3 for the hash because it is strong and fast, and base58 to encode the hash to valid symbol names.

It leaves alone the naming of the entrypoint symbols as I don't understand that code enough to know if and how it should change.

Fixes https://github.com/solana-labs/move/issues/303
Fixes https://github.com/solana-labs/move/issues/378