### PR TITLE
Modify tools path for new releases

### DIFF
--- a/.github/actions/acquire-solana-tools/action.yml
+++ b/.github/actions/acquire-solana-tools/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: |
         mkdir ../llvm
-        curl -L https://github.com/solana-labs/platform-tools/releases/download/v1.38/move-dev-linux-x86_64.tar.bz2 \
+        curl -L https://github.com/solana-labs/platform-tools/releases/download/v1.39/move-dev-linux-x86_64.tar.bz2 \
              -o ../llvm/move-dev-linux-x86_64.tar.bz2
         ls -lh ../llvm
         (cd ../llvm && tar xjf move-dev-linux-x86_64.tar.bz2)
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         mkdir ../platform-tools
-        curl -L https://github.com/solana-labs/platform-tools/releases/download/v1.38/platform-tools-linux-x86_64.tar.bz2 \
+        curl -L https://github.com/solana-labs/platform-tools/releases/download/v1.39/platform-tools-linux-x86_64.tar.bz2 \
              -o ../platform-tools/platform-tools.tar.bz2
         ls -lh ../platform-tools
         (cd ../platform-tools && tar xjf platform-tools.tar.bz2)

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u128-build/modules/0_Test.expected.ll
@@ -154,8 +154,8 @@ join_bb:                                          ; preds = %entry
 ; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare { i128, i1 } @llvm.umul.with.overflow.i128(i128, i128) #1
 
 attributes #0 = { cold noreturn }
-attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u32-build/modules/0_Test.expected.ll
@@ -125,8 +125,8 @@ join_bb:                                          ; preds = %entry
 ; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare { i32, i1 } @llvm.umul.with.overflow.i32(i32, i32) #1
 
 attributes #0 = { cold noreturn }
-attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u64-build/modules/0_Test.expected.ll
@@ -125,8 +125,8 @@ join_bb:                                          ; preds = %entry
 ; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64) #1
 
 attributes #0 = { cold noreturn }
-attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
+++ b/language/tools/move-mv-llvm-compiler/tests/move-ir-tests/math_u8-build/modules/0_Test.expected.ll
@@ -154,8 +154,8 @@ join_bb:                                          ; preds = %entry
 ; Function Attrs: cold noreturn
 declare void @move_rt_abort(i64) #0
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8) #1
 
 attributes #0 = { cold noreturn }
-attributes #1 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/scripts/acquire_solana_tools.sh
+++ b/scripts/acquire_solana_tools.sh
@@ -8,7 +8,7 @@ export MOVE_DEV_PATH
 export PLATFORM_TOOLS_PATH
 
 # platform tools version
-version=v1.38
+version=v1.39
 
 # check os and arch
 OS=$(uname -s)


### PR DESCRIPTION
For toolchain release 1.39. After this patch I can run build commands and tests

```
$ cargo test -p move-mv-llvm-compiler --test ir-tests --test move-ir-tests --test rbpf-tests

$ cargo run -p move-cli --features solana-backend --bin move -- test --solana -p language/move-stdlib
```

Fixes: #408