### PR TITLE
Bring move-stdlib/src/natives/debug.rs on par with sui/debug.rs

### DIFF
--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -171,7 +171,10 @@ pub fn nursery_natives(
     }
 
     add_natives!("event", event::make_all(gas_params.event));
-    add_natives!("debug", debug::make_all(gas_params.debug, move_std_addr));
+    add_natives!(
+        "debug",
+        debug::make_all(true, gas_params.debug, move_std_addr)
+    );
 
     make_table_from_iter(move_std_addr, natives)
 }


### PR DESCRIPTION
Partly addressing #411
Diff between: 
- https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-stdlib/src/natives/debug.rs
- https://github.com/anza-xyz/move/blob/llvm-sys/language/move-stdlib/src/natives/debug.rs

