### PR TITLE
Doc: Add error message for easy search

### DIFF
--- a/language/tools/move-mv-llvm-compiler/docs/Development.md
+++ b/language/tools/move-mv-llvm-compiler/docs/Development.md
@@ -258,8 +258,9 @@ For example
 > RUST_LOG=info move-mv-llvm-compiler -b tests/BasicCoin.mv
 
 ----
-On MacOS, some builds and tests might spuriously fail because the tools downloaded may not be trusted by the OS. To get around that run the following command in each directory where binaries are there e.g., `move-dev/bin` and `rust/bin`
+On MacOS, some builds and tests might spuriously fail because the tools downloaded may not be trusted by the OS. You may get error message like "clang-17 can't be opened because Apple cannot check it for malicious software". To get around that run the following command in each directory where binaries are there e.g., `move-dev/bin` and `rust/bin`
 
+> cd /path/to/move-dev/bin
 > xattr -d com.apple.quarantine  *
 Note that this will not remove the attribute from symlinks. For symlinks you have to do it separately or use bash tricks like
 > for i in `find . -type l`; do echo $i; mv $i $i.tmp; done ; # rename all the symlinks to .tmp


### PR DESCRIPTION
clang-17 cant be opened because Apple cannot check it for malicious software