### PR TITLE
Dwarf test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ target-out-docker
 **/move-mv-llvm-compiler/**/cli-tests/**/*.ll.actual
 **/move-mv-llvm-compiler/**/cli-tests/basic-coin-build/absolute_path_results/*
 **/move-mv-llvm-compiler/**/cli-tests/basic-coin-build/relative_path_results/*
+**/move-mv-llvm-compiler/**/dwarf-tests/basic-coin-build/stored_results/*
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.mv
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.o
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.so

--- a/language/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/language/solana/move-to-solana/src/stackless/dwarf.rs
@@ -114,7 +114,12 @@ impl DIBuilder {
 
             // create module
             let module_name = module_ref_name + ".dbg_info";
-            let (mod_nm_ptr, mut mod_nm_len) = str_to_c_params(&module_name);
+            // let (mod_nm_ptr, mut mod_nm_len) = str_to_c_params(&module_name);
+            let cstr = match CString::new(module_name.as_str()) {
+                Ok(cstr) => cstr,
+                Err(_) => CString::new("unknown").expect("Failed to create CString"),
+            };
+            let (mod_nm_ptr, mut mod_nm_len) = (cstr.as_ptr(), cstr.as_bytes().len());
             dbg!(mod_nm_len);
             let module_di = unsafe { LLVMModuleCreateWithName(mod_nm_ptr as *const ::libc::c_char) };
 

--- a/language/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/language/solana/move-to-solana/src/stackless/dwarf.rs
@@ -61,7 +61,10 @@ pub fn from_raw_slice_to_string(raw_ptr: *const i8, raw_len: ::libc::size_t) -> 
 
 fn relative_to_absolute(relative_path: &str) -> std::io::Result<String> {
     let current_dir = env::current_dir()?;
-    let absolute_path = current_dir.join(relative_path);
+    let absolute_path = current_dir
+        .join(relative_path)
+        .canonicalize()
+        .expect("Cannot canonicanize path");
 
     Ok(absolute_path.to_string_lossy().to_string())
 }

--- a/language/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/language/solana/move-to-solana/src/stackless/dwarf.rs
@@ -53,9 +53,14 @@ pub struct DIBuilderCore {
 #[derive(Clone, Debug)]
 pub struct DIBuilder(Option<DIBuilderCore>);
 
-/// Convert &str to a CString
-fn str_to_c_params(s: &str) -> (*const ::libc::c_char, ::libc::size_t) {
-    (s.as_ptr() as *const libc::c_char, s.len())
+macro_rules! to_cstring {
+    ($x:expr) => {{
+        let cstr = match std::ffi::CString::new($x) {
+            Ok(cstr) => cstr,
+            Err(_) => std::ffi::CString::new("unknown").expect("Failed to create CString"),
+        };
+        cstr
+    }};
 }
 
 /// Convert the Rust String to a CString (null-terminated C-style string)
@@ -65,29 +70,6 @@ fn string_to_c_params(s: String) -> (*const ::libc::c_char, ::libc::size_t) {
         Err(_) => CString::new("").expect("Failed to create an empty CString"),
     };
     (cstr.as_ptr(), cstr.as_bytes().len())
-}
-fn path_to_c_params(
-    file_path: &str,
-) -> (
-    *const ::libc::c_char,
-    ::libc::size_t,
-    *const ::libc::c_char,
-    ::libc::size_t,
-) {
-    let path = std::path::Path::new(&file_path);
-    let directory = path
-        .parent()
-        .expect("Failed to get directory")
-        .to_str()
-        .expect("Failed to convert to string");
-    let (dir_ptr, dir_len) = str_to_c_params(directory);
-    let file = path
-        .file_name()
-        .expect("Failed to get file name")
-        .to_str()
-        .expect("Failed to convert to string");
-    let (filename_ptr, filename_len) = str_to_c_params(file);
-    (filename_ptr, filename_len, dir_ptr, dir_len)
 }
 
 pub fn from_raw_slice_to_string(raw_ptr: *const i8, raw_len: ::libc::size_t) -> String {
@@ -109,57 +91,73 @@ impl DIBuilder {
         use log::debug;
         if debug {
             let module_ref_name = module.get_module_id();
-            dbg!(&module_ref_name);
             let module_ref = module.as_mut();
 
-            // create module
+            // create new module
             let module_name = module_ref_name + ".dbg_info";
-            // let (mod_nm_ptr, mut mod_nm_len) = str_to_c_params(&module_name);
-            let cstr = match CString::new(module_name.as_str()) {
-                Ok(cstr) => cstr,
-                Err(_) => CString::new("unknown").expect("Failed to create CString"),
-            };
-            let (mod_nm_ptr, mut mod_nm_len) = (cstr.as_ptr(), cstr.as_bytes().len());
-            dbg!(mod_nm_len);
-            let module_di = unsafe { LLVMModuleCreateWithName(mod_nm_ptr as *const ::libc::c_char) };
+            let cstr = to_cstring!(module_name.as_str());
+            let (mut mod_nm_ptr, mut mod_nm_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+            let module_di =
+                unsafe { LLVMModuleCreateWithName(mod_nm_ptr as *const ::libc::c_char) };
 
             // check dbg module name
-            let mod_nm_ptr = unsafe { LLVMGetModuleIdentifier(module_di, &mut mod_nm_len) };
-            let module_di_name = from_raw_slice_to_string(mod_nm_ptr, mod_nm_len);
-            dbg!(mod_nm_len);
-            dbg!(&module_di_name);
-            debug!(target: "dwarf", "Created dbg module {:#?}", &module_di_name);
+            mod_nm_ptr = unsafe { LLVMGetModuleIdentifier(module_di, &mut mod_nm_len) };
+            let module_di_name = &from_raw_slice_to_string(mod_nm_ptr, mod_nm_len);
+            debug!(target: "dwarf", "Created dbg module {:#?}", module_di_name);
 
-            // set source to created module
-            dbg!(source);
             let source = relative_to_absolute(source).expect("Must be the legal path");
-            dbg!(&source);
-            let (src_ptr, src_len) = str_to_c_params(&source);
-            unsafe { LLVMSetSourceFileName(module_di, src_ptr, src_len) };
+            let cstr = to_cstring!(source.as_str());
+            unsafe { LLVMSetSourceFileName(module_di, cstr.as_ptr(), cstr.as_bytes().len()) };
 
             // check the source name
             let mut src_len: ::libc::size_t = 0;
             let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
-            let src0 = from_raw_slice_to_string(src_ptr, src_len);
-            debug!(target: "dwarf", "Module {:#?} has source {:#?}", module_name, src0);
+            let module_src = &from_raw_slice_to_string(src_ptr, src_len);
+            debug!(target: "dwarf", "Module {:#?} has source {:#?}", module_name, module_src);
 
             // create builder
             let builder_ref = unsafe { LLVMCreateDIBuilder(module_di) };
 
-            // create builder file
-            let (mod_nm_ptr, mod_nm_len, dir_ptr, dir_len) = path_to_c_params(&source);
+            // create file
+            let path = std::path::Path::new(&source);
+            let directory = path
+                .parent()
+                .expect("Failed to get directory")
+                .to_str()
+                .expect("Failed to convert to string");
+            let cstr = to_cstring!(directory);
+            let (dir_ptr, dir_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+
+            let file = path
+                .file_name()
+                .expect("Failed to get file name")
+                .to_str()
+                .expect("Failed to convert to string");
+            let cstr = to_cstring!(file);
+            let (filename_ptr, filename_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+            let (mod_nm_ptr, mod_nm_len, dir_ptr, dir_len) =
+                (filename_ptr, filename_len, dir_ptr, dir_len);
+
             let builder_file = unsafe {
                 LLVMDIBuilderCreateFile(builder_ref, mod_nm_ptr, mod_nm_len, dir_ptr, dir_len)
             };
 
+            // create compile unit
             let producer = "move-mv-llvm-compiler".to_string();
-            let (producer_ptr, producer_len) = str_to_c_params(producer.as_str());
+            let cstr = to_cstring!(producer);
+            let (producer_ptr, producer_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+
             let flags = "".to_string();
-            let (flags_ptr, flags_len) = str_to_c_params(flags.as_str());
+            let cstr = to_cstring!(flags);
+            let (flags_ptr, flags_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+
             let slash = "/".to_string();
-            let (slash_ptr, slash_len) = str_to_c_params(slash.as_str());
+            let cstr = to_cstring!(slash);
+            let (slash_ptr, slash_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+
             let none = String::new();
-            let (none_ptr, none_len) = str_to_c_params(none.as_str());
+            let cstr = to_cstring!(none);
+            let (none_ptr, none_len) = (cstr.as_ptr(), cstr.as_bytes().len());
 
             let compiled_unit = unsafe {
                 LLVMDIBuilderCreateCompileUnit(
@@ -185,19 +183,15 @@ impl DIBuilder {
                 )
             };
 
-            // check the name
-            let mut src_len: ::libc::size_t = 0;
-            let src_ptr = unsafe { LLVMGetSourceFileName(module_di, &mut src_len) };
-            let src1 = from_raw_slice_to_string(src_ptr, src_len);
-            debug!(target: "dwarf", "Self-check: module {:#?} has source {:#?}", module_name, src1);
-
-            // create compiled unit
+            // create di module
             let parent_scope = compiled_unit;
             let name = module_name;
-            let (name_ptr, name_len) = str_to_c_params(name.as_str());
-            let (config_macros_ptr, config_macros_len) = str_to_c_params(none.as_str());
-            let (include_path_ptr, include_path_len) = str_to_c_params(none.as_str());
-            let (api_notes_file_ptr, api_notes_file_len) = str_to_c_params(none.as_str());
+            let cstr = to_cstring!(name);
+            let (name_ptr, name_len) = (cstr.as_ptr(), cstr.as_bytes().len());
+
+            let (config_macros_ptr, config_macros_len) = (none_ptr, none_len);
+            let (include_path_ptr, include_path_len) = (none_ptr, none_len);
+            let (api_notes_file_ptr, api_notes_file_len) = (none_ptr, none_len);
             let compiled_module = unsafe {
                 LLVMDIBuilderCreateModule(
                     builder_ref,

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -91,4 +91,3 @@ harness = false
 [[test]]
 name = "dwarf-tests"
 harness = false
-

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -87,3 +87,8 @@ harness = false
 [[test]]
 name = "cli-tests"
 harness = false
+
+[[test]]
+name = "dwarf-tests"
+harness = false
+

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
@@ -1,0 +1,128 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests of compilation from .move to LLVM IR with resolution against Move stdlib.
+//!
+//! # Usage
+//!
+//! These tests require `move-compiler` to be pre-built:
+//!
+//! ```
+//! cargo build -p move-compiler
+//! ```
+//!
+//! Running the tests:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test dwarf-tests
+//! ```
+//!
+//! Running a specific test:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test dwarf-tests -- basic-coin.move
+//! ```
+//!
+//! Promoting all results to expected results:
+//!
+//! ```
+//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test dwarf-tests
+//! ```
+//!
+//! # Details
+//!
+//! They do the following:
+//!
+//! - Create a test for every .move file in dwarf-tests/, for example for test basic-coin.move
+//! directort basic-coin-build is created.
+//! - Run `move-mv-llvm-compiler` twice:
+//! -- with dependency -p option set as relative path - sub-directory relative_path_results will be created;
+//! -- with dependency -p option set as absolute path - sub-directory absolute_path_results will be created.
+//! - Compare the actual IR to an existing expected IR in each directory.
+//!
+//! If the `PROMOTE_LLVM_IR` env var is set, the actual IR is promoted to the
+//! expected IR.
+//!
+
+use std::{env, path::{Path, PathBuf}};
+
+mod test_common;
+use anyhow::bail;
+use test_common as tc;
+
+pub const TEST_DIR: &str = "tests/dwarf-tests";
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
+
+fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    tc::setup_logging_for_test();
+    Ok(run_test_inner(test_path)?)
+}
+
+fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
+    let harness_paths = tc::get_harness_paths("move-compiler")?;
+    let test_plan = tc::get_test_plan(test_path)?;
+
+    if test_plan.should_ignore() {
+        eprintln!("ignoring {}", test_plan.name);
+        return Ok(());
+    }
+
+    let current_dir = env::current_dir()
+        .or_else(|err| bail!("Cannot get currecnt directory. Got error: {}", err))
+        .unwrap();
+
+    let test_name = &test_plan.name;
+
+    let toml_dir: String;
+    if let Some(pos) = test_name.rfind('.') {
+        toml_dir = test_name[..pos].to_string();
+    } else {
+        bail!("No extension found in the filename {}", test_name);
+    }
+
+    let p_absolute_path = current_dir.join(&toml_dir).to_str().unwrap().to_owned();
+
+    let src = &test_plan.build_dir;
+    let dst = &src.join("stored_results");
+
+    tc::clean_results(src)?;
+    tc::clean_directory(dst)?;
+
+    /////////////////////
+    // test absolute path
+    tc::run_move_to_llvm_build(
+        &harness_paths,
+        &test_plan,
+        vec![&"-p".to_string(), &p_absolute_path, &"-g".to_string()],
+    )?;
+
+    tc::remove_files_with_extension(src, "actual")?;
+    rename_dwarf_files(&test_plan);
+    tc::compare_results(&test_plan)?;
+
+    tc::store_results(src, dst)?;
+
+    Ok(())
+}
+
+fn rename_dwarf_files(test_plan: &tc::TestPlan) {
+    // let move_file = &test_plan.move_file;
+    let build_dir = &test_plan.build_dir;
+
+    if !build_dir.exists() {
+        return; //  Err(anyhow::anyhow!("Building directory does not exist"));
+    }
+
+    // match find_matching_files(build_dir, "actual", "expected") {
+    match tc::list_files_with_extension(build_dir, "debug_info") {
+        Ok(files) => {
+            for file in files {
+                tc::switch_last_two_extensions_and_rename(&PathBuf::from(file));
+            }
+        }
+        Err(_err) => {
+        }
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests of compilation from .move to LLVM IR with resolution against Move stdlib.
+//! Tests of compilation generated debug information. Only *.dbg_info files are checked.
 //!
 //! # Usage
 //!
@@ -24,26 +24,14 @@
 //! cargo test -p move-mv-llvm-compiler --test dwarf-tests -- basic-coin.move
 //! ```
 //!
-//! Promoting all results to expected results:
-//!
-//! ```
-//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test dwarf-tests
-//! ```
-//!
 //! # Details
 //!
 //! They do the following:
 //!
 //! - Create a test for every .move file in dwarf-tests/, for example for test basic-coin.move
 //! directort basic-coin-build is created.
-//! - Run `move-mv-llvm-compiler` twice:
-//! -- with dependency -p option set as relative path - sub-directory relative_path_results will be created;
-//! -- with dependency -p option set as absolute path - sub-directory absolute_path_results will be created.
-//! - Compare the actual IR to an existing expected IR in each directory.
-//!
-//! If the `PROMOTE_LLVM_IR` env var is set, the actual IR is promoted to the
-//! expected IR.
-//!
+//! - Run `move-mv-llvm-compiler` with -g option. This will create *.dbg_info files.
+//! - Compare the dbg_info.actual files with dbg_info.expected files.
 
 use std::{
     env,
@@ -102,10 +90,11 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
     )?;
 
     tc::remove_files_with_extension(src, "actual")?;
-    rename_dwarf_files(&test_plan);
+    rename_dwarf_files(&test_plan); // will rename *.actual.dbg_info to *.dbg_info.actual
     tc::compare_results(&test_plan)?;
 
     tc::store_results(src, dst)?;
+    tc::clean_results(src)?;
 
     Ok(())
 }

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
@@ -45,7 +45,10 @@
 //! expected IR.
 //!
 
-use std::{env, path::{Path, PathBuf}};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 mod test_common;
 use anyhow::bail;
@@ -82,7 +85,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
         bail!("No extension found in the filename {}", test_name);
     }
 
-    let p_absolute_path = current_dir.join(&toml_dir).to_str().unwrap().to_owned();
+    let p_absolute_path = current_dir.join(toml_dir).to_str().unwrap().to_owned();
 
     let src = &test_plan.build_dir;
     let dst = &src.join("stored_results");
@@ -122,7 +125,6 @@ fn rename_dwarf_files(test_plan: &tc::TestPlan) {
                 tc::switch_last_two_extensions_and_rename(&PathBuf::from(file));
             }
         }
-        Err(_err) => {
-        }
+        Err(_err) => {}
     }
 }

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
@@ -1,0 +1,7 @@
+; ModuleID = '0x1__signer.dbg_info'
+source_filename = "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/./../../../../../move-stdlib/sources/signer.move"
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
+!1 = !DIFile(filename: "signer.move", directory: "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/./../../../../../move-stdlib/sources")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
@@ -1,7 +1,7 @@
 ; ModuleID = '0x1__signer.dbg_info'
-source_filename = "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/./../../../../../move-stdlib/sources/signer.move"
+source_filename = "/language/move-stdlib/sources/signer.move"
 
 !llvm.dbg.cu = !{!0}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
-!1 = !DIFile(filename: "signer.move", directory: "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/./../../../../../move-stdlib/sources")
+!1 = !DIFile(filename: "signer.move", directory: "/language/move-stdlib/sources")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
@@ -1,7 +1,7 @@
 ; ModuleID = '0xcafe__BasicCoin.dbg_info'
-source_filename = "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move"
+source_filename = "/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move"
 
 !llvm.dbg.cu = !{!0}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
-!1 = !DIFile(filename: "basic-coin.move", directory: "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests")
+!1 = !DIFile(filename: "basic-coin.move", directory: "/language/tools/move-mv-llvm-compiler/tests/dwarf-tests")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
@@ -1,0 +1,7 @@
+; ModuleID = '0xcafe__BasicCoin.dbg_info'
+source_filename = "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move"
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
+!1 = !DIFile(filename: "basic-coin.move", directory: "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/dwarf-tests")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move
@@ -1,0 +1,100 @@
+/// This module defines a minimal and generic Coin and Balance.
+module NamedAddr::BasicCoin {
+    use std::signer;
+
+    /// Error codes
+    const ENOT_MODULE_OWNER: u64 = 0;
+    const EINSUFFICIENT_BALANCE: u64 = 1;
+    const EALREADY_HAS_BALANCE: u64 = 2;
+    const EEQUAL_ADDR: u64 = 4;
+
+    struct Coin<phantom CoinType> has store {
+        value: u64
+    }
+
+    struct Balance<phantom CoinType> has key {
+        coin: Coin<CoinType>
+    }
+
+    /// Publish an empty balance resource under `account`'s address. This function must be called before
+    /// minting or transferring to the account.
+    public fun publish_balance<CoinType>(account: &signer) {
+        let empty_coin = Coin<CoinType> { value: 0 };
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
+        move_to(account, Balance<CoinType> { coin: empty_coin });
+    }
+
+    /// Mint `amount` tokens to `mint_addr`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the minting policy.
+    public fun mint<CoinType: drop>(mint_addr: address, amount: u64, _witness: CoinType) acquires Balance {
+        // Deposit `total_value` amount of tokens to mint_addr's balance
+        deposit(mint_addr, Coin<CoinType> { value: amount });
+    }
+
+    public fun balance_of<CoinType>(owner: address): u64 acquires Balance {
+        borrow_global<Balance<CoinType>>(owner).coin.value
+    }
+
+    spec balance_of {
+        pragma aborts_if_is_strict;
+        aborts_if !exists<Balance<CoinType>>(owner);
+    }
+
+    /// Transfers `amount` of tokens from `from` to `to`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the transferring policy.
+    public fun transfer<CoinType: drop>(from: &signer, to: address, amount: u64, _witness: CoinType) acquires Balance {
+        let from_addr = signer::address_of(from);
+        assert!(from_addr != to, EEQUAL_ADDR);
+        let check = withdraw<CoinType>(from_addr, amount);
+        deposit<CoinType>(to, check);
+    }
+
+    spec transfer {
+        let addr_from = signer::address_of(from);
+
+        let balance_from = global<Balance<CoinType>>(addr_from).coin.value;
+        let balance_to = global<Balance<CoinType>>(to).coin.value;
+        let post balance_from_post = global<Balance<CoinType>>(addr_from).coin.value;
+        let post balance_to_post = global<Balance<CoinType>>(to).coin.value;
+
+        ensures balance_from_post == balance_from - amount;
+        ensures balance_to_post == balance_to + amount;
+    }
+
+    fun withdraw<CoinType>(addr: address, amount: u64) : Coin<CoinType> acquires Balance {
+        let balance = balance_of<CoinType>(addr);
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        *balance_ref = balance - amount;
+        Coin<CoinType> { value: amount }
+    }
+
+    spec withdraw {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance < amount;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures result == Coin<CoinType> { value: amount };
+        ensures balance_post == balance - amount;
+    }
+
+    fun deposit<CoinType>(addr: address, check: Coin<CoinType>) acquires Balance{
+        let balance = balance_of<CoinType>(addr);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        let Coin { value } = check;
+        *balance_ref = balance + value;
+    }
+
+    spec deposit {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+        let check_value = check.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance + check_value > MAX_U64;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures balance_post == balance + check_value;
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "BasicCoin"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib/" }

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -816,7 +816,10 @@ pub fn switch_last_two_extensions_and_rename(path: &Path) {
     }
 }
 
-pub fn list_files_with_extension(directory_path: &Path, extension: &str) -> std::io::Result<Vec<String>> {
+pub fn list_files_with_extension(
+    directory_path: &Path,
+    extension: &str,
+) -> std::io::Result<Vec<String>> {
     let dir = fs::read_dir(directory_path)?;
 
     let file_names: Vec<String> = dir
@@ -845,16 +848,12 @@ pub fn list_files_with_extension(directory_path: &Path, extension: &str) -> std:
 pub fn remove_files_with_extension(directory_path: &Path, extension: &str) -> std::io::Result<()> {
     let dir = fs::read_dir(directory_path)?;
 
-    for entry in dir {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            if path.is_file() {
-                if let Some(ext) = path.extension() {
-                    if ext == extension {
-                        // Delete the file with the specified extension
-                        fs::remove_file(&path)?;
-                        println!("Removed: {:?}", path);
-                    }
+    for entry in dir.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == extension {
+                    fs::remove_file(&path)?;
                 }
             }
         }

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -416,8 +416,6 @@ pub fn run_move_to_llvm_build(
     fs::create_dir_all(test_plan.build_dir.to_str().unwrap()).expect("Directory does not exist");
     cmd.args(["-o", test_plan.build_dir.to_str().expect("utf-8")]);
 
-    dbg!(&cmd);
-
     let output = cmd.output()?;
 
     if !output.status.success() {

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -861,18 +861,20 @@ pub fn remove_files_with_extension(directory_path: &Path, extension: &str) -> st
 }
 
 pub fn clean_directory(directory_path: &Path) -> std::io::Result<()> {
-    for entry in fs::read_dir(directory_path)? {
-        let entry = entry?;
-        let entry_path = entry.path();
+    if fs::metadata(directory_path).is_ok() {
+        for entry in fs::read_dir(directory_path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
 
-        if entry_path.is_dir() {
-            // If the entry is a directory, recursively clean it
-            clean_directory(&entry_path)?;
-            // After cleaning the subdirectory, remove it
-            fs::remove_dir(&entry_path)?;
-        } else if entry_path.is_file() {
-            // If the entry is a file, remove it
-            fs::remove_file(&entry_path)?;
+            if entry_path.is_dir() {
+                // If the entry is a directory, recursively clean it
+                clean_directory(&entry_path)?;
+                // After cleaning the subdirectory, remove it
+                fs::remove_dir(&entry_path)?;
+            } else if entry_path.is_file() {
+                // If the entry is a file, remove it
+                fs::remove_file(&entry_path)?;
+            }
         }
     }
 


### PR DESCRIPTION
Added dwarf_tests.rs.

Also added macro `macro_rules! to_cstring`, since usage of the pointer and len of a local CString in a call was incorrect.

Since .dbg_info contains the absolute paths of source names, the content of .dbg_info becomes host sensitive. Test_common.rs was updated with code that helps to mask out this sensitivity before comparison of .actual vs .expected.
