### PR TITLE
WIP]] Dwarf struct

### DIFF
--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -57,6 +57,7 @@ pub fn get_attr_kind_for_name(attr_name: &str) -> Option<usize> {
         }
     }
 }
+
 #[derive(Debug)]
 pub struct Context(LLVMContextRef);
 

--- a/language/solana/move-to-solana/src/stackless/llvm.rs
+++ b/language/solana/move-to-solana/src/stackless/llvm.rs
@@ -57,7 +57,7 @@ pub fn get_attr_kind_for_name(attr_name: &str) -> Option<usize> {
         }
     }
 }
-
+#[derive(Debug)]
 pub struct Context(LLVMContextRef);
 
 impl Drop for Context {

--- a/language/solana/move-to-solana/src/stackless/module_context.rs
+++ b/language/solana/move-to-solana/src/stackless/module_context.rs
@@ -240,9 +240,6 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
     // e.g. Struct_A<Vector<Struct_B<T>>>, where T is substituted by a
     // concrete type, won't be declared correctly.
     fn translate_struct(&self, s_env: &mm::StructEnv<'mm>, tyvec: &[mty::Type]) {
-        let id = s_env.get_identifier();
-        dbg!(id);
-        // let llvm_di_builder = &self.llvm_di_builder;
         let ll_name = s_env.ll_struct_name_from_raw_name(tyvec);
         debug!(target: "structs", "translating struct {}", s_env.struct_raw_type_name(tyvec));
         // Visit each field in this struct, collecting field types.

--- a/language/solana/move-to-solana/src/stackless/translate.rs
+++ b/language/solana/move-to-solana/src/stackless/translate.rs
@@ -37,6 +37,8 @@ use crate::{
         rttydesc::RttyContext,
     },
 };
+use codespan::Location;
+use llvm_sys::core::LLVMGetModuleContext;
 use log::debug;
 use move_core_types::{account_address, u256::U256, vm_status::StatusCode::ARITHMETIC_ERROR};
 use move_model::{ast as mast, model as mm, ty as mty};
@@ -301,6 +303,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         }
 
         // Translate instructions
+        dbg!(&fn_data.code);
         for instr in &fn_data.code {
             self.translate_instruction(instr);
         }
@@ -1110,6 +1113,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         use sbc::Operation;
         let emitter_nop: CheckEmitterFn = (|_, _| (), EmitterFnKind::PreCheck);
         let builder = &self.module_cx.llvm_builder;
+        // let m_context = self.module_cx.llvm_cx;
+        // dbg!(m_context);
+        let di_builder = &self.module_cx.llvm_di_builder;
+        dbg!(di_builder);
         match op {
             Operation::Function(mod_id, fun_id, types) => {
                 let types = mty::Type::instantiate_vec(types.to_vec(), self.type_params);
@@ -1156,6 +1163,8 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     .llvm_cx
                     .named_struct_type(&struct_name)
                     .expect("no struct type");
+                // let struct_ctx = &stype.get_context();
+                // dbg!(struct_ctx);
                 let fvals = src
                     .iter()
                     .map(|i| (self.locals[*i].llty, self.locals[*i].llval))
@@ -1163,6 +1172,22 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 let dst_idx = dst[0];
                 let ldst = (self.locals[dst_idx].llty, self.locals[dst_idx].llval);
                 builder.insert_fields_and_store(&fvals, ldst, stype);
+                if let Some(module) = di_builder.module_di() {
+                    dbg!(&module);
+                    let context = unsafe { LLVMGetModuleContext(module) };
+                    dbg!(context);
+                } else {
+                };
+                let loc = struct_env.get_loc();
+                let (filename, location) = struct_env
+                    .module_env
+                    .env
+                    .get_file_and_location(&loc)
+                    .unwrap_or(("unknown".to_string(), Location::new(0, 0)));
+                dbg!(&op);
+                dbg!(filename);
+                dbg!(location.line.0);
+                di_builder.create_struct_di(&struct_name, location.line.0);
             }
             Operation::Unpack(mod_id, struct_id, types) => {
                 let types = mty::Type::instantiate_vec(types.to_vec(), self.type_params);


### PR DESCRIPTION
Added dwarf info for struct. 
For simple struct like
```
module 0x100::M {

    struct MyStruct {
        field1: u32,
        field2: bool,
        field3: EmptyStruct
    }

    struct EmptyStruct {}

    public fun boofun(): 0x100::M::MyStruct {
        MyStruct { field1: 32, field2: true, field3: EmptyStruct {} }
    }
}
```

expected:

```
; ModuleID = '0x100__M.dbg_info'
source_filename = "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests/struct01.move"

!llvm.dbg.cu = !{!0}
!struct.M__EmptyStruct = !{!2}
!struct.M__MyStruct = !{!8}

!0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
!1 = !DIFile(filename: "struct01.move", directory: "/home/sol/work/git/move-100623/language/tools/move-mv-llvm-compiler/tests/move-to-llvm-tests")
!2 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "struct.M__EmptyStruct__ptr", baseType: !3, size: 192, align: 192, dwarfAddressSpace: 0)
!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct.M__EmptyStruct", scope: !4, file: !1, line: 9, flags: DIFlagObjcClassComplete, elements: !5)
!4 = !DINamespace(name: "struct.M__EmptyStruct", scope: !1)
!5 = !{!6}
!6 = !DIDerivedType(tag: DW_TAG_member, name: "dummy_field", scope: !4, file: !1, line: 10, baseType: !7)
!7 = !DIBasicType(name: "u32", size: 32)
!8 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "struct.M__MyStruct__ptr", baseType: !9, size: 192, align: 192, dwarfAddressSpace: 0)
!9 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct.M__MyStruct", scope: !10, file: !1, line: 3, flags: DIFlagObjcClassComplete, elements: !11)
!10 = !DINamespace(name: "struct.M__MyStruct", scope: !1)
!11 = !{!12, !13, !14}
!12 = !DIDerivedType(tag: DW_TAG_member, name: "field1", scope: !10, file: !1, line: 4, baseType: !7)
!13 = !DIDerivedType(tag: DW_TAG_member, name: "field2", scope: !10, file: !1, line: 5, baseType: !7)
!14 = !DIDerivedType(tag: DW_TAG_member, name: "field3", scope: !10, file: !1, line: 6, baseType: !7)
```
