### PR TITLE
Add Dwarf test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ target-out-docker
 **/move-mv-llvm-compiler/**/cli-tests/**/*.ll.actual
 **/move-mv-llvm-compiler/**/cli-tests/basic-coin-build/absolute_path_results/*
 **/move-mv-llvm-compiler/**/cli-tests/basic-coin-build/relative_path_results/*
+**/move-mv-llvm-compiler/**/dwarf-tests/basic-coin-build/stored_results/*
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.mv
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.o
 **/move-mv-llvm-compiler/**/rbpf-tests/**/*.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "num-traits 0.2.16",
  "once_cell",
  "parking_lot 0.11.1",
+ "rand 0.8.5",
  "regex",
  "semver 1.0.17",
  "serde 1.0.188",

--- a/language/tools/move-mv-llvm-compiler/Cargo.toml
+++ b/language/tools/move-mv-llvm-compiler/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = "1.10"
 parking_lot = "0.11"
 toml = "0.5.8"
 regex = "1.1.9"
+rand = "0.8"
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-command-line-common = { path = "../../move-command-line-common" }
@@ -86,4 +87,8 @@ harness = false
 
 [[test]]
 name = "cli-tests"
+harness = false
+
+[[test]]
+name = "dwarf-tests"
 harness = false

--- a/language/tools/move-mv-llvm-compiler/docs/Development.md
+++ b/language/tools/move-mv-llvm-compiler/docs/Development.md
@@ -193,6 +193,24 @@ Install [CodeLLDB plugin](https://marketplace.visualstudio.com/items?itemName=va
 
 - lldb with gdbserver
 
+To debug in VS Code add this config:
+ {
+    "type": "lldb",
+    "request": "launch",
+    "name": "dwarf-tests direct call",
+    "env": {
+            "RUST_BACKTRACE": "all",
+            "RUST_LOG": "debug",
+            "CARGO_MANIFEST_DIR": "something like /home/sol/work/git/move/language/tools/move-mv-llvm-compiler",
+            "LLVM_SYS_150_PREFIX": "something like /home/sol/work/git/platform-tools/out/rust/build/x86_64-unknown-linux-gnu/llvm",
+            "PLATFORM_TOOLS_ROOT": "something like /home/sol/work/git/platform-tools/out/deploy"
+    },
+    "program": "something like /home/sol/work/git/move/target/debug/deps/dwarf_tests-XXXXXXXXXXXXXXXX",
+    "args": ["--test"],
+    "cwd": "something like /home/sol/work/git/move/language/tools/move-mv-llvm-compiler",
+    "stopOnEntry": false
+ }
+
 ### Protip
 
 ----

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
@@ -98,7 +98,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
     match tc::list_files_with_extension(src, "debug_info") {
         Ok(files) => {
             for file in files {
-                tc::filter_file(&file, spot, tc::erase_spot_from_line)?;
+                tc::filter_file(&file, spot, |line: &str, spot: &str| line.replace(spot, ""))?;
             }
         }
         Err(_err) => {}

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests.rs
@@ -1,0 +1,127 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests of compilation generated debug information. Only *.dbg_info files are checked.
+//!
+//! # Usage
+//!
+//! These tests require `move-compiler` to be pre-built:
+//!
+//! ```
+//! cargo build -p move-compiler
+//! ```
+//!
+//! Running the tests:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test dwarf-tests
+//! ```
+//!
+//! Running a specific test:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test dwarf-tests -- basic-coin.move
+//! ```
+//!
+//! # Details
+//!
+//! They do the following:
+//!
+//! - Create a test for every .move file in dwarf-tests/, for example for test basic-coin.move
+//! directort basic-coin-build is created.
+//! - Run `move-mv-llvm-compiler` with -g option. This will create *.dbg_info files.
+//! - Compare the dbg_info.actual files with dbg_info.expected files.
+
+use std::{env, path::Path};
+
+mod test_common;
+use anyhow::bail;
+use test_common as tc;
+
+pub const TEST_DIR: &str = "tests/dwarf-tests";
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
+
+fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    tc::setup_logging_for_test();
+    Ok(run_test_inner(test_path)?)
+}
+
+fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
+    let harness_paths = tc::get_harness_paths("move-compiler")?;
+    let test_plan = tc::get_test_plan(test_path)?;
+
+    if test_plan.should_ignore() {
+        eprintln!("ignoring {}", test_plan.name);
+        return Ok(());
+    }
+
+    let current_dir = env::current_dir()
+        .or_else(|err| bail!("Cannot get currecnt directory. Got error: {}", err))
+        .unwrap();
+
+    let test_name = &test_plan.name;
+
+    let toml_dir: String;
+    if let Some(pos) = test_name.rfind('.') {
+        toml_dir = test_name[..pos].to_string();
+    } else {
+        bail!("No extension found in the filename {}", test_name);
+    }
+
+    let p_absolute_path = current_dir.join(toml_dir).to_str().unwrap().to_owned();
+
+    let src = &test_plan.build_dir;
+    let dst = &src.join("stored_results");
+
+    tc::clean_results(src)?;
+    std::fs::remove_dir_all(dst).ok();
+
+    tc::run_move_to_llvm_build(
+        &harness_paths,
+        &test_plan,
+        vec![&"-p".to_string(), &p_absolute_path, &"-g".to_string()],
+    )?;
+
+    // remove .actual files; this will not remove.dbg_info files
+    tc::clean_results(src)?;
+
+    let spot = current_dir
+        .ancestors()
+        .nth(3)
+        .expect("Cannot go up in directory")
+        .to_str()
+        .unwrap();
+
+    // dbg_info files contain lines with absolute path, since it is host dependent, remove prefix in all paths.
+    match tc::list_files_with_extension(src, "debug_info") {
+        Ok(files) => {
+            for file in files {
+                tc::filter_file(&file, spot, tc::erase_spot_from_line)?;
+            }
+        }
+        Err(_err) => {}
+    }
+
+    rename_dwarf_files(&test_plan); // will rename *.actual.dbg_info to *.dbg_info.actual
+    tc::compare_results(&test_plan)?;
+
+    tc::store_results(src, dst)?;
+    tc::clean_results(src)?;
+
+    Ok(())
+}
+
+fn rename_dwarf_files(test_plan: &tc::TestPlan) {
+    let build_dir = &test_plan.build_dir;
+
+    match tc::list_files_with_extension(build_dir, "debug_info") {
+        Ok(files) => {
+            for file in files {
+                tc::switch_last_two_extensions_and_rename(&file);
+            }
+        }
+        Err(_err) => {}
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0x1__signer.ll.debug_info.expected
@@ -1,0 +1,7 @@
+; ModuleID = '0x1__signer.dbg_info'
+source_filename = "/language/move-stdlib/sources/signer.move"
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
+!1 = !DIFile(filename: "signer.move", directory: "/language/move-stdlib/sources")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin-build/0xcafe__BasicCoin.ll.debug_info.expected
@@ -1,0 +1,7 @@
+; ModuleID = '0xcafe__BasicCoin.dbg_info'
+source_filename = "/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move"
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
+!1 = !DIFile(filename: "basic-coin.move", directory: "/language/tools/move-mv-llvm-compiler/tests/dwarf-tests")

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin.move
@@ -1,0 +1,100 @@
+/// This module defines a minimal and generic Coin and Balance.
+module NamedAddr::BasicCoin {
+    use std::signer;
+
+    /// Error codes
+    const ENOT_MODULE_OWNER: u64 = 0;
+    const EINSUFFICIENT_BALANCE: u64 = 1;
+    const EALREADY_HAS_BALANCE: u64 = 2;
+    const EEQUAL_ADDR: u64 = 4;
+
+    struct Coin<phantom CoinType> has store {
+        value: u64
+    }
+
+    struct Balance<phantom CoinType> has key {
+        coin: Coin<CoinType>
+    }
+
+    /// Publish an empty balance resource under `account`'s address. This function must be called before
+    /// minting or transferring to the account.
+    public fun publish_balance<CoinType>(account: &signer) {
+        let empty_coin = Coin<CoinType> { value: 0 };
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
+        move_to(account, Balance<CoinType> { coin: empty_coin });
+    }
+
+    /// Mint `amount` tokens to `mint_addr`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the minting policy.
+    public fun mint<CoinType: drop>(mint_addr: address, amount: u64, _witness: CoinType) acquires Balance {
+        // Deposit `total_value` amount of tokens to mint_addr's balance
+        deposit(mint_addr, Coin<CoinType> { value: amount });
+    }
+
+    public fun balance_of<CoinType>(owner: address): u64 acquires Balance {
+        borrow_global<Balance<CoinType>>(owner).coin.value
+    }
+
+    spec balance_of {
+        pragma aborts_if_is_strict;
+        aborts_if !exists<Balance<CoinType>>(owner);
+    }
+
+    /// Transfers `amount` of tokens from `from` to `to`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the transferring policy.
+    public fun transfer<CoinType: drop>(from: &signer, to: address, amount: u64, _witness: CoinType) acquires Balance {
+        let from_addr = signer::address_of(from);
+        assert!(from_addr != to, EEQUAL_ADDR);
+        let check = withdraw<CoinType>(from_addr, amount);
+        deposit<CoinType>(to, check);
+    }
+
+    spec transfer {
+        let addr_from = signer::address_of(from);
+
+        let balance_from = global<Balance<CoinType>>(addr_from).coin.value;
+        let balance_to = global<Balance<CoinType>>(to).coin.value;
+        let post balance_from_post = global<Balance<CoinType>>(addr_from).coin.value;
+        let post balance_to_post = global<Balance<CoinType>>(to).coin.value;
+
+        ensures balance_from_post == balance_from - amount;
+        ensures balance_to_post == balance_to + amount;
+    }
+
+    fun withdraw<CoinType>(addr: address, amount: u64) : Coin<CoinType> acquires Balance {
+        let balance = balance_of<CoinType>(addr);
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        *balance_ref = balance - amount;
+        Coin<CoinType> { value: amount }
+    }
+
+    spec withdraw {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance < amount;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures result == Coin<CoinType> { value: amount };
+        ensures balance_post == balance - amount;
+    }
+
+    fun deposit<CoinType>(addr: address, check: Coin<CoinType>) acquires Balance{
+        let balance = balance_of<CoinType>(addr);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        let Coin { value } = check;
+        *balance_ref = balance + value;
+    }
+
+    spec deposit {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+        let check_value = check.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance + check_value > MAX_U64;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures balance_post == balance + check_value;
+    }
+}

--- a/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
+++ b/language/tools/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "BasicCoin"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib/" }

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -5,12 +5,12 @@
 use anyhow::Context;
 use core::result::Result::Ok;
 use log::debug;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 use std::{
     ffi::OsStr,
-    fs,
-    fs::File,
+    fs::{self, File},
     io::{BufRead, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
     process::Command,
@@ -835,14 +835,6 @@ pub fn list_files_with_extension(
     Ok(file_names)
 }
 
-pub fn erase_spot_from_line(line: &str, spot: &str) -> String {
-    if let Some(index) = line.find(spot) {
-        line[..index].to_string() + &line[(index + spot.len())..]
-    } else {
-        line.to_string()
-    }
-}
-
 pub fn filter_file<F>(file_path: &PathBuf, filter_key: &str, mut filter: F) -> std::io::Result<()>
 where
     F: FnMut(&str, &str) -> String,
@@ -870,9 +862,6 @@ where
 
     Ok(())
 }
-
-extern crate rand;
-use rand::Rng;
 
 fn generate_random_number() -> u32 {
     let mut rng = rand::thread_rng();

--- a/language/tools/move-mv-llvm-compiler/tests/test_common.rs
+++ b/language/tools/move-mv-llvm-compiler/tests/test_common.rs
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)]
 use anyhow::Context;
+use core::result::Result::Ok;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 use std::{
     ffi::OsStr,
     fs,
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -396,7 +399,6 @@ pub fn run_move_build_full(
     Ok(())
 }
 
-// use std::io::{self, Write};
 pub fn run_move_to_llvm_build(
     harness_paths: &HarnessPaths,
     test_plan: &TestPlan,
@@ -774,6 +776,7 @@ pub fn store_results<P: AsRef<Path>>(source: P, destination: P) -> std::io::Resu
     Ok(())
 }
 
+// Removes files with extension "actual"
 pub fn clean_results<P: AsRef<Path>>(source: P) -> std::io::Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
@@ -789,4 +792,106 @@ pub fn clean_results<P: AsRef<Path>>(source: P) -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+pub fn switch_last_two_extensions_and_rename(path: &Path) {
+    if let Some(filename) = path.file_name() {
+        if let Some(filename_str) = filename.to_str() {
+            let mut parts: Vec<&str> = filename_str.split('.').collect();
+
+            if parts.len() >= 3 {
+                // Swap the last two extensions
+                let last_ext = parts.pop().unwrap();
+                let second_last_ext = parts.pop().unwrap();
+                parts.push(last_ext);
+                parts.push(second_last_ext);
+
+                let new_filename = parts.join(".");
+
+                let mut new_path = path.to_path_buf();
+                new_path.set_file_name(new_filename);
+
+                fs::rename(path, new_path).expect("Error in renameing");
+            }
+        }
+    }
+}
+
+use std::ffi::OsString;
+pub fn list_files_with_extension(
+    directory_path: &Path,
+    extension: &str,
+) -> std::io::Result<Vec<PathBuf>> {
+    let dir = fs::read_dir(directory_path)?;
+    let dummy = OsString::from(extension.to_owned() + "dummy");
+    let dummy_ext = dummy.as_os_str();
+
+    let file_names: Vec<PathBuf> = dir
+        .filter_map(anyhow::Result::ok)
+        .filter(|f| extension == f.path().extension().unwrap_or(dummy_ext))
+        .map(|f| f.path())
+        .collect();
+
+    Ok(file_names)
+}
+
+pub fn erase_spot_from_line(line: &str, spot: &str) -> String {
+    if let Some(index) = line.find(spot) {
+        line[..index].to_string() + &line[(index + spot.len())..]
+    } else {
+        line.to_string()
+    }
+}
+
+pub fn filter_file<F>(file_path: &PathBuf, filter_key: &str, mut filter: F) -> std::io::Result<()>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    // Open the original file for reading
+    let input_file = File::open(file_path)?;
+    let input_file_reader = BufReader::new(input_file);
+
+    // Create a temporary file for writing the modified content
+    let random_extension = generate_random_string();
+    let tmp_file_path = file_path.with_extension(random_extension);
+    let tmp_file = File::create(&tmp_file_path)?;
+    let mut tmp_file_writer = BufWriter::new(tmp_file);
+
+    for line in input_file_reader.lines() {
+        let original_line = line?;
+        let modified_line = filter(&original_line, filter_key);
+
+        // Write the modified line to the temporary file
+        writeln!(tmp_file_writer, "{}", modified_line)?;
+    }
+
+    // Replace the original file with the temporary file
+    std::fs::rename(&tmp_file_path, file_path)?;
+
+    Ok(())
+}
+
+extern crate rand;
+use rand::Rng;
+
+fn generate_random_number() -> u32 {
+    let mut rng = rand::thread_rng();
+    rng.gen::<u32>()
+}
+
+fn generate_random_string() -> String {
+    let rand = generate_random_number();
+    let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let charset_length = charset.len();
+    let length = rand as usize % charset_length;
+
+    let mut rng = rand::thread_rng();
+    let random_string: String = (0..length)
+        .map(|_| {
+            let index = rng.gen_range(0..charset_length);
+            charset.chars().nth(index).unwrap()
+        })
+        .collect();
+
+    random_string
 }


### PR DESCRIPTION
Added dwarf_tests.rs.

Also added macro macro_rules! to_cstring, since usage of the pointer and len of a local CString in a call was incorrect.

Since .dbg_info contains the absolute paths of source names, the content of .dbg_info becomes host sensitive. Test_common.rs was updated with code that helps to mask out this sensitivity before comparison of .actual vs .expected.