### PR TITLE
Adding DWARF to Solana Move compiler

### DIFF
--- a/language/solana/move-to-solana/src/lib.rs
+++ b/language/solana/move-to-solana/src/lib.rs
@@ -405,8 +405,13 @@ fn compile(global_env: &GlobalEnv, options: &Options) -> anyhow::Result<()> {
         debug!("Generating code for module {}", modname);
         let llmod = global_cx.llvm_cx.create_module(&modname);
         let module_source_path = module.get_source_path().to_str().expect("utf-8");
-        let mod_cx =
-            &mut global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, options, module_source_path);
+        let mod_cx = &mut global_cx.create_module_context(
+            mod_id,
+            &llmod,
+            &entrypoint_generator,
+            options,
+            module_source_path,
+        );
         mod_cx.translate();
 
         let mut out_path = out_path.join(&modname);

--- a/language/solana/move-to-solana/src/lib.rs
+++ b/language/solana/move-to-solana/src/lib.rs
@@ -404,8 +404,9 @@ fn compile(global_env: &GlobalEnv, options: &Options) -> anyhow::Result<()> {
         let modname = module.llvm_module_name();
         debug!("Generating code for module {}", modname);
         let llmod = global_cx.llvm_cx.create_module(&modname);
+        let module_source_path = module.get_source_path().to_str().expect("utf-8");
         let mod_cx =
-            global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, options);
+            &mut global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, options, module_source_path);
         mod_cx.translate();
 
         let mut out_path = out_path.join(&modname);

--- a/language/solana/move-to-solana/src/options.rs
+++ b/language/solana/move-to-solana/src/options.rs
@@ -61,6 +61,10 @@ pub struct Options {
     #[clap(short)]
     pub compile: bool,
 
+    /// Create debug information.
+    #[clap(short = 'g')]
+    pub debug: bool,
+
     /// Location of precompiled move native library.
     #[clap(long = "move-native-archive")]
     pub move_native_archive: Option<String>,

--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -14,6 +14,10 @@
 //! - Provides high-level instruction builders compatible with the stackless bytecode model.
 
 use llvm_extra_sys::*;
+use llvm_sys::debuginfo::{
+    LLVMDIBuilderCreateCompileUnit, LLVMDIBuilderCreateModule, LLVMDIBuilderFinalize,
+    LLVMDWARFEmissionKind, LLVMDWARFSourceLanguage::LLVMDWARFSourceLanguageRust,
+};
 use llvm_sys::{core::*, prelude::*, target::*, target_machine::*, LLVMOpcode, LLVMUnnamedAddr};
 use move_core_types::u256;
 use num_traits::{PrimInt, ToPrimitive};
@@ -26,8 +30,11 @@ use std::{
 };
 
 pub use llvm_sys::{
+    debuginfo::{LLVMCreateDIBuilder, LLVMDIBuilderCreateFile, LLVMDisposeDIBuilder},
     LLVMAttributeFunctionIndex, LLVMAttributeIndex, LLVMAttributeReturnIndex, LLVMIntPredicate,
-    LLVMLinkage, LLVMLinkage::LLVMInternalLinkage, LLVMTypeKind::LLVMIntegerTypeKind,
+    LLVMLinkage,
+    LLVMLinkage::LLVMInternalLinkage,
+    LLVMTypeKind::LLVMIntegerTypeKind,
 };
 
 pub fn initialize_sbf() {
@@ -74,6 +81,10 @@ impl Context {
 
     pub fn create_builder(&self) -> Builder {
         unsafe { Builder(LLVMCreateBuilderInContext(self.0)) }
+    }
+
+    pub fn create_di_builder(&self, module: &mut Module, source: &str, debug: bool) -> DIBuilder {
+        DIBuilder::new(module, source, debug)
     }
 
     pub fn get_anonymous_struct_type(&self, field_tys: &[Type]) -> Type {
@@ -244,6 +255,24 @@ impl Module {
         unsafe {
             LLVMDumpModule(self.0);
         }
+    }
+
+    pub fn get_module_id(&self) -> String {
+        let mut mod_len: ::libc::size_t = 0;
+        let mod_ptr = unsafe { LLVMGetModuleIdentifier(self.0, &mut mod_len) };
+        from_raw_slice_to_string(mod_ptr, mod_len)
+    }
+
+    pub fn get_module_source(&self) -> String {
+        let mut mod_len: ::libc::size_t = 0;
+        let mod_ptr = unsafe { LLVMGetSourceFileName(self.0, &mut mod_len) };
+        from_raw_slice_to_string(mod_ptr, mod_len)
+    }
+
+    pub fn get_source_file_name(&self) -> String {
+        let mut src_len: ::libc::size_t = 0;
+        let src_ptr = unsafe { LLVMGetSourceFileName(self.0, &mut src_len) };
+        from_raw_slice_to_string(src_ptr, src_len)
     }
 
     pub fn set_source_file_name(&self, name: &str) {
@@ -424,6 +453,224 @@ impl Module {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DIBuilderCore {
+    module_di: LLVMModuleRef,
+    builder_ref: LLVMDIBuilderRef,
+    // fields below reserved for future usage
+    builder_file: LLVMMetadataRef,
+    compiled_unit: LLVMMetadataRef,
+    compiled_module: LLVMMetadataRef,
+    module_ref: LLVMModuleRef,
+    module_source: String,
+}
+#[derive(Clone, Debug)]
+pub struct DIBuilder(Option<DIBuilderCore>);
+
+/// Convert &str to a CString
+fn str_to_c_params(s: &str) -> (*const ::libc::c_char, ::libc::size_t) {
+    (s.as_ptr() as *const libc::c_char, s.len())
+}
+
+/// Convert the Rust String to a CString (null-terminated C-style string)
+fn string_to_c_params(s: String) -> (*const ::libc::c_char, ::libc::size_t) {
+    let cstr = match CString::new(s) {
+        Ok(cstr) => cstr,
+        Err(_) => CString::new("").expect("Failed to create an empty CString"),
+    };
+    (cstr.as_ptr(), cstr.as_bytes().len())
+}
+
+fn path_to_c_params(
+    file_path: &str,
+) -> (
+    *const ::libc::c_char,
+    ::libc::size_t,
+    *const ::libc::c_char,
+    ::libc::size_t,
+) {
+    let path = std::path::Path::new(&file_path);
+    let directory = path
+        .parent()
+        .expect("Failed to get directory")
+        .to_str()
+        .expect("Failed to convert to string");
+    let (dir_ptr, dir_len) = str_to_c_params(directory);
+    let file = path
+        .file_name()
+        .expect("Failed to get file name")
+        .to_str()
+        .expect("Failed to convert to string");
+    let (filename_ptr, filename_len) = str_to_c_params(file);
+    (filename_ptr, filename_len, dir_ptr, dir_len)
+}
+
+fn from_raw_slice_to_string(raw_ptr: *const i8, raw_len: ::libc::size_t) -> String {
+    let byte_slice: &[i8] = unsafe { std::slice::from_raw_parts(raw_ptr, raw_len) };
+    let byte_slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(byte_slice.as_ptr() as *const u8, byte_slice.len()) };
+    String::from_utf8_lossy(byte_slice).to_string()
+}
+
+impl DIBuilder {
+    pub fn new(module: &mut Module, source: &str, debug: bool) -> DIBuilder {
+        if debug {
+            let module_ref = module.0;
+
+            let module_ref_name = module.get_module_id();
+
+            // create module
+            let module_name = format!("{}.dbg_info", module_ref_name);
+            let (mod_nm_ptr, _mod_nm_len) = str_to_c_params(module_name.as_str());
+            let module_di = unsafe { LLVMModuleCreateWithName(mod_nm_ptr) };
+
+            // set source to created module
+            let (src_ptr, src_len) = str_to_c_params(source);
+            unsafe { LLVMSetSourceFileName(module_di, src_ptr, src_len) };
+            // check the name
+            let mut src_len: ::libc::size_t = 0;
+            let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
+            let src0 = from_raw_slice_to_string(src_ptr, src_len);
+            dbg!(&src0);
+
+            // create builder
+            let builder_ref = unsafe { LLVMCreateDIBuilder(module_di) };
+
+            // create builder file
+            let (mod_nm_ptr, mod_nm_len, dir_ptr, dir_len) = path_to_c_params(source);
+            let builder_file = unsafe {
+                LLVMDIBuilderCreateFile(builder_ref, mod_nm_ptr, mod_nm_len, dir_ptr, dir_len)
+            };
+
+            let producer = "move-mv-llvm-compiler".to_string();
+            let (producer_ptr, producer_len) = str_to_c_params(producer.as_str());
+            let flags = "".to_string();
+            let (flags_ptr, flags_len) = str_to_c_params(flags.as_str());
+            let slash = "/".to_string();
+            let (slash_ptr, slash_len) = str_to_c_params(slash.as_str());
+            let none = String::new();
+            let (none_ptr, none_len) = str_to_c_params(none.as_str());
+
+            let compiled_unit = unsafe {
+                LLVMDIBuilderCreateCompileUnit(
+                    builder_ref,
+                    LLVMDWARFSourceLanguageRust,
+                    builder_file,
+                    producer_ptr,
+                    producer_len,
+                    0, /* is_optimized */
+                    flags_ptr,
+                    flags_len,
+                    0,                /* runtime_version */
+                    std::ptr::null(), /* *const i8 */
+                    0,                /* usize */
+                    LLVMDWARFEmissionKind::LLVMDWARFEmissionKindFull,
+                    0,         /* u32 */
+                    0,         /* i32 */
+                    0,         /* i32 */
+                    slash_ptr, /* *const i8 */
+                    slash_len, /* usize */
+                    none_ptr,  /* *const i8 */
+                    none_len,  /* usize */
+                )
+            };
+
+            // check the name
+            let mut src_len: ::libc::size_t = 0;
+            let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
+            let src1 = from_raw_slice_to_string(src_ptr, src_len);
+            dbg!(&src1);
+
+            // create compiled unit
+            let parent_scope = compiled_unit;
+            let name = module_name;
+            let (name_ptr, name_len) = str_to_c_params(name.as_str());
+            let (config_macros_ptr, config_macros_len) = str_to_c_params(none.as_str());
+            let (include_path_ptr, include_path_len) = str_to_c_params(none.as_str());
+            let (api_notes_file_ptr, api_notes_file_len) = str_to_c_params(none.as_str());
+            let compiled_module = unsafe {
+                LLVMDIBuilderCreateModule(
+                    builder_ref,
+                    parent_scope,
+                    name_ptr,
+                    name_len,
+                    config_macros_ptr,
+                    config_macros_len,
+                    include_path_ptr,
+                    include_path_len,
+                    api_notes_file_ptr,
+                    api_notes_file_len,
+                )
+            };
+
+            // store all control fields for future usage
+            let builder_core = DIBuilderCore {
+                module_di,
+                builder_ref,
+                builder_file,
+                compiled_unit,
+                compiled_module,
+                module_ref,
+                module_source: source.to_string(),
+            };
+
+            DIBuilder(Some(builder_core))
+        } else {
+            DIBuilder(None)
+        }
+    }
+
+    pub fn module_di(&self) -> Option<LLVMModuleRef> {
+        self.0.as_ref().map(|x| x.module_di)
+    }
+
+    pub fn builder_ref(&self) -> Option<LLVMDIBuilderRef> {
+        self.0.as_ref().map(|x| x.builder_ref)
+    }
+
+    pub fn builder_file(&self) -> Option<LLVMMetadataRef> {
+        self.0.as_ref().map(|x| x.builder_file)
+    }
+
+    pub fn compiled_unit(&self) -> Option<LLVMMetadataRef> {
+        self.0.as_ref().map(|x| x.compiled_unit)
+    }
+
+    pub fn compiled_module(&self) -> Option<LLVMMetadataRef> {
+        self.0.as_ref().map(|x| x.compiled_module)
+    }
+
+    pub fn module_ref(&self) -> Option<LLVMModuleRef> {
+        self.0.as_ref().map(|x| x.module_ref)
+    }
+
+    pub fn module_source(&self) -> Option<String> {
+        self.0.as_ref().map(|x| x.module_source.clone())
+    }
+
+    pub fn print_module_to_file(&self, file_path: String) {
+        if let Some(x) = &self.0 {
+            let mut err_string = ptr::null_mut();
+            let (filename_ptr, _filename_ptr_len) = string_to_c_params(file_path);
+            unsafe {
+                let res = LLVMPrintModuleToFile(x.module_di, filename_ptr, &mut err_string);
+                if res != 0 {
+                    assert!(!err_string.is_null());
+                    let msg = CStr::from_ptr(err_string).to_string_lossy();
+                    print!("{msg}");
+                    LLVMDisposeMessage(err_string);
+                }
+            };
+        }
+    }
+
+    pub fn finalize(&self) {
+        if let Some(x) = &self.0 {
+            unsafe { LLVMDIBuilderFinalize(x.builder_ref) };
+        }
     }
 }
 

--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -523,6 +523,7 @@ fn from_raw_slice_to_string(raw_ptr: *const i8, raw_len: ::libc::size_t) -> Stri
 
 impl DIBuilder {
     pub fn new(module: &mut Module, source: &str, debug: bool) -> DIBuilder {
+        use log::debug;
         if debug {
             let module_ref = module.0;
 
@@ -540,6 +541,7 @@ impl DIBuilder {
             let mut src_len: ::libc::size_t = 0;
             let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
             let src0 = from_raw_slice_to_string(src_ptr, src_len);
+            debug!(target: "dwarf", "Module {:#?} has source {:#?}", module_name, src0);
 
             // create builder
             let builder_ref = unsafe { LLVMCreateDIBuilder(module_di) };
@@ -587,7 +589,7 @@ impl DIBuilder {
             let mut src_len: ::libc::size_t = 0;
             let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
             let src1 = from_raw_slice_to_string(src_ptr, src_len);
-            assert!(src0.eq(&src1), "Error in setting/getting source name");
+            debug!(target: "dwarf", "Self-check: module {:#?} has source {:#?}", module_name, src1);
 
             // create compiled unit
             let parent_scope = compiled_unit;

--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -540,7 +540,6 @@ impl DIBuilder {
             let mut src_len: ::libc::size_t = 0;
             let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
             let src0 = from_raw_slice_to_string(src_ptr, src_len);
-            dbg!(&src0);
 
             // create builder
             let builder_ref = unsafe { LLVMCreateDIBuilder(module_di) };
@@ -588,7 +587,7 @@ impl DIBuilder {
             let mut src_len: ::libc::size_t = 0;
             let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
             let src1 = from_raw_slice_to_string(src_ptr, src_len);
-            dbg!(&src1);
+            assert!(src0.eq(&src1), "Error in setting/getting source name");
 
             // create compiled unit
             let parent_scope = compiled_unit;

--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -14,11 +14,17 @@
 //! - Provides high-level instruction builders compatible with the stackless bytecode model.
 
 use llvm_extra_sys::*;
-use llvm_sys::debuginfo::{
-    LLVMDIBuilderCreateCompileUnit, LLVMDIBuilderCreateModule, LLVMDIBuilderFinalize,
-    LLVMDWARFEmissionKind, LLVMDWARFSourceLanguage::LLVMDWARFSourceLanguageRust,
+use llvm_sys::{
+    core::*,
+    debuginfo::{
+        LLVMDIBuilderCreateCompileUnit, LLVMDIBuilderCreateModule, LLVMDIBuilderFinalize,
+        LLVMDWARFEmissionKind, LLVMDWARFSourceLanguage::LLVMDWARFSourceLanguageRust,
+    },
+    prelude::*,
+    target::*,
+    target_machine::*,
+    LLVMOpcode, LLVMUnnamedAddr,
 };
-use llvm_sys::{core::*, prelude::*, target::*, target_machine::*, LLVMOpcode, LLVMUnnamedAddr};
 use move_core_types::u256;
 use num_traits::{PrimInt, ToPrimitive};
 

--- a/language/solana/move-to-solana/src/stackless/module_context.rs
+++ b/language/solana/move-to-solana/src/stackless/module_context.rs
@@ -61,12 +61,12 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
             let fn_env = self.env.env.get_function(fn_qiid.to_qualified_id());
             assert!(!fn_env.is_native());
             self.rtty_cx.reset_func(fn_qiid);
-            let fn_cx = self.create_fn_context(fn_env, &self, &fn_qiid.inst);
+            let fn_cx = self.create_fn_context(fn_env, self, &fn_qiid.inst);
             fn_cx.translate();
         }
 
         if !self.env.is_script_module() {
-            self.entrypoint_generator.add_entries(&self);
+            self.entrypoint_generator.add_entries(self);
         }
 
         self.llvm_module.verify();

--- a/language/solana/move-to-solana/src/stackless/module_context.rs
+++ b/language/solana/move-to-solana/src/stackless/module_context.rs
@@ -29,6 +29,7 @@ pub struct ModuleContext<'mm: 'up, 'up> {
     pub llvm_cx: &'up llvm::Context,
     pub llvm_module: &'up llvm::Module,
     pub llvm_builder: llvm::Builder,
+    pub llvm_di_builder: llvm::DIBuilder,
     /// A map of move function id's to llvm function ids
     ///
     /// All functions that might be called are declared prior to function translation.
@@ -39,10 +40,11 @@ pub struct ModuleContext<'mm: 'up, 'up> {
     pub target_machine: &'up TargetMachine,
     pub options: &'up Options,
     pub rtty_cx: RttyContext<'mm, 'up>,
+    pub source: &'up str,
 }
 
 impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
-    pub fn translate(mut self) {
+    pub fn translate(&mut self) {
         let filename = self.env.get_source_path().to_str().expect("utf-8");
         self.llvm_module.set_source_file_name(filename);
         self.llvm_module.set_target(self.target.triple());

--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -141,11 +141,9 @@ impl<'up> GlobalContext<'up> {
         let m_env = env.get_module(id);
         let llvm_builder = llvm_cx.create_builder();
         let modname = m_env.llvm_module_name();
-        dbg!(&modname);
+        debug!(target: "dwarf", "Create DWARF for module {:#?} with source {:#?}", modname, source);
         let mut module = self.llvm_cx.create_module(&modname);
-        dbg!(source);
         let llvm_di_builder = llvm_cx.create_di_builder(&mut module, source, options.debug);
-        dbg!(&llvm_di_builder);
         let rtty_cx = RttyContext::new(self.env, &self.llvm_cx, llmod);
         ModuleContext {
             env: self.env.get_module(id),

--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -134,20 +134,37 @@ impl<'up> GlobalContext<'up> {
         llmod: &'this llvm::Module,
         entrypoint_generator: &'this EntrypointGenerator<'this, 'up>,
         options: &'this Options,
+        source: &'this str,
     ) -> ModuleContext<'up, 'this> {
+        let Self {
+            env,
+            llvm_cx,
+            ..
+        } = self;
+
+        let m_env = env.get_module(id);
+        let llvm_builder = llvm_cx.create_builder();
+        let modname = m_env.llvm_module_name();
+        dbg!(&modname);
+        let mut module = self.llvm_cx.create_module(&modname);
+        dbg!(source);
+        let llvm_di_builder = llvm_cx.create_di_builder(&mut module, source, options.debug);
+        dbg!(&llvm_di_builder);
         let rtty_cx = RttyContext::new(self.env, &self.llvm_cx, llmod);
         ModuleContext {
             env: self.env.get_module(id),
             entrypoint_generator,
             llvm_cx: &self.llvm_cx,
             llvm_module: llmod,
-            llvm_builder: self.llvm_cx.create_builder(),
+            llvm_builder,
+            llvm_di_builder,
             fn_decls: BTreeMap::new(),
             expanded_functions: Vec::new(),
             target: self.target,
             target_machine: self.target_machine,
             options,
             rtty_cx,
+            source,
         }
     }
 }

--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -136,11 +136,7 @@ impl<'up> GlobalContext<'up> {
         options: &'this Options,
         source: &'this str,
     ) -> ModuleContext<'up, 'this> {
-        let Self {
-            env,
-            llvm_cx,
-            ..
-        } = self;
+        let Self { env, llvm_cx, .. } = self;
 
         let m_env = env.get_module(id);
         let llvm_builder = llvm_cx.create_builder();

--- a/language/tools/move-mv-llvm-compiler/src/cli.rs
+++ b/language/tools/move-mv-llvm-compiler/src/cli.rs
@@ -39,6 +39,10 @@ pub struct Args {
     #[clap(short = 'c', long = "compile")]
     pub compile: Option<String>,
 
+    /// Call Move compiler and pass this option.
+    #[clap(short = 'g')]
+    pub debug: bool,
+
     /// Use stdlib.
     #[clap(long = "stdlib")]
     pub stdlib: bool,

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -255,7 +255,13 @@ fn main() -> anyhow::Result<()> {
             // let mod_cx =
             //     global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, &options);
             let mod_src = module.get_source_path().to_str().expect("utf-8");
-            let mod_cx = &mut global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, &options, mod_src);
+            let mod_cx = &mut global_cx.create_module_context(
+                mod_id,
+                &llmod,
+                &entrypoint_generator,
+                &options,
+                mod_src,
+            );
             mod_cx.translate();
 
             mod_cx.llvm_di_builder.finalize();

--- a/language/tools/move-mv-llvm-compiler/src/main.rs
+++ b/language/tools/move-mv-llvm-compiler/src/main.rs
@@ -238,6 +238,7 @@ fn main() -> anyhow::Result<()> {
             gen_dot_cfg: args.gen_dot_cfg.clone(),
             dot_file_path: args.dot_file_path.clone(),
             test_signers: args.test_signers.clone(),
+            debug: args.debug,
             ..MoveToSolanaOptions::default()
         };
         let entry_llmod = global_cx.llvm_cx.create_module("solana_entrypoint");
@@ -251,9 +252,14 @@ fn main() -> anyhow::Result<()> {
                 let disasm = module.disassemble();
                 println!("Module {} bytecode {}", modname, disasm);
             }
-            let mod_cx =
-                global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, &options);
+            // let mod_cx =
+            //     global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, &options);
+            let mod_src = module.get_source_path().to_str().expect("utf-8");
+            let mod_cx = &mut global_cx.create_module_context(mod_id, &llmod, &entrypoint_generator, &options, mod_src);
             mod_cx.translate();
+
+            mod_cx.llvm_di_builder.finalize();
+
             if args.diagnostics {
                 println!("Module {} Solana llvm ir", modname);
                 llmod.dump();
@@ -273,6 +279,10 @@ fn main() -> anyhow::Result<()> {
                         Ok(_) => {}
                         Err(err) => eprintln!("Error creating directory: {}", err),
                     }
+                }
+                if let Some(module_di) = mod_cx.llvm_di_builder.module_di() {
+                    let output_file = format!("{}.debug_info", output_file);
+                    llvm_write_to_file(module_di, true, &output_file)?;
                 }
                 llvm_write_to_file(llmod.as_mut(), args.llvm_ir, &output_file)?;
                 drop(llmod);


### PR DESCRIPTION
This is to set foot in Dwarf generating for Solana Move compiler.
DIBuilder is created and will be used to accumulate more Dwarf information.

With this patch we have something as simple as:

sol@dev-equinix-new-york-2:~/tmp/090623:$ less ~/tmp/090623/0x1__unit_test.ll.debug_info
```
; ModuleID = '0x1__unit_test.dbg_info'
source_filename = "/home/sol/work/git/move-090523/language/move-stdlib/sources/unit_test.move"

!llvm.dbg.cu = !{!0}

!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
!1 = !DIFile(filename: "unit_test.move", directory: "/home/sol/work/git/move-090523/language/move-stdlib/sources")
```