### PR TITLE
Fix ABI of move_rt_str_cmp_eq and move_rt_deserialize

### DIFF
--- a/language/move-native/src/rt.rs
+++ b/language/move-native/src/rt.rs
@@ -45,8 +45,17 @@ unsafe extern "C" fn vec_cmp_eq(
 }
 
 #[export_name = "move_rt_str_cmp_eq"]
-unsafe fn str_cmp_eq(s1: &str, s2: &str) -> bool {
-    *s1 == *s2
+unsafe extern "C" fn str_cmp_eq(
+    s1_ptr: *const u8,
+    s1_len: u64,
+    s2_ptr: *const u8,
+    s2_len: u64,
+) -> bool {
+    let s1 = core::slice::from_raw_parts(s1_ptr, usize::try_from(s1_len).expect("usize"));
+    let s1 = core::str::from_utf8_unchecked(s1); // assume utf8
+    let s2 = core::slice::from_raw_parts(s2_ptr, usize::try_from(s2_len).expect("usize"));
+    let s2 = core::str::from_utf8_unchecked(s2); // assume utf8
+    s1 == s2
 }
 
 #[export_name = "move_rt_struct_cmp_eq"]


### PR DESCRIPTION
I was prototyping some type signatures for storage-related runtime calls and saw that these declarations had issues.

The ABI here technically worked as written, but is not defined to work according to Rust.

Any function called through FFI needs to be declared `extern "C"` to have a well-defined ABI and these weren't. Adding those declarations and the compiler printed warnings for some additional problems with the types used in these signatures.

## move_rt_str_cmp_eq

This function accepted two string slices as arguments, but Rust slices do not have a defined layout. These args are now passed as ptr, len, ptr, len; which is actually how they are declared in LLVM. I thought it was pretty interesting that the LLVM lowering actually agreed with the Rust slice argument lowering.

## move_rt_deserialize

This function returned a tuple, but Rust tuples (surprisingly) do not have defined layout, though they in practice have struct layout. I changed the return type to be a `repr(C)` struct. This aggregate return type also contained a slice, which I changed to a `repr(C)` struct of ptr, len so that it agrees with the LLVM declaration.

I also removed the `pub` declarations from `deserialize` and its constants, as they are not needed.