### PR TITLE
Bring move-stdlib/src/natives/type_name.rs on par with sui version

### DIFF
--- a/language/move-stdlib/src/natives/type_name.rs
+++ b/language/move-stdlib/src/natives/type_name.rs
@@ -20,6 +20,7 @@ pub struct GetGasParameters {
 }
 
 fn native_get(
+    _use_original_id: bool,
     gas_params: &GetGasParameters,
     context: &mut NativeContext,
     ty_args: Vec<Type>,
@@ -42,8 +43,10 @@ fn native_get(
     Ok(NativeResult::ok(cost, smallvec![type_name_val]))
 }
 
-pub fn make_native_get(gas_params: GetGasParameters) -> NativeFunction {
-    Arc::new(move |context, ty_args, args| native_get(&gas_params, context, ty_args, args))
+pub fn make_native_get(use_original_id: bool, gas_params: GetGasParameters) -> NativeFunction {
+    Arc::new(move |context, ty_args, args| {
+        native_get(use_original_id, &gas_params, context, ty_args, args)
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +55,16 @@ pub struct GasParameters {
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [("get", make_native_get(gas_params.get))];
+    let natives = [
+        (
+            "get",
+            make_native_get(/* use_original_id */ false, gas_params.get.clone()),
+        ),
+        (
+            "get_with_original_ids",
+            make_native_get(/* use_original_id */ true, gas_params.get),
+        ),
+    ];
 
     crate::natives::helpers::make_module_natives(natives)
 }


### PR DESCRIPTION
Partially fixes #411

Diff between:
- https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-stdlib/src/natives/type_name.rs
- https://github.com/anza-xyz/move/blob/llvm-sys/language/move-stdlib/src/natives/type_name.rs
